### PR TITLE
avalocation -> avalancheLocation

### DIFF
--- a/docs/v1.0/en/tools/avash.md
+++ b/docs/v1.0/en/tools/avash.md
@@ -28,7 +28,7 @@ While Avash can be started without a premade configuration file, it's available 
 Below is the format of an Avash configuration file:
 
 ```yaml
-avalocation: <filepath>
+avalancheLocation: <filepath>
 datadir: <directory>
 log:
   terminal: <log-level>
@@ -44,7 +44,7 @@ The field arguments are described as follows:
 
 ### Fields
 
-#### `avalocation`
+#### `avalancheLocation`
 
 ```
 File path to Avalanche binary.


### PR DESCRIPTION
Update the `avash` configuration information to reflect the change from `avalocation` to `avalancheLocation` for the Everest release.