### PR TITLE
Add X-Chain to C-Chain atomic swap steps to the tutorial, change C-Chain docs to avax RPC, update getCurrent/PendingValidators call.

### DIFF
--- a/docs/v1.0/en/api/evm.md
+++ b/docs/v1.0/en/api/evm.md
@@ -721,7 +721,7 @@ curl -X POST --data '{
 
 ## AVAX RPC endpoints
 
-### ava.exportAVAX
+### avax.exportAVAX
 
 Send AVAX from the C-Chain to the X Chain.  
 After calling this method, you must call `importAVAX` on the X Chain to complete the transfer.
@@ -729,7 +729,7 @@ After calling this method, you must call `importAVAX` on the X Chain to complete
 #### Signature
 
 ```go
-ava.exportAVAX({
+avax.exportAVAX({
     to: string,
     amount: int,
     username: string,
@@ -747,7 +747,7 @@ ava.exportAVAX({
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"ava.exportAVAX",
+    "method" :"avax.exportAVAX",
     "params" :{
         "to":"X-avax1q9c6ltuxpsqz7ul8j0h0d0ha439qt70sr3x2m0",
         "amount": 500,
@@ -769,15 +769,15 @@ curl -X POST --data '{
 }
 ```
 
-### ava.exportKey
+### avax.exportKey
 
 Get the private key that controls a given address.  
-The returned private key can be added to a user with `ava.importKey`.
+The returned private key can be added to a user with `avax.importKey`.
 
 #### Signature
 
 ```go
-ava.exportKey({
+avax.exportKey({
     username: string,
     password:string,
     address:string
@@ -793,7 +793,7 @@ ava.exportKey({
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"ava.exportKey",
+    "method" :"avax.exportKey",
     "params" :{
         "username" :"myUsername",
         "password":"myPassword",
@@ -814,7 +814,7 @@ curl -X POST --data '{
 }}
 ```
 
-### ava.importAVAX
+### avax.importAVAX
 
 Finalize a transfer of AVAX from the X-Chain to the C-Chain.
 Before this method is called, you must call the X-Chain's [`exportAVAX`](./avm.md#avmexportavax) method to initiate the transfer.
@@ -822,7 +822,7 @@ Before this method is called, you must call the X-Chain's [`exportAVAX`](./avm.m
 #### Signature
 
 ```go
-ava.importAVAX({
+avax.importAVAX({
     to: string,
     sourceChain: string,
     username: string,
@@ -842,7 +842,7 @@ ava.importAVAX({
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"ava.importAVAX",
+    "method" :"avax.importAVAX",
     "params" :{
         "to":"0x4b879aff6b3d24352Ac1985c1F45BA4c3493A398",
         "sourceChain":"X",
@@ -864,14 +864,14 @@ curl -X POST --data '{
 }
 ```
 
-### ava.importKey
+### avax.importKey
 
 Give a user control over an address by providing the private key that controls the address.
 
 #### Signature
 
 ```go
-ava.importKey({
+avax.importKey({
     username: string,
     password:string,
     privateKey:string
@@ -886,7 +886,7 @@ ava.importKey({
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"ava.importKey",
+    "method" :"avax.importKey",
     "params" :{
         "username" :"myUsername",
         "password":"myPassword",

--- a/docs/v1.0/en/api/platform.md
+++ b/docs/v1.0/en/api/platform.md
@@ -665,24 +665,55 @@ List the current validators of the given Subnet.
 platform.getCurrentValidators({subnetID: string}) ->
 {
     validators: []{
-        startTime: int,
-        endTime: int,
-        weight: int, (optional)
-        stakeAmount: int, (optional)
-        address: string
-        nodeID: string
+        startTime: string,
+        endTime: string,
+        stakeAmount: string, (optional)
+        nodeID: string,
+        weight: string, (optional)
+        rewardOwner: {
+            locktime: string,
+            threshold: string,
+            addresses: string[]
+        },
+        potentialReward: string,
+        delegationFee: string,
+        uptime: string,
+        connected: boolean
+    },
+    delegators: []{
+        startTime: string,
+        endTime: string,
+        stakeAmount: string, (optional)
+        nodeID: string,
+        rewardOwner: {
+            locktime: string,
+            threshold: string,
+            addresses: string[]
+        },
+        potentialReward: string,
     }
 }
 ```
 
 * `subnetID` is the subnet whose current validators are returned. If omitted, returns the current validators of the Primary Network.
-* `startTime` is the Unix time when the validator starts validating the Subnet.
-* `endTime` is the Unix time when the validator stops validating the Subnet.
-* `weight` is the validator's weight when sampling validators.
-  Omitted if `subnetID` is the Primary Network.
-* `stakeAmount` is the amount of nAVAX this validator staked.
-  Omitted if `subnetID` is not the Primary Network.
-* `nodeID` is the validator's node ID.
+* `validators`:
+    * `startTime` is the Unix time when the validator starts validating the Subnet.
+    * `endTime` is the Unix time when the validator stops validating the Subnet.
+    * `stakeAmount` is the amount of nAVAX this validator staked. Omitted if `subnetID` is not the Primary Network.
+    * `nodeID` is the validator's node ID.
+    * `weight` is the validator's weight when sampling validators. Omitted if `subnetID` is the Primary Network.
+    * `rewardOwner` is an `OutputOwners` output which includes `locktime`, `threshold` and array of `addresses`.
+    * `potentialReward` is the potential reward earned from staking
+    * `delegationFeeRate` is the percent fee this validator charges when others delegate stake to them.
+    * `uptime` is the % of time the queried node has reported the peer as online.
+    * `connected` is if the node is connected to the network
+* `delegators`: 
+    * `startTime` is the Unix time when the delegator started.
+    * `endTime` is the Unix time when the delegator stops.
+    * `stakeAmount` is the amount of nAVAX this delegator staked. Omitted if `subnetID` is not the Primary Network.
+    * `nodeID` is the validating node's node ID.
+    * `rewardOwner` is an `OutputOwners` output which includes `locktime`, `threshold` and array of `addresses`.
+    * `potentialReward` is the potential reward earned from staking
 
 #### Example Call
 
@@ -703,22 +734,37 @@ curl -X POST --data '{
     "result": {
         "validators": [
             {
-                "startTime": "1591878109",
-                "endtime": "1594469809",
-                "stakeAmount": "319902",
-                "nodeID": "NodeID-NDmcZNsWoPrkN9KSt2A9js639hEQWUmUf"
-            },
+                "startTime": "1600368632",
+                "endTime": "1602960455",
+                "stakeAmount": "200000000000",
+                "nodeID": "NodeID-5mb46qkSBj81k9g9e4VFjGGSbaaSLFRzD",
+                "rewardOwner": {
+                    "locktime": "0",
+                    "threshold": "1",
+                    "addresses": [
+                        "P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
+                    ]
+                },
+                "potentialReward": "117431493426",
+                "delegationFee": "10.0000",
+                "uptime": "0.0000",
+                "connected": false
+            }
+        ],
+        "delegators": [
             {
-                "startTime": "1591473391",
-                "endtime": "1592855191",
-                "stakeAmount": "10000",
-                "nodeID": "NodeID-62T5AAwKdFMNi7Gm193A6zyJhVscRfuhP"
-            },
-            {
-                "startTime": "1591387125",
-                "endtime": "1622923025",
-                "stakeAmount": "20000000000000",
-                "nodeID": "NodeID-HGZ8ae74J3odT8ESreAdCtdnvWG1J4X5n"
+                "startTime": "1600368523",
+                "endTime": "1602960342",
+                "stakeAmount": "20000000000",
+                "nodeID": "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg",
+                "rewardOwner": {
+                    "locktime": "0",
+                    "threshold": "1",
+                    "addresses": [
+                        "P-local18jma8ppw3nhx5r4ap8clazz0dps7rv5u00z96u"
+                    ]
+                },
+                "potentialReward": "11743144774"
             }
         ]
     },
@@ -773,23 +819,35 @@ Each validator is not currently validating the Subnet but will in the future.
 platform.getPendingValidators({subnetID: string}) ->
 {
     validators: []{
-        startTime: int,
-        endTime: int,
-        weight: int, (optional)
-        stakeAmount: int, (optional)
+        startTime: string,
+        endTime: string,
+        stakeAmount: string, (optional)
+        nodeID: string
+        delegationFee: string,
+        connected: bool,
+        weight: string, (optional)
+    },
+    delegators: []{
+        startTime: string,
+        endTime: string,
+        stakeAmount: string,
         nodeID: string
     }
 }
 ```
-
 * `subnetID` is the subnet whose current validators are returned. If omitted, returns the current validators of the Primary Network.
-* `startTime` is the Unix time when the validator starts validating the Subnet.
-* `endTime` is the Unix time when the validator stops validating the Subnet.
-* `weight` is the validator's weight when sampling validators.
-  Omitted if `subnetID` is the Primary Network.
-* `stakeAmount` is the amount of nAVAX this validator staked.
-  Omitted if `subnetID` is not the Primary Network.
-* `nodeID` is the validator's node ID.
+* `validators`:
+    * `startTime` is the Unix time when the validator starts validating the Subnet.
+    * `endTime` is the Unix time when the validator stops validating the Subnet.
+    * `stakeAmount` is the amount of nAVAX this validator staked. Omitted if `subnetID` is not the Primary Network.
+    * `nodeID` is the validator's node ID.
+    * `connected` if the node is connected.
+    * `weight` is the validator's weight when sampling validators. Omitted if `subnetID` is the Primary Network.
+* `delegators`:
+    * `startTime` is the Unix time when the delegator starts.
+    * `endTime` is the Unix time when the delegator stops.
+    * `stakeAmount` is the amount of nAVAX this delegator staked. Omitted if `subnetID` is not the Primary Network.
+    * `nodeID` is the validating node's node ID.
 
 #### Example Call
 
@@ -810,11 +868,21 @@ curl -X POST --data '{
     "result": {
         "validators": [
             {
-                "startTime": "1592400591",
-                "endtime": "1622923025",
-                "stakeAmount": "10000",
-                "nodeID": "NodeID-DpL8PTsrjtLzv5J8LL3D2A6YcnCTqrNH9"
-            },
+                "startTime": "1600368632",
+                "endTime": "1602960455",
+                "stakeAmount": "200000000000",
+                "nodeID": "NodeID-5mb46qkSBj81k9g9e4VFjGGSbaaSLFRzD",
+                "delegationFee": "10.0000",
+                "connected": false
+            }
+        ],
+        "delegators": [
+            {
+                "startTime": "1600368523",
+                "endTime": "1602960342",
+                "stakeAmount": "20000000000",
+                "nodeID": "NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg"
+            }
         ]
     },
     "id": 1

--- a/docs/v1.0/en/tutorials/atomic-swap.md
+++ b/docs/v1.0/en/tutorials/atomic-swap.md
@@ -2,12 +2,11 @@
 
 ## Introduction
 
-AVAX tokens exist on both the X-Chain, where they can be traded, and the P-Chain, where they can be provided as a stake when validating the Primary Network.
+The Avalanche network's Primary Network has 3 chains, the X-Chain, the P-Chain and the C-Chain. AVAX tokens exist on all 3 chains&mdash;the X-Chain, where they can be traded, the P-Chain, where they can be provided as a stake when validating the Primary Network, and the C-Chain where they can be used in smart contracts.
 
-Avalanche supports **atomic swaps** of AVAX between the X-Chain and P-chain.
-(In the future Avalanche will support more generic atomic swaps between chains.)
+Avalanche supports **atomic swaps** of AVAX between the X-Chain and P-chain as well as the X-Chain and C-Chain. (In the future Avalanche will support more generic atomic swaps between chains.)
 
-In this tutorial we'll send AVAX tokens from the X-Chain to the P-chain and back.
+In this tutorial we&rsquo;ll first send AVAX tokens from the X-Chain to the P-chain and back. Then we&rsquo;ll send AVAX tokens from the X-CHain to the C-Chain and back.
 
 ## Requirements
 
@@ -31,6 +30,7 @@ curl -X POST --data '{
     "method" :"avm.exportAVAX",
     "params" :{
         "to":"P-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q",
+        "destinationChain": "P",
         "amount": 5000000,
         "username":"myUsername",
         "password":"myPassword"
@@ -38,14 +38,11 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
 ```
 
-where `to` is the address of a P-Chain address you hold.
-(See [here](../api/platform.md#platformcreateaddress) for instructions on creating a new P-Chain address.)
+where `to` is the address of a P-Chain address you hold. (See [here](../api/platform.md#platformcreateaddress) for instructions on creating a new P-Chain address.)
 
+Note that you will pay a transaction fee for both the export and import operations. In this example, let's assume the transaction fee is `1,000,000` nAVAX. Then the above export actually consumes `6,000,000` nAVAX; `5,000,000` goes to the P-Chain and `1,000,000` is burned as a transaction fee.
 
-Note that you will pay a transaction fee for both the export and import operations.
-In this example, let's assume the transaction fee is `1,000,000` nAVAX.
-Then the above export actually consumes `6,000,000` nAVAX; `5,000,000` goes to the P-Chain and `1,000,000` is burned as a transaction fee.
-Make sure that the amount that you're sending exceeds the transaction fee. 
+Make sure that the amount that you're sending exceeds the transaction fee.
 Otherwise, when you import the AVAX on the P-Chain it will consume the transaction fee and you'll end up with _less_ AVAX on the P-Chain.
 
 The response should look like this:
@@ -99,13 +96,11 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
 ```
 
-The amount deducted is the exported amount (`5,000,000` in this example) plus the transaction fee.
-If your user controls multiple X-Chain addresses, the AVAX may have been sent from any combination of them.
+The amount deducted is the exported amount (`5,000,000` in this example) plus the transaction fee. If your user controls multiple X-Chain addresses, the AVAX may have been sent from any combination of them.
 
 ## Import AVAX to the P-Chain from the X-Chain
 
-Our transfer isn't done just yet.
-We need to call the P-Chain's [`importAVAX`](../api/platform.md#platformimportavax) method to finish the transfer.
+Our transfer isn't done just yet. We need to call the P-Chain's [`importAVAX`](../api/platform.md#platformimportavax) method to finish the transfer.
 
 Your call should look like this:
 
@@ -207,8 +202,7 @@ curl -X POST --data '{
 
 where `to` is the X-Chain address the AVAX is being sent to.
 
-This returns the transaction ID, and we can check that the transaction was committed with another call to `platform.getTxStatus`.
-Again, make sure that the amount you're sending exceeds the transaction fee.
+This returns the transaction ID, and we can check that the transaction was committed with another call to `platform.getTxStatus`. Again, make sure that the amount you're sending exceeds the transaction fee.
 
 ## Import AVAX to the X-Chain from the P-Chain
 
@@ -233,7 +227,143 @@ Note that `to` is the same address specified in our call to `platform.exportAVAX
 Just as before, we can call `avm.getBalance` to verify the funds were received.
 The balance should have increased by `3,000,000`, less the transaction fee.
 
+## Export AVAX from the X-Chain to the C-Chain
+
+In addition to sending AVAX between the X-Chain and P-Chain, you can also send AVAX between the X-Chain and the C-Chain and back. First, to export AVAX from the X-Chain call the X-Chain's [`exportAVAX`](../api/avm.md#avmexportavax) method.
+
+Your call should look like this:
+
+```json
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"avm.exportAVAX",
+    "params" :{
+        "to":"C-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q",
+        "destinationChain": "C",
+        "amount": 5000000,
+        "username":"myUsername",
+        "password":"myPassword"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
+```
+
+where `to` is the bech32 encoded address of a C-Chain address you hold. (See [here](../api/evm.md#avaximportkey) for instructions importing an existing P-Chain or C-Chain private key.)
+
+Note that, similar to an X-Chain to P-Chain transfer, you will pay a transaction fee for both the export and import operations. In this example, let's assume the transaction fee is `1,000,000` nAVAX. Then the above export actually consumes `6,000,000` nAVAX; `5,000,000` goes to the C-Chain and `1,000,000` is burned as a transaction fee.
+
+Make sure that the amount that you're sending exceeds the transaction fee. Otherwise, when you import the AVAX on the C-Chain it will consume the transaction fee and you'll end up with _less_ AVAX on the C-Chain.
+
+The response should look like this:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "txID": "H9VLj5kABGaTJY1vXJb8SbatKbcthNo5HWUnis9NUdDr5ym4X"
+    },
+    "id": 1
+}
+```
+
+## Import AVAX to the C-Chain from the X-Chain
+
+Now to finish the cross chain transfer call `avax.importAVAX`. Confirm the path is `ext/bc/C/avax`.
+
+```json
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method": "avax.importAVAX",
+    "params": {
+        "username":"myUsername",
+        "password":"myPassword",
+        "sourceChain": "X",
+        "to":"0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
+```
+
+where `to` is a hex encoded evm address.
+
+The response should look like this:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "txID": "2kxwWpHvZPhMsJcSTmM7a3Da7sExB8pPyF7t4cr2NSwnYqNHni"
+    },
+    "id": 1
+}
+```
+
+Once your AVAX have been transferred to the C-Chain you can immediately begin running smart contracts. See the ["Deploy a smart contract"](https://docs.avax.network/v1.0/en/tutorials/deploy-a-smart-contract/) for more info.
+
+## Export AVAX from the C-Chain to the X-Chain
+
+Now you can move AVAX back from the C-Chain to the X-Chain
+
+```json
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"avax.exportAVAX",
+    "params" :{
+        "to":"X-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q",
+        "amount": 5000000,
+        "username":"myUsername",
+        "password":"myPassword"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
+```
+
+where `to` is the bech32 encoded address of an X-Chain address you hold. Again, make sure that the amount you're sending exceeds the transaction fee.
+
+The response should look like this:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "txID": "2ZDt3BNwzA8vm4CMP42pWD242VZy7TSWYUXEuBifkDh4BxbCvj"
+    },
+    "id": 1
+}
+```
+
+## Import AVAX to the X-Chain from the C-Chain
+
+Lastly, we can finish up by importing AVAX from the C-Chain to the X-Chain, call `avm.importAVAX`.
+
+```json
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method": "avm.importAVAX",
+    "params": {
+        "username":"myUsername",
+        "password":"myPassword",
+        "sourceChain": "C",
+        "to":"X-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
+```
+
+where `to` is the bech32 encoded address the X-Chain address which you sent the funds to in the previous step.
+
+The response should look like this:
+
+```json
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "txID": "2kxwWpHvZPhMsJcSTmM7a3Da7sExB8pPyF7t4cr2NSwnYqNHni"
+    },
+    "id": 1
+}
+```
+
 ## Wrapping Up
 
-That's it! Now you can swap AVAX back and forth between the X-Chain and P-Chain.
-In the future Avalanche will support more generalized atomic swaps between chains.
+That's it! Now you can swap AVAX back and forth between the X-Chain and P-Chain as well as the X-Chain and the C-Chain. In the future Avalanche will support more generalized atomic swaps between chains.


### PR DESCRIPTION
* Update Atomic Swap tutorial to include X-Chain to C-Chain transfers and C-Chain to X-Chain transfers.
* Update C-Chain RPC endpoints from `ava` to `avax`.
* Update getCurrent/PendingValidators call with correct response data.