### PR TITLE
Add missing command line args to docs

### DIFF
--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -150,15 +150,23 @@ Avalanche uses two-way authenticated TLS connections to securely identify the `s
 
 Avalanche uses two-way authenticated TLS connections to securely identify the `stakingID` of connected peers when `--p2p-tls-enabled=true`. This argument specifies the location of the TLS private key used by the node. This must be specified when `--p2p-tls-enabled=true`. The default value is `""`.
 
+`--uptime-requirement` (float):
+
+Fraction of time a validator must be online to receive rewards. The default value is `0.6`.
+
 ***
 
 ## Advanced Options
 
 The following options affect the correctness of the platform. They may need to be changed network-wide, and as a result, an ordinary user should not change from the defaults.
 
-`--avax-tx-fee` (int):
+`--tx-fee` (int):
 
-The required amount of nAVAX to be burned for a transaction to be valid. This parameter requires network agreement in its current form. Changing this value from the default should only be done on private networks. Defaults to `0` nAVAX per transaction.
+The required amount of nAVAX to be burned for a transaction to be valid. This parameter requires network agreement in its current form. Changing this value from the default should only be done on private networks. Defaults to `1000000` nAVAX per transaction.
+
+`--creation-tx-fee` (int):
+
+Transaction fee, in nAVAX, for transactions that create new state. Defaults to `1000000` nAVAX per transaction.
 
 `--min-delegator-stake` (int):
 
@@ -211,3 +219,7 @@ The default value is `false`.
 `--xput-server-port` [Deprecated] (string):
 
 This option lets one specify on which port the throughput server, if enabled, will listen. The default value is `9652`.
+
+`--version` (boolean):
+
+If this is true, print the version and quit. The default value is `false`.

--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -150,9 +150,9 @@ Avalanche uses two-way authenticated TLS connections to securely identify the `s
 
 Avalanche uses two-way authenticated TLS connections to securely identify the `stakingID` of connected peers when `--p2p-tls-enabled=true`. This argument specifies the location of the TLS private key used by the node. This must be specified when `--p2p-tls-enabled=true`. The default value is `""`.
 
-`--uptime-requirement` (float):
+`--version` (boolean)
 
-Fraction of time a validator must be online to receive rewards. The default value is `0.6`.
+If this is `true`, print the version and quit. The default is `false`.
 
 ***
 
@@ -210,6 +210,10 @@ Snow consensus defines `beta1` as the number of consecutive polls that a virtuou
 
 Snow consensus defines `beta2` as the number of consecutive polls that a rogue transaction must increase its confidence for it to be accepted. This parameter lets us define the `beta2` value used for consensus. This should only be changed after careful consideration of the tradeoffs of Snow consensus. The value must be at least `beta1`. The default value is `30`.
 
+`--uptime-requirement` (float):
+
+Fraction of time a validator must be online to receive rewards. The default value is `0.6`.
+
 `--xput-server-enabled` [Deprecated] (boolean):
 
 An optional server helps run throughput tests by injecting load into the network on command.
@@ -219,7 +223,3 @@ The default value is `false`.
 `--xput-server-port` [Deprecated] (string):
 
 This option lets one specify on which port the throughput server, if enabled, will listen. The default value is `9652`.
-
-`--version` (boolean):
-
-If this is true, print the version and quit. The default value is `false`.

--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -173,11 +173,11 @@ The following options affect the correctness of the platform. They may need to b
 
 `--consensus-gossip-frequency` (int):
 
-Frequency of gossiping accepted frontiers. The default is `60`.
+Number of nanoseconds between gossiping accepted frontiers. The default is `10000000000`.
 
 `--consensus-shutdown-timeout` (int):
 
-Timeout before killing an unresponsive chain. The default is `1`.
+Timeout before killing an unresponsive chain. The default is `1000000000`.
 
 `--creation-tx-fee` (int):
 
@@ -219,17 +219,17 @@ The maximum stake, in nAVAX, that can be placed on a validator on the primary ne
 
 `--network-initial-timeout` (int):
 
-Initial timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `600`.
+Initial timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `10000000000`.
 
 `--network-minimum-timeout` (int):
 
-Minimum timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `5000`.
+Minimum timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `500000000`.
 
 `--network-maximum-timeout` (int):
 
-Maximum timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `10`.
+Maximum timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `10000000000`.
 
-`--network-maximum-timeout` (float):
+`--network-timeout-multiplier` (float):
 
 Multiplier of the timeout after a failed request.. The default value is: `1.1`.
 

--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -175,12 +175,28 @@ The minimum stake that can be delegated to a validator of the Primary Network.
 Default on Main Net: `25000000000` (25 AVAX)
 Default on Everest Test Net: `5000000`  (5 x 10^-3 AVAX)
 
+`--min-delegation-fee` (int):
+
+The minimum delegation fee, in the range [0, 1000000], that can be charged for delegation on the Primary Network. Default on Main Net: `20000` (2%)
+
+`--min-stake-duration` (int):
+
+Minimum staking duration, in seconds. The Default on Main Net: `86400` (60*60*24)
+
 `--min-validator-stake` (int):
 
 The minimum stake, in nAVAX, required to validate the Primary Network.
 
 Default on Main Net: `2000000000000` (2,000 AVAX)
 Default on Everest Test Net: `5000000` (5 x 10^-3 AVAX)
+
+`--max-stake-duration` (int):
+
+The maximum staking duration, in seconds. The Default on Main Net: `31536000` (365*60*60*24)
+
+`--max-validator-stake` (int):
+
+The maximum stake, in nAVAX, that can be placed on a validator on the primary network. The default on Main Net: `3000000000000000` (3,000,000 AVAX)
 
 `--snow-avalanche-batch-size` (int):
 

--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -135,7 +135,7 @@ Avalanche uses two-way authenticated TLS connections to securely identify the `s
 
 `--staking-enabled` (boolean):
 
-Avalanche uses Proof of Stake (PoS) as Sybil resistance to make it prohibitively expensive to attack the network. When this is true, `--p2p-tls-enabled` must be set to `true` in order to secure P2P communications.
+Avalanche uses Proof of Stake (PoS) as Sybil resistance to make it prohibitively expensive to attack the network. When this is `true`, `--p2p-tls-enabled` must be set to `true` in order to secure P2P communications.
 
 `--staking-tls-cert-file` (string, file path):
 
@@ -144,6 +144,10 @@ Avalanche uses two-way authenticated TLS connections to securely identify the `s
 `--staking-tls-key-file` (string, file path):
 
 Avalanche uses two-way authenticated TLS connections to securely identify the `stakingID` of connected peers when `--p2p-tls-enabled=true`. This argument specifies the location of the TLS private key used by the node. This must be specified when `--p2p-tls-enabled=true`. The default value is `""`.
+
+`--staking-disabled-weight` (int):
+
+Weight to provide to each peer when staking is disabled. The default is `1`.
 
 `--version` (boolean)
 

--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -6,11 +6,11 @@ When running a node, there are a variety of possible configurations that are sup
 
 `--api-admin-enabled` (boolean):
 
-If set to false, this node will not expose the Admin API. Defaults to `false`.
+If set to `false`, this node will not expose the Admin API. Defaults to `false`.
 
 `--api-auth-required` (boolean):
 
-If set to true, API calls require an authorization token. Defaults to `false`. See [here](../api/auth.md) for more information.
+If set to `true`, API calls require an authorization token. Defaults to `false`. See [here](../api/auth.md) for more information.
 
 `--api-auth-password` (string):
 
@@ -18,23 +18,23 @@ The password needed to create/revoke authorization tokens. If `--api-auth-requir
 
 `--api-ipcs-enabled` (boolean):
 
-If set to true, this node will expose the IPCs API. Defaults to `false`.
+If set to `true`, this node will expose the IPCs API. Defaults to `false`.
 
 `--api-keystore-enabled` (boolean):
 
-If set to false, this node will not expose the Keystore API. Defaults to `true`.
+If set to `false`, this node will not expose the Keystore API. Defaults to `true`.
 
 `--api-metrics-enabled` (boolean):
 
-If set to false, this node will not expose the Metrics API. Defaults to `true`.
+If set to `false`, this node will not expose the Metrics API. Defaults to `true`.
 
 `--assertions-enabled` (boolean):
 
-When set to true, assertions will execute at runtime throughout the codebase. This is intended for use in debugging, as we may get a more specific error message. Defaults to `true`.
+When set to `true`, assertions will execute at runtime throughout the codebase. This is intended for use in debugging, as we may get a more specific error message. Defaults to `true`.
 
 `--bootstrap-ids` (string):
 
-Bootstrap IDs is an array of validator IDs. These IDs will be used to authenticate bootstrapping peers. This only needs to be set when `--p2p-tls-enabled=true`. An example setting of this field would be `--bootstrap-ids="7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg,MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ"`. The default value is the empty set.
+Bootstrap IDs is an array of validator IDs. These IDs will be used to authenticate bootstrapping peers. This only needs to be set when `--p2p-tls-enabled=true`. An example setting of this field would be `--bootstrap-ids="NodeID-7Xhw2mDxuDS44j42TCB6U5579esbSt3Lg,NodeID-MFrZFVCXPv5iCn6M9K6XduxGTYp891xXZ"`. The default value is the empty set.
 
 `--bootstrap-ips` (string):
 
@@ -46,19 +46,15 @@ Specifies the directory to which the database is persisted. Defaults to `"$HOME/
 
 `--db-enabled` (boolean):
 
-If set to false, state updates are performed solely to an in-memory database, without making any changes on permanent storage.
-When set to true, state updates are written to a local persistent database. Defaults to `true`.
+If set to `false`, state updates are performed solely to an in-memory database, without making any changes on permanent storage. When set to `true`, state updates are written to a local persistent database. Defaults to `true`.
 
 `--http-host` (string):
 
-The address that HTTP APIs listen on. The default value is `127.0.0.1`.
-This means that by default, your node can only handle API calls made from the same machine.
-To allow API calls from other machines, do `--http-host=`.
+The address that HTTP APIs listen on. The default value is `127.0.0.1`. This means that by default, your node can only handle API calls made from the same machine. To allow API calls from other machines, do `--http-host=`. For example if your public IP address is `1.2.3.4` and you'd like to access AvalancheGo's RPC over that IP address then you need to pass in `--http-host=1.2.3.4`.
 
 `--http-port` (int):
 
-Each node runs an HTTP server that provides the APIs for interacting with the node and the Avalanche network.
-This argument specifies the port that the http server will listen on. The default value is `9650`.
+Each node runs an HTTP server that provides the APIs for interacting with the node and the Avalanche network. This argument specifies the port that the http server will listen on. The default value is `9650`.
 
 `--http-tls-cert-file` (string, file path):
 
@@ -66,7 +62,7 @@ This argument specifies the location of the TLS certificate used by the node for
 
 `--http-tls-enabled` (boolean):
 
-If set to true, this flag will attempt to upgrade the server to use HTTPS. Defaults to `false`.
+If set to `true`, this flag will attempt to upgrade the server to use HTTPS. Defaults to `false`.
 
 `--http-tls-key-file` (string, file path):
 
@@ -119,8 +115,7 @@ The identity of the network the node should connect to. Can be one of:
 
 `--public-ip` (string):
 
-Validators must know their public facing IP addresses so they can let other nodes know how to connect to them.
-If this argument is not provided, the node will attempt to perform NAT traversal to get the node's public IP. Should be set to `127.0.0.1` to create a local network. The default value is `""`.
+Validators must know their public facing IP addresses so they can let other nodes know how to connect to them. If this argument is not provided, the node will attempt to perform NAT traversal to get the node's public IP. Should be set to `127.0.0.1` to create a local network. The default value is `""`.
 
 `--plugin-dir` (string, file path):
 
@@ -128,7 +123,7 @@ Specifies the directory in which the `evm` plugin is kept. Defaults to `"$HOME/.
 
 `--signature-verification-enabled` (boolean):
 
-Enables signature verification to be disabled for testing. When set to false, signatures won't be checked in VMs that allow signatures to be disabled. Defaults to `true`.
+Enables signature verification. When set to `false`, signatures won't be checked in VMs that allow signatures to be disabled. Defaults to `true`.
 
 `--staking-port` (string):
 
@@ -140,7 +135,7 @@ Avalanche uses two-way authenticated TLS connections to securely identify the `s
 
 `--staking-enabled` (boolean):
 
-Avalanche uses Proof of Stake (PoS) as Sybil resistance to make it prohibitively expensive to attack the network. When this is true, `--p2p-tls-enabled` must be set to true in order to secure P2P communications.
+Avalanche uses Proof of Stake (PoS) as Sybil resistance to make it prohibitively expensive to attack the network. When this is true, `--p2p-tls-enabled` must be set to `true` in order to secure P2P communications.
 
 `--staking-tls-cert-file` (string, file path):
 
@@ -225,6 +220,10 @@ Snow consensus defines `beta1` as the number of consecutive polls that a virtuou
 `--snow-rogue-commit-threshold` (int):
 
 Snow consensus defines `beta2` as the number of consecutive polls that a rogue transaction must increase its confidence for it to be accepted. This parameter lets us define the `beta2` value used for consensus. This should only be changed after careful consideration of the tradeoffs of Snow consensus. The value must be at least `beta1`. The default value is `30`.
+
+`--stake-minting-period` (int):
+
+Consumption period of the staking function, in seconds. The Default on Main Net: `31536000` (365*60*60*24)
 
 `--uptime-requirement` (float):
 

--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -189,6 +189,10 @@ The minimum stake, in nAVAX, required to validate the Primary Network.
 Default on Main Net: `2000000000000` (2,000 AVAX)
 Default on Everest Test Net: `5000000` (5 x 10^-3 AVAX)
 
+`--max-non-staker-pending-msgs` (int):
+
+Maximum number of messages a non-staker is allowed to have pending. The default is `3`.
+
 `--max-stake-duration` (int):
 
 The maximum staking duration, in seconds. The Default on Main Net: `31536000` (365*60*60*24)
@@ -196,6 +200,18 @@ The maximum staking duration, in seconds. The Default on Main Net: `31536000` (3
 `--max-validator-stake` (int):
 
 The maximum stake, in nAVAX, that can be placed on a validator on the primary network. The default on Main Net: `3000000000000000` (3,000,000 AVAX)
+
+`--network-initial-timeout` (int):
+
+Initial timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `600`.
+
+`--network-minimum-timeout` (int):
+
+Minimum timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `5000`.
+
+`--network-maximum-timeout` (int):
+
+Maximum timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `10`.
 
 `--snow-avalanche-batch-size` (int):
 
@@ -227,7 +243,15 @@ Snow consensus defines `beta2` as the number of consecutive polls that a rogue t
 
 `--stake-minting-period` (int):
 
-Consumption period of the staking function, in seconds. The Default on Main Net: `31536000` (365*60*60*24)
+Consumption period of the staking function, in seconds. The Default on Main Net: `31536000` (365*60*60*24).
+
+`--staker-msg-reserved` (float):
+
+Reserve a portion of the chain message queue's space for stakers. The default value is `0.2`.
+
+`--staker-cpu-reserved` (float):
+
+Reserve a portion of the chain's CPU time for stakers.
 
 `--uptime-requirement` (float):
 

--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -16,6 +16,14 @@ If set to `true`, API calls require an authorization token. Defaults to `false`.
 
 The password needed to create/revoke authorization tokens. If `--api-auth-required=true`, must be specified; otherwise ignored. See [here](../api/auth.md) for more information.
 
+`--api-health-enabled` (boolean):
+
+If set to `true`, this node will expose the Health API. Defaults to `true`.
+
+`--api-info-enabled` (boolean):
+
+If set to `true`, this node will expose the Info API. Defaults to `true`.
+
 `--api-ipcs-enabled` (boolean):
 
 If set to `true`, this node will expose the IPCs API. Defaults to `false`.
@@ -98,6 +106,10 @@ When specifying a log level note that all logs with the specified priority or hi
 
 The log level determines which events to display to the screen. If left blank, will default to the value provided to `--log-level`.
 
+`--log-display-highlight` (string, `{auto, plain, colors}`):
+
+Whether to color/highlight display logs. Default highlights when the output is a terminal. Otherwise, should be one of `{auto, plain, colors}`
+
 `--log-dir` (string, file path):
 
 Specifies the directory in which system logs are kept. Defaults to `"$HOME/.avalanchego/logs"`.
@@ -159,9 +171,13 @@ If this is `true`, print the version and quit. The default is `false`.
 
 The following options affect the correctness of the platform. They may need to be changed network-wide, and as a result, an ordinary user should not change from the defaults.
 
-`--tx-fee` (int):
+`--consensus-gossip-frequency` (int):
 
-The required amount of nAVAX to be burned for a transaction to be valid. This parameter requires network agreement in its current form. Changing this value from the default should only be done on private networks. Defaults to `1000000` nAVAX per transaction.
+Frequency of gossiping accepted frontiers. The default is `60`.
+
+`--consensus-shutdown-timeout` (int):
+
+Timeout before killing an unresponsive chain. The default is `1`.
 
 `--creation-tx-fee` (int):
 
@@ -213,6 +229,14 @@ Minimum timeout value of the adaptive timeout manager, in nanoseconds. The defau
 
 Maximum timeout value of the adaptive timeout manager, in nanoseconds. The default value is: `10`.
 
+`--network-maximum-timeout` (float):
+
+Multiplier of the timeout after a failed request.. The default value is: `1.1`.
+
+`--network-timeout-reduction` (int):
+
+Reduction of the timeout after a successful request, in nanoseconds. The default value is: `1`.
+
 `--snow-avalanche-batch-size` (int):
 
 DAG implementations of Snow consensus define `b` as the number of transactions a vertex should include. Increasing `b` will, theoretically, increase throughput while increasing latency. The node will wait for at most 1 second to collect a batch, and will then issue the entire batch at once. The value must be at least `1`. The default value is `30`.
@@ -252,6 +276,10 @@ Reserve a portion of the chain message queue's space for stakers. The default va
 `--staker-cpu-reserved` (float):
 
 Reserve a portion of the chain's CPU time for stakers.
+
+`--tx-fee` (int):
+
+The required amount of nAVAX to be burned for a transaction to be valid. This parameter requires network agreement in its current form. Changing this value from the default should only be done on private networks. Defaults to `1000000` nAVAX per transaction.
 
 `--uptime-requirement` (float):
 

--- a/docs/v1.0/en/references/command-line-interface.md
+++ b/docs/v1.0/en/references/command-line-interface.md
@@ -4,11 +4,11 @@ When running a node, there are a variety of possible configurations that are sup
 
 ## Arguments
 
-`--api-admin-enabled` (bool):
+`--api-admin-enabled` (boolean):
 
 If set to false, this node will not expose the Admin API. Defaults to `false`.
 
-`--api-auth-required` (bool):
+`--api-auth-required` (boolean):
 
 If set to true, API calls require an authorization token. Defaults to `false`. See [here](../api/auth.md) for more information.
 
@@ -16,19 +16,19 @@ If set to true, API calls require an authorization token. Defaults to `false`. S
 
 The password needed to create/revoke authorization tokens. If `--api-auth-required=true`, must be specified; otherwise ignored. See [here](../api/auth.md) for more information.
 
-`--api-ipcs-enabled` (bool):
+`--api-ipcs-enabled` (boolean):
 
 If set to true, this node will expose the IPCs API. Defaults to `false`.
 
-`--api-keystore-enabled` (bool):
+`--api-keystore-enabled` (boolean):
 
 If set to false, this node will not expose the Keystore API. Defaults to `true`.
 
-`--api-metrics-enabled` (bool):
+`--api-metrics-enabled` (boolean):
 
 If set to false, this node will not expose the Metrics API. Defaults to `true`.
 
-`--assertions-enabled` (bool):
+`--assertions-enabled` (boolean):
 
 When set to true, assertions will execute at runtime throughout the codebase. This is intended for use in debugging, as we may get a more specific error message. Defaults to `true`.
 
@@ -44,7 +44,7 @@ Bootstrap IPs is an array of IPv4:port pairs. These IP Addresses will be used to
 
 Specifies the directory to which the database is persisted. Defaults to `"$HOME/.avalanchego/db"`.
 
-`--db-enabled` (bool):
+`--db-enabled` (boolean):
 
 If set to false, state updates are performed solely to an in-memory database, without making any changes on permanent storage.
 When set to true, state updates are written to a local persistent database. Defaults to `true`.
@@ -64,7 +64,7 @@ This argument specifies the port that the http server will listen on. The defaul
 
 This argument specifies the location of the TLS certificate used by the node for the HTTPS server. This must be specified when `--http-tls-enabled=true`. There is no default value.
 
-`--http-tls-enabled` (bool):
+`--http-tls-enabled` (boolean):
 
 If set to true, this flag will attempt to upgrade the server to use HTTPS. Defaults to `false`.
 
@@ -72,13 +72,17 @@ If set to true, this flag will attempt to upgrade the server to use HTTPS. Defau
 
 This argument specifies the location of the TLS private key used by the node for the HTTPS server. This must be specified when `--http-tls-enabled=true`. There is no default value.
 
-`--ipcs-chain-ids` string
+`--ipcs-chain-ids` (string)
 
 Comma separated list of chain ids to connect to. There is no default value.
 
-`--ipcs-path` string
+`--ipcs-path` (string)
 
 The directory (Unix) or named pipe prefix (Windows) for IPC sockets. Defaults to /tmp.
+
+`--fd-limit` (int)
+
+Attempts to raise the process file descriptor limit to at least this value. Defaults to `32768`
 
 `--log-level` (string, `{Off, Fatal, Error, Warn, Info, Debug, Verbo}`):
 
@@ -122,7 +126,7 @@ If this argument is not provided, the node will attempt to perform NAT traversal
 
 Specifies the directory in which the `evm` plugin is kept. Defaults to `"$HOME/.avalanchego/build/plugins"`.
 
-`--signature-verification-enabled` (bool):
+`--signature-verification-enabled` (boolean):
 
 Enables signature verification to be disabled for testing. When set to false, signatures won't be checked in VMs that allow signatures to be disabled. Defaults to `true`.
 


### PR DESCRIPTION
## Add the following missing flags

* `--fd-limit`
* `--uptime-requirement`
* `--tx-fee`
* `--creation-tx-fee`
* `--version`
* `--min-delegation-fee`
* `--min-stake-duration`
* `--max-stake-duration`
* `--max-validator-stake`
* `--stake-minting-period`
* `--staking-disabled-work`
* `--max-non-staker-pending-msgs`
* `--staker-msg-reserved`
* `--staker-cpu-reserved`
* `--network-initial-timeout`
* `--network-minimum-timeout`
* `--network-maximum-timeout`
* `--network-maximum-timeout`
* `--network-timeout-reduction`
* `--log-display-highlight`
* `--api-info-enabled`
* `--api-health-enabled`
* `--consensus-gossip-frequency`
* `--consensus-shutdown-timeout`

## Miscellaneous

* Fix incorrect data types: ex `bool` to `boolean`