### PR TITLE
Removing the changeAddr prop from the avm.importAVAX example

### DIFF
--- a/docs/v1.0/en/tutorials/atomic-swap.md
+++ b/docs/v1.0/en/tutorials/atomic-swap.md
@@ -219,7 +219,6 @@ curl -X POST --data '{
     "params" :{
         "to":"X-avax1fjn5rffqvny7uk3tjegjs6snwjs3hhgcpcxfax",
         "sourceChain":"P",
-        "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
         "username":"myUsername",
         "password":"myPassword"
     }


### PR DESCRIPTION
As per title.

Discussion [here](https://avalancheavax.slack.com/archives/CM288M010/p1604345172086600)

![image](https://user-images.githubusercontent.com/4471462/97919241-60e25680-1d4f-11eb-8afe-b61000ca7c61.png)

![image](https://user-images.githubusercontent.com/4471462/97919270-6dff4580-1d4f-11eb-98dd-a4a5ab282be6.png)

