### PR TITLE
Api documentation fixes

### DIFF
--- a/build/avalanchego-apis/admin-api.md
+++ b/build/avalanchego-apis/admin-api.md
@@ -141,6 +141,12 @@ curl -X POST --data '{
 
 Writes a memory profile of the to `mem.profile`.
 
+#### **Signature**
+
+```text
+admin.memoryProfile() -> {success:bool}
+```
+
 #### **Example Call**
 
 ```text

--- a/build/avalanchego-apis/admin-api.md
+++ b/build/avalanchego-apis/admin-api.md
@@ -23,7 +23,7 @@ Assign an API endpoint an alias, a different endpoint for the API. The original 
 #### **Signature**
 
 ```text
-admin.alias(endpoint:string, alias:string) -> {success:bool}
+admin.alias({endpoint:string, alias:string}) -> {success:bool}
 ```
 
 * `endpoint` is the original endpoint of the API. `endpoint` should only include the part of the endpoint after `/ext/`.

--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -48,7 +48,7 @@ To interact with the `avax` specific RPC calls
 
 ### avax.export
 
-Export an asset from the C-Chain to the X-Chain. After calling this method, you must call `import` on the X-Chain to complete the transfer.
+Export an asset from the C-Chain to the X-Chain. After calling this method, you must call [`avm.import`](https://docs.avax.network/build/avalanchego-apis/exchange-chain-x-chain-api#avm-import) on the X-Chain to complete the transfer.
 
 #### Signature
 
@@ -294,7 +294,7 @@ This gives response:
 
 ### avax.import
 
-Finalize the transfer of a non-AVAX or AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`export`](https://docs.avax.network/build/avalanchego-apis/exchange-chain-x-chain-api#avm-export) method to initiate the transfer.
+Finalize the transfer of a non-AVAX or AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`avm.export`](https://docs.avax.network/build/avalanchego-apis/exchange-chain-x-chain-api#avm-export) method to initiate the transfer.
 
 #### Signature
 
@@ -349,7 +349,7 @@ curl -X POST --data '{
 
 **DEPRECATED—instead use** [**avax.import**](https://docs.avax.network/build/avalanchego-apis/contract-chain-c-chain-api#avax-import)
 
-Finalize a transfer of AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`exportAVAX`](https://docs.avax.network/build/avalanchego-apis/exchange-chain-x-chain-api#avm-exportavax) method to initiate the transfer.
+Finalize a transfer of AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`avm.exportAVAX`](https://docs.avax.network/build/avalanchego-apis/exchange-chain-x-chain-api#avm-exportavax) method to initiate the transfer.
 
 #### Signature
 

--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -100,13 +100,13 @@ curl -X POST --data '{
 
 **DEPRECATED—instead use** [**avax.export**](https://docs.avax.network/build/avalanchego-apis/contract-chain-c-chain-api#avax-export).
 
-Send AVAX from the C-Chain to the X-Chain. After calling this method, you must call `importAVAX` on the X-Chain to complete the transfer.
+Send AVAX from the C-Chain to the X-Chain. After calling this method, you must call [`avm.importAVAX`](https://docs.avax.network/build/avalanchego-apis/exchange-chain-x-chain-api#avm-importavax) on the X-Chain to complete the transfer.
 
 #### Signature
 
 ```go
 avax.exportAVAX({
-    from: string[],
+    from: []string,
     to: string,
     amount: int,
     destinationChain: string,
@@ -232,7 +232,7 @@ avax.getUTXOs(
     },
 ) -> 
 {
-    numFetched: int
+    numFetched: int,
     utxos: []string,
     endIndex: {
         address: string,

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -231,7 +231,7 @@ avm.createFixedCapAsset({
     },
     from: []string, (optional)
     changeAddr: string, (optional)
-    username: string,  
+    username: string,
     password: string
 }) ->
 {
@@ -370,7 +370,7 @@ avm.createVariableCapAsset({
     },
     from: []string, (optional)
     changeAddr: string, (optional)
-    username: string,  
+    username: string,
     password: string
 }) ->
 {
@@ -454,7 +454,7 @@ avm.createNFTAsset({
     },
     from: []string, (optional)
     changeAddr: string, (optional)
-    username: string,  
+    username: string,
     password: string
 }) ->
  {
@@ -643,7 +643,7 @@ curl -X POST --data '{
 
 ### avm.exportAVAX
 
-Send AVAX from the X-Chain to another chain.  
+Send AVAX from the X-Chain to another chain.
 After calling this method, you must call `import` on the other chain to complete the transfer.
 
 #### **Signature**
@@ -984,7 +984,7 @@ avm.getUTXOs(
         sourceChain: string, (optional)
         encoding: string, (optional)
     },
-) -> 
+) ->
 {
     numFetched: int,
     utxos: []string,

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -353,7 +353,7 @@ curl -X POST --data '{
 
 ### avm.createVariableCapAsset
 
-Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mint`.
+Create a new variable-cap, fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `avm.mint`.
 
 {% page-ref page="../tutorials/smart-digital-assets/creating-a-variable-cap-asset.md" %}
 
@@ -438,7 +438,7 @@ curl -X POST --data '{
 
 ### avm.createNFTAsset
 
-Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `mintNFT`.
+Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint units of this asset using `avm.mintNFT`.
 
 {% page-ref page="../tutorials/smart-digital-assets/creating-a-nft-part-1.md" %}
 

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -292,7 +292,7 @@ curl -X POST --data '{
 
 ### avm.mint
 
-Mint units of a variable-cap asset \(an asset created with [`avm.createVariableCapAsset`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)\).
+Mint units of a variable-cap asset created with [`avm.createVariableCapAsset`](#avm-createvariablecapasset).
 
 #### **Signature**
 
@@ -513,7 +513,7 @@ curl -X POST --data '{
 
 ### avm.mintNFT
 
-Mint non-fungible tokens which were created with [`avm.createNFTAsset`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-createnftasset).
+Mint non-fungible tokens which were created with [`avm.createNFTAsset`](#avm-createnftasset).
 
 {% page-ref page="../tutorials/smart-digital-assets/creating-a-nft-part-1.md" %}
 
@@ -579,8 +579,8 @@ curl -X POST --data '{
 
 ### avm.export
 
-Send a non-AVAX from the X-Chain to the P-Chain or C-Chain.  
-After calling this method, you must call [`avax.import`](https://docs.avax-dev.network/build/apis/contract-chain-c-chain-api#avax-import) on the C-Chain to complete the transfer.
+Send a non-AVAX from the X-Chain to the P-Chain or C-Chain.
+After calling this method, you must call [`avax.import`](contract-chain-c-chain-api#avax-import) on the C-Chain to complete the transfer.
 
 #### **Signature**
 
@@ -705,7 +705,7 @@ curl -X POST --data '{
 ### avm.exportKey
 
 Get the private key that controls a given address.  
-The returned private key can be added to a user with [`avm.importKey`](https://app.gitbook.com/@avalanche/s/avalanche/~/drafts/-MLJEet0dNR5tQOXsXki/build/apis/exchange-chain-x-chain-api#avm-importkey).
+The returned private key can be added to a user with [`avm.importKey`](#avm-importkey).
 
 #### **Signature**
 
@@ -1126,7 +1126,7 @@ This gives response:
 
 ### avm.import
 
-Finalize a transfer of AVAX from the P-Chain or C-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-exportavax) or C-Chain’s [`avax.export`](https://docs.avax-dev.network/build/apis/contract-chain-c-chain-api#avax-export) method to initiate the transfer.
+Finalize a transfer of AVAX from the P-Chain or C-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](platform-chain-p-chain-api#platform-exportavax) or C-Chain’s [`avax.export`](contract-chain-c-chain-api#avax-export) method to initiate the transfer.
 
 #### **Signature**
 
@@ -1173,7 +1173,7 @@ curl -X POST --data '{
 
 ### avm.importAVAX
 
-Finalize a transfer of AVAX from the P-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-exportavax) method to initiate the transfer.
+Finalize a transfer of AVAX from the P-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](platform-chain-p-chain-api#platform-exportavax) method to initiate the transfer.
 
 #### **Signature**
 

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -218,7 +218,7 @@ Create a new fixed-cap, fungible asset. A quantity of it is created at initializ
 
 {% page-ref page="../tutorials/smart-digital-assets/create-a-fix-cap-asset.md" %}
 
-**Signature**
+#### **Signature**
 
 ```text
 avm.createFixedCapAsset({

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -224,7 +224,7 @@ Create a new fixed-cap, fungible asset. A quantity of it is created at initializ
 avm.createFixedCapAsset({
     name: string,
     symbol: string,
-    denomination: int,  
+    denomination: int, (optional)
     initialHolders: []{
         address: string,
         amount: int
@@ -363,7 +363,7 @@ Create a new variable-cap, fungible asset. No units of the asset exist at initia
 avm.createVariableCapAsset({
     name: string,
     symbol: string,
-    denomination: int,  
+    denomination: int, (optional)
     minterSets: []{
         minters: []string,
         threshold: int

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -364,7 +364,7 @@ avm.createVariableCapAsset({
     name: string,
     symbol: string,
     denomination: int,  
-    minterSets []{
+    minterSets: []{
         minters: []string,
         threshold: int
     },
@@ -448,7 +448,7 @@ Create a new non-fungible asset. No units of the asset exist at initialization. 
 avm.createNFTAsset({
     name: string,
     symbol: string,
-    minterSets []{
+    minterSets: []{
         minters: []string,
         threshold: int
     },
@@ -986,7 +986,7 @@ avm.getUTXOs(
     },
 ) -> 
 {
-    numFetched: int
+    numFetched: int,
     utxos: []string,
     endIndex: {
         address: string,
@@ -1412,8 +1412,8 @@ avm.sendMultiple({
     outputs: []{
       assetID: string,
       amount: int,
-      to: string
-    }
+      to: string,
+    },
     from: []string, (optional)
     changeAddr: string, (optional)
     memo: string, (optional)
@@ -1596,8 +1596,8 @@ wallet.sendMultiple({
     outputs: []{
       assetID: string,
       amount: int,
-      to: string
-    }
+      to: string,
+    },
     from: []string, (optional)
     changeAddr: string, (optional)
     memo: string, (optional)

--- a/build/avalanchego-apis/info-api.md
+++ b/build/avalanchego-apis/info-api.md
@@ -216,7 +216,7 @@ Check whether a given chain is done bootstrapping
 #### **Signature**
 
 ```text
-info.isBootstrapped(chain: string) -> {isBootstrapped: bool}
+info.isBootstrapped({chain: string}) -> {isBootstrapped: bool}
 ```
 
 `chain` is the ID or alias of a chain.

--- a/build/avalanchego-apis/info-api.md
+++ b/build/avalanchego-apis/info-api.md
@@ -262,7 +262,7 @@ info.peers() ->
         nodeID: string,
         version: string,
         lastSent: string,
-        lastRecevied: string
+        lastReceived: string
     }
 }
 ```

--- a/build/avalanchego-apis/info-api.md
+++ b/build/avalanchego-apis/info-api.md
@@ -16,7 +16,7 @@ This API uses the `json 2.0` RPC format. For more information on making JSON RPC
 
 ### info.getBlockchainID
 
-Given a blockchain’s alias, get its ID. \(See [`admin.aliasChain`](https://docs.avax-dev.network/build/apis/admin-api#admin-aliaschain)for more context.\)
+Given a blockchain’s alias, get its ID. \(See [`admin.aliasChain`](admin-api#admin-aliaschain)for more context.\)
 
 #### **Signature**
 

--- a/build/avalanchego-apis/keystore-api.md
+++ b/build/avalanchego-apis/keystore-api.md
@@ -64,6 +64,8 @@ curl -X POST --data '{
 
 Delete a user.
 
+#### **Signature**
+
 ```text
 keystore.deleteUser({username: string, password:string}) -> {success: bool}
 ```
@@ -95,6 +97,8 @@ curl -X POST --data '{
 ### keystore.exportUser
 
 Export a user. The user can be imported to another node with [`keystore.importUser`](keystore-api.md#keystore-importuser). The user’s password remains encrypted.
+
+#### **Signature**
 
 ```text
 keystore.exportUser(
@@ -134,6 +138,8 @@ curl -X POST --data '{
 ### keystore.importUser
 
 Import a user. `password` must match the user’s password. `username` doesn’t have to match the username `user` had when it was exported.
+
+#### **Signature**
 
 ```text
 keystore.importUser(

--- a/build/avalanchego-apis/platform-chain-p-chain-api.md
+++ b/build/avalanchego-apis/platform-chain-p-chain-api.md
@@ -1,6 +1,6 @@
 # Platform Chain \(P-Chain\) API
 
-This API allows clients to interact with the [P-Chain](../../learn/platform-overview/#platform-chain-p-chain), which maintains Avalanche’s [validator](https://docs.avax-dev.network/learn/platform-overview/staking#validators) set and handles blockchain creation.
+This API allows clients to interact with the [P-Chain](../../learn/platform-overview/#platform-chain-p-chain), which maintains Avalanche’s [validator](../../learn/platform-overview/staking#validators) set and handles blockchain creation.
 
 ## Endpoint
 
@@ -24,7 +24,7 @@ The delegatee charges a fee to the delegator; the former receives a percentage o
 
 The delegation period must be a subset of the period that the delegatee validates the Primary Network.
 
-Note that once you issue the transaction to add a node as a delegator, there is no way to change the parameters. **You can’t remove a stake early or change the stake amount, node ID, or reward address.** Please make sure you’re using the correct values. If you’re not sure, check out our [Developer FAQ](http://support.avalabs.org/en/collections/2618154-developer-faq) or ask for help on [Discord.](https://chat.avalabs.org/)
+Note that once you issue the transaction to add a node as a delegator, there is no way to change the parameters. **You can’t remove a stake early or change the stake amount, node ID, or reward address.** Please make sure you’re using the correct values. If you’re not sure, check out our [Developer FAQ](https://support.avalabs.org/en/collections/2618154-developer-faq) or ask for help on [Discord.](https://chat.avalabs.org/)
 
 {% page-ref page="../../learn/platform-overview/staking.md" %}
 
@@ -105,7 +105,7 @@ The validation period must be between 2 weeks and 1 year.
 
 There is a maximum total weight imposed on validators. This means that no validator will ever have more AVAX staked and delegated to it than this value. This value will initially be set to `min(5 * amount staked, 3M AVAX)`. The total value on a validator is 3 million AVAX.
 
-Note that once you issue the transaction to add a node as a validator, there is no way to change the parameters. **You can’t remove stake early or change the stake amount, node ID, or reward address.** Please make sure you’re using the correct values. If you’re not sure, check out our [Developer FAQ](http://support.avalabs.org/en/collections/2618154-developer-faq) or ask for help on [Discord.](https://chat.avalabs.org/)
+Note that once you issue the transaction to add a node as a validator, there is no way to change the parameters. **You can’t remove stake early or change the stake amount, node ID, or reward address.** Please make sure you’re using the correct values. If you’re not sure, check out our [Developer FAQ](https://support.avalabs.org/en/collections/2618154-developer-faq) or ask for help on [Discord.](https://chat.avalabs.org/)
 
 {% page-ref page="../../learn/platform-overview/staking.md" %}
 
@@ -430,7 +430,7 @@ curl -X POST --data '{
 
 ### platform.exportAVAX
 
-Send AVAX from an address on the P-Chain to an address on the X-Chain. After issuing this transaction, you must call the X-Chain’s [`avm.importAVAX`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-importavax) method to complete the transfer.
+Send AVAX from an address on the P-Chain to an address on the X-Chain. After issuing this transaction, you must call the X-Chain’s [`avm.importAVAX`](exchange-chain-x-chain-api#avm-importavax) method to complete the transfer.
 
 #### **Signature**
 
@@ -493,7 +493,7 @@ curl -X POST --data '{
 ### platform.exportKey
 
 Get the private key that controls a given address.  
-The returned private key can be added to a user with [`platform.importKey`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-importkey).
+The returned private key can be added to a user with [`platform.importKey`](#platform-importkey).
 
 #### **Signature**
 
@@ -1484,7 +1484,7 @@ This gives response:
 
 Complete a transfer of AVAX from the X-Chain to the P-Chain.
 
-Before this method is called, you must call the X-Chain’s [`avm.exportAVAX`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-exportavax) method to initiate the transfer.
+Before this method is called, you must call the X-Chain’s [`avm.exportAVAX`](exchange-chain-x-chain-api#avm-exportavax) method to initiate the transfer.
 
 #### **Signature**
 

--- a/build/avalanchego-apis/platform-chain-p-chain-api.md
+++ b/build/avalanchego-apis/platform-chain-p-chain-api.md
@@ -784,7 +784,7 @@ The top level field `delegators` is deprecated as of v1.0.1. If you are using it
 #### **Signature**
 
 ```cpp
-platform.getCurrentValidators({subnetID: string}) ->
+platform.getCurrentValidators({subnetID: string, (optional)}) ->
 {
     validators: []{
         startTime: string,
@@ -1004,7 +1004,7 @@ List the validators in the pending validator set of the specified Subnet. Each v
 #### **Signature**
 
 ```cpp
-platform.getPendingValidators({subnetID: string}) ->
+platform.getPendingValidators({subnetID: string, (optional)}) ->
 {
     validators: []{
         startTime: string,
@@ -1678,7 +1678,7 @@ Sample validators from the specified Subnet.
 platform.sampleValidators(
     {
         size: int,
-        subnetID: string
+        subnetID: string, (optional)
     }
 ) ->
 {

--- a/build/avalanchego-apis/platform-chain-p-chain-api.md
+++ b/build/avalanchego-apis/platform-chain-p-chain-api.md
@@ -338,7 +338,7 @@ curl -X POST --data '{
     "method": "platform.createBlockchain",
     "params" : {
         "vmID":"timestamp",
-        "SubnetID":"2bRCr6B4MiEfSjidDwxDpdCyviwnfUVqB2HGwhm947w9YYqb7r",
+        "subnetID":"2bRCr6B4MiEfSjidDwxDpdCyviwnfUVqB2HGwhm947w9YYqb7r",
         "name":"My new timestamp",
         "genesisData": "45oj4CqFViNHUtBxJ55TZfqaVAXFwMRMj2XkHVqUYjJYoTaEM",
         "encoding": "cb58",
@@ -553,7 +553,6 @@ platform.getBalance({
     utxoIDs: []{
         txID: string,
         outputIndex: int
-        }
     }
 }
 ```
@@ -801,7 +800,7 @@ platform.getCurrentValidators({subnetID: string}) ->
         potentialReward: string,
         delegationFee: string,
         uptime: string,
-        connected: boolean,
+        connected: bool,
         delegators: []{
             startTime: string,
             endTime: string,
@@ -934,7 +933,7 @@ Returns the height of the last accepted block.
 ```cpp
 platform.getHeight() ->
 {
-      height: int,
+    height: int,
 }
 ```
 
@@ -1011,7 +1010,7 @@ platform.getPendingValidators({subnetID: string}) ->
         startTime: string,
         endTime: string,
         stakeAmount: string, (optional)
-        nodeID: string
+        nodeID: string,
         delegationFee: string,
         connected: bool,
         weight: string, (optional)
@@ -1129,9 +1128,9 @@ platform.getSubnets(
 ) ->
 {
     subnets: []{
-            id: string,
-            controlKeys: []string,
-            threshold: string
+        id: string,
+        controlKeys: []string,
+        threshold: string
     }
 }
 ```
@@ -1257,7 +1256,7 @@ Optional `encoding` parameter to specify the format for the returned transaction
 platform.getTx({
     txID: string,
     encoding: string (optional)
-} -> {
+}) -> {
     tx: string,
     encoding: string,
 })
@@ -1297,7 +1296,7 @@ Gets a transaction’s status by its ID.
 #### **Signature**
 
 ```cpp
-platform.getTxStatus({txID: string} -> {status: string})
+platform.getTxStatus({txID: string}) -> {status: string}
 ```
 
 #### **Example Call**
@@ -1334,7 +1333,7 @@ platform.getUTXOs(
     {
         addresses: string,
         limit: int, (optional)
-        startIndex: { (optional )
+        startIndex: { (optional)
             address: string,
             utxo: string
         },
@@ -1343,7 +1342,7 @@ platform.getUTXOs(
     },
 ) -> 
 {
-    numFetched: int
+    numFetched: int,
     utxos: []string,
     endIndex: {
         address: string,

--- a/build/avalanchego-apis/platform-chain-p-chain-api.md
+++ b/build/avalanchego-apis/platform-chain-p-chain-api.md
@@ -1547,7 +1547,7 @@ curl -X POST --data '{
 
 Give a user control over an address by providing the private key that controls the address.
 
-**Signature**
+#### **Signature**
 
 ```cpp
 platform.importKey({

--- a/build/avalanchego-apis/platform-chain-p-chain-api.md
+++ b/build/avalanchego-apis/platform-chain-p-chain-api.md
@@ -389,7 +389,7 @@ platform.createSubnet(
 }
 ```
 
-* In order to create add a validator to this subnet, `threshold` signatures are required from the addresses in `controlKeys`
+* In order to add a validator to this subnet, `threshold` signatures are required from the addresses in `controlKeys`
 * `from` are the addresses that you want to use for this operation. If omitted, uses any of your addresses as needed.
 * `changeAddr` is the address any change will be sent to. If omitted, change is sent to one of the addresses controlled by the user.
 * `username` is the user that pays the transaction fee.
@@ -1324,7 +1324,7 @@ curl -X POST --data '{
 
 ### platform.getUTXOs
 
-Gets the UTXOs that reference a given set address.
+Gets the UTXOs that reference a given set of addresses.
 
 #### **Signature**
 


### PR DESCRIPTION
I recently released [Codl.center](https://codl.center), an interactive API documentation for avalanchego. It uses [API specs](https://github.com/CodlTech/app-codl-center/tree/master/src/data/specs) that are generated from a specialized [documentation parser](https://github.com/CodlTech/app-codl-center/tree/master/lab/doc-parser).

While writing this parser, I stumbled on inconsistencies for which I wrote the following patches.

My parser harmonizes method signatures formatting - you can check the result on [Codl.center](https://codl.center). I can merge that change back into avalanche-docs if you like.