### PR TITLE
Convert internal docs links to relative links

### DIFF
--- a/build/avalanchego-apis/auth-api.md
+++ b/build/avalanchego-apis/auth-api.md
@@ -14,7 +14,7 @@ Note that if you run your node with `--api-auth-required` then some tools like M
 
 ## Format
 
-This API uses the `json 2.0` RPC format. For more information on making JSON RPC calls, see [here.](https://docs.avax.network/v1.0/en/api/issuing-api-calls/)
+This API uses the `json 2.0` RPC format. For more information on making JSON RPC calls, see [here.](issuing-api-calls.md)
 
 ## Endpoint
 
@@ -73,7 +73,7 @@ This call will generate an authorization token that allows access to API endpoin
 
 This authorization token should be included in API calls by giving header `Authorization` value `Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJFbmRwb2ludHMiOlsiKiJdLCJleHAiOjE1OTM0NzU4OTR9.Cqo7TraN_CFN13q3ae4GRJCMgd8ZOlQwBzyC29M6Aps`.
 
-For example, to call [`info.peers`](https://docs.avax-dev.network/build/apis/info-api#info-peers) with this token:
+For example, to call [`info.peers`](info-api.md#info-peers) with this token:
 
 ```text
 curl -X POST --data '{

--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -98,7 +98,7 @@ curl -X POST --data '{
 
 ### avax.exportAVAX
 
-**DEPRECATED—instead use** [**avax.export**](https://docs.avax.network/build/avalanchego-apis/contract-chain-c-chain-api#avax-export).
+**DEPRECATED—instead use** [**avax.export**](contract-chain-c-chain-api.md#avax-export).
 
 Send AVAX from the C-Chain to the X-Chain. After calling this method, you must call `importAVAX` on the X-Chain to complete the transfer.
 
@@ -294,7 +294,7 @@ This gives response:
 
 ### avax.import
 
-Finalize the transfer of a non-AVAX or AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`export`](https://docs.avax.network/build/avalanchego-apis/exchange-chain-x-chain-api#avm-export) method to initiate the transfer.
+Finalize the transfer of a non-AVAX or AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`export`](exchange-chain-x-chain-api.md#avm-export) method to initiate the transfer.
 
 #### Signature
 
@@ -347,9 +347,9 @@ curl -X POST --data '{
 
 ### avax.importAVAX
 
-**DEPRECATED—instead use** [**avax.import**](https://docs.avax.network/build/avalanchego-apis/contract-chain-c-chain-api#avax-import)
+**DEPRECATED—instead use** [**avax.import**](contract-chain-c-chain-api.md#avax-import)
 
-Finalize a transfer of AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`exportAVAX`](https://docs.avax.network/build/avalanchego-apis/exchange-chain-x-chain-api#avm-exportavax) method to initiate the transfer.
+Finalize a transfer of AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`exportAVAX`](exchange-chain-x-chain-api.md#avm-exportavax) method to initiate the transfer.
 
 #### Signature
 

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -293,7 +293,7 @@ curl -X POST --data '{
 
 ### avm.mint
 
-Mint units of a variable-cap asset \(an asset created with [`avm.createVariableCapAsset`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-createvariablecapasset)\).
+Mint units of a variable-cap asset \(an asset created with [`avm.createVariableCapAsset`](exchange-chain-x-chain-api.md#avm-createvariablecapasset)\).
 
 #### **Signature**
 
@@ -514,7 +514,7 @@ curl -X POST --data '{
 
 ### avm.mintNFT
 
-Mint non-fungible tokens which were created with [`avm.createNFTAsset`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-createnftasset).
+Mint non-fungible tokens which were created with [`avm.createNFTAsset`](exchange-chain-x-chain-api.md#avm-createnftasset).
 
 {% page-ref page="../tutorials/smart-digital-assets/creating-a-nft-part-1.md" %}
 
@@ -581,7 +581,7 @@ curl -X POST --data '{
 ### avm.export
 
 Send a non-AVAX from the X-Chain to the P-Chain or C-Chain.  
-After calling this method, you must call [`avax.import`](https://docs.avax-dev.network/build/apis/contract-chain-c-chain-api#avax-import) on the C-Chain to complete the transfer.
+After calling this method, you must call [`avax.import`](contract-chain-c-chain-api.md#avax-import) on the C-Chain to complete the transfer.
 
 #### **Signature**
 
@@ -1133,7 +1133,7 @@ This gives response:
 
 ### avm.import
 
-Finalize a transfer of AVAX from the P-Chain or C-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-exportavax) or C-Chain’s [`avax.export`](https://docs.avax-dev.network/build/apis/contract-chain-c-chain-api#avax-export) method to initiate the transfer.
+Finalize a transfer of AVAX from the P-Chain or C-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](platform-chain-p-chain-api.md#platform-exportavax) or C-Chain’s [`avax.export`](contract-chain-c-chain-api.md#avax-export) method to initiate the transfer.
 
 #### **Signature**
 
@@ -1181,7 +1181,7 @@ curl -X POST --data '{
 
 ### avm.importAVAX
 
-Finalize a transfer of AVAX from the P-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-exportavax) method to initiate the transfer.
+Finalize a transfer of AVAX from the P-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](platform-chain-p-chain-api.md#platform-exportavax) method to initiate the transfer.
 
 #### **Signature**
 

--- a/build/avalanchego-apis/info-api.md
+++ b/build/avalanchego-apis/info-api.md
@@ -16,7 +16,7 @@ This API uses the `json 2.0` RPC format. For more information on making JSON RPC
 
 ### info.getBlockchainID
 
-Given a blockchain’s alias, get its ID. \(See [`admin.aliasChain`](https://docs.avax-dev.network/build/apis/admin-api#admin-aliaschain)for more context.\)
+Given a blockchain’s alias, get its ID. \(See [`admin.aliasChain`](admin-api.md#admin-aliaschain)for more context.\)
 
 #### **Signature**
 

--- a/build/avalanchego-apis/platform-chain-p-chain-api.md
+++ b/build/avalanchego-apis/platform-chain-p-chain-api.md
@@ -1,6 +1,6 @@
 # Platform Chain \(P-Chain\) API
 
-This API allows clients to interact with the [P-Chain](../../learn/platform-overview/#platform-chain-p-chain), which maintains Avalanche’s [validator](https://docs.avax-dev.network/learn/platform-overview/staking#validators) set and handles blockchain creation.
+This API allows clients to interact with the [P-Chain](../../learn/platform-overview/#platform-chain-p-chain), which maintains Avalanche’s [validator](../../learn/platform-overview/staking.md#validators) set and handles blockchain creation.
 
 ## Endpoint
 
@@ -430,7 +430,7 @@ curl -X POST --data '{
 
 ### platform.exportAVAX
 
-Send AVAX from an address on the P-Chain to an address on the X-Chain. After issuing this transaction, you must call the X-Chain’s [`avm.importAVAX`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-importavax) method to complete the transfer.
+Send AVAX from an address on the P-Chain to an address on the X-Chain. After issuing this transaction, you must call the X-Chain’s [`avm.importAVAX`](exchange-chain-x-chain-api.md#avm-importavax) method to complete the transfer.
 
 #### **Signature**
 
@@ -493,7 +493,7 @@ curl -X POST --data '{
 ### platform.exportKey
 
 Get the private key that controls a given address.  
-The returned private key can be added to a user with [`platform.importKey`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-importkey).
+The returned private key can be added to a user with [`platform.importKey`](platform-chain-p-chain-api.md#platform-importkey).
 
 #### **Signature**
 
@@ -1138,7 +1138,7 @@ platform.getSubnets(
 
 `ids` are the IDs of the subnets to get information about. If omitted, gets information about all subnets. `id` is the Subnet’s ID.  
 `threshold` signatures from addresses in `controlKeys` are needed to add a validator to the subnet.  
-See [here](https://docs.avax-dev.network/build/tutorials/platform/add-a-validator) for information on adding a validator to a Subnet.
+See [here](../tutorials/nodes-and-staking/add-a-validator.md) for information on adding a validator to a Subnet.
 
 #### **Example Call**
 
@@ -1485,7 +1485,7 @@ This gives response:
 
 Complete a transfer of AVAX from the X-Chain to the P-Chain.
 
-Before this method is called, you must call the X-Chain’s [`avm.exportAVAX`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-exportavax) method to initiate the transfer.
+Before this method is called, you must call the X-Chain’s [`avm.exportAVAX`](exchange-chain-x-chain-api.md#avm-exportavax) method to initiate the transfer.
 
 #### **Signature**
 

--- a/build/references/command-line-interface.md
+++ b/build/references/command-line-interface.md
@@ -31,11 +31,11 @@ If set to `false`, this node will not expose the Admin API. Defaults to `false`.
 
 `--api-auth-required` \(boolean\):
 
-If set to `true`, API calls require an authorization token. Defaults to `false`. See [here](https://docs.avax-dev.network/build/apis/auth-api) for more information.
+If set to `true`, API calls require an authorization token. Defaults to `false`. See [here](../avalanchego-apis/auth-api) for more information.
 
 `--api-auth-password` \(string\):
 
-The password needed to create/revoke authorization tokens. If `--api-auth-required=true`, must be specified; otherwise ignored. See [here](https://docs.avax-dev.network/build/apis/auth-api) for more information.
+The password needed to create/revoke authorization tokens. If `--api-auth-required=true`, must be specified; otherwise ignored. See [here](../avalanchego-apis/auth-api) for more information.
 
 `--api-health-enabled` \(boolean\):
 

--- a/build/tutorials/platform/create-a-new-blockchain.md
+++ b/build/tutorials/platform/create-a-new-blockchain.md
@@ -16,7 +16,7 @@ Every blockchain is validated by a [subnet](https://avalanche.gitbook.io/avalanc
 
 The subnet needs validators in it to, well, validate blockchains.
 
-Make sure the subnet that will validate your blockchain has at least `snow-sample-size` validators in it. \(Recall that `snow-sample-size` is one of the [command-line arguments](https://docs.avax.network/v1.0/en/references/command-line-interface/) when starting a node. Its default value is 20.\)
+Make sure the subnet that will validate your blockchain has at least `snow-sample-size` validators in it. \(Recall that `snow-sample-size` is one of the [command-line arguments](../../references/command-line-interface.md) when starting a node. Its default value is 20.\)
 
 {% page-ref page="../nodes-and-staking/add-a-validator.md" %}
 
@@ -24,7 +24,7 @@ Make sure the subnet that will validate your blockchain has at least `snow-sampl
 
 Each blockchain has some genesis state when it’s created. Each Virtual Machine has a static API method named `buildGenesis` that takes in a JSON representation of a blockchain’s genesis state and returns the byte representation of that state. \(This isn’t true for some VMs, like the Platform VM, because we disallow the creation of new instances.\)
 
-The [AVM’s documentation](../../avalanchego-apis/exchange-chain-x-chain-api.md) specifies that the argument to [`avm.buildGenesis`](https://avalanche.gitbook.io/avalanche/build/apis/exchange-chain-x-chain-api#avm-buildgenesis) should look like this:
+The [AVM’s documentation](../../avalanchego-apis/exchange-chain-x-chain-api.md) specifies that the argument to [`avm.buildGenesis`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-buildgenesis) should look like this:
 
 ```cpp
 {

--- a/build/tutorials/platform/create-a-subnet.md
+++ b/build/tutorials/platform/create-a-subnet.md
@@ -10,7 +10,7 @@ In this tutorial, we’ll create a new subnet with 2 control keys and a threshol
 
 ### Generate the Control Keys <a id="generate-the-control-keys"></a>
 
-First, let’s generate the 2 control keys. To do so we call [`platform.createAddress`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-createaddress) This generates a new private key and stores it for a user.
+First, let’s generate the 2 control keys. To do so we call [`platform.createAddress`](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-createaddress) This generates a new private key and stores it for a user.
 
 To generate the first key:
 
@@ -66,7 +66,7 @@ The response contains the second control key, which is held by the user we just 
 
 ### Create the Subnet <a id="create-the-subnet"></a>
 
-To create a subnet, we call [`platform.createSubnet`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-createsubnet).
+To create a subnet, we call [`platform.createSubnet`](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-createsubnet).
 
 ```cpp
 curl -X POST --data '{
@@ -100,7 +100,7 @@ The response gives us the transaction’s ID, which is also the ID of the newly 
 
 ### Verifying Success <a id="verifying-success"></a>
 
-We can call [`platform.getSubnets`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-getsubnets) to get all Subnets that exist:
+We can call [`platform.getSubnets`](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-getsubnets) to get all Subnets that exist:
 
 ```cpp
 curl -X POST --data '{

--- a/build/tutorials/platform/create-a-virtual-machine-vm.md
+++ b/build/tutorials/platform/create-a-virtual-machine-vm.md
@@ -4,7 +4,7 @@ _The code below is slightly out of date. Some methods, interfaces, and implement
 
 ## Introduction
 
-One of the core features of Avalanche is the creation of new, custom blockchains, which are defined by [Virtual Machines \(VMs\)](https://docs.avax-dev.network/learn/platform-overview#virtual-machines)
+One of the core features of Avalanche is the creation of new, custom blockchains, which are defined by [Virtual Machines \(VMs\)](../../../learn/platform-overview#virtual-machines)
 
 In this tutorial, we’ll create a very simple VM. The blockchain defined by the VM is a timestamp server. Each block in the blockchain contains the timestamp when it was created along with a 32-byte piece of data \(payload\). Each block’s timestamp is after its parent’s timestamp.
 

--- a/build/tutorials/platform/transfer-avax-between-x-chain-and-p-chain.md
+++ b/build/tutorials/platform/transfer-avax-between-x-chain-and-p-chain.md
@@ -12,7 +12,7 @@ You've completed [Getting Started](../../getting-started.md) and are familiar wi
 
 In order to send AVAX, you need to have some AVAX! Use the [AVAX Test Faucet](https://faucet.avax-test.network) to send some AVAX to an X-Chain address you hold.
 
-To send the AVAX, call the X-Chain’s [`avm.exportAVAX`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-exportavax) method.
+To send the AVAX, call the X-Chain’s [`avm.exportAVAX`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-exportavax) method.
 
 Your call should look like this:
 
@@ -32,7 +32,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
 ```
 
-where `to` is the address of a P-Chain address you hold and `changeAddr` is the address to send any change to. You can leave `changeAddr` blank; if you leave it blank, change will be returned to an address controlled by your user \(see [here](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-createaddress) for instructions on creating a new P-Chain address\).
+where `to` is the address of a P-Chain address you hold and `changeAddr` is the address to send any change to. You can leave `changeAddr` blank; if you leave it blank, change will be returned to an address controlled by your user \(see [here](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-createaddress) for instructions on creating a new P-Chain address\).
 
 Note that you will pay a transaction fee for both the export and import operations. In this example, let’s assume the transaction fee is `1,000,000` nAVAX. Then, the above export actually consumes `6,000,000` nAVAX; `5,000,000` goes to the P-Chain and `1,000,000` is burned as a transaction fee.
 
@@ -51,7 +51,7 @@ The response should look like this:
 }
 ```
 
-We can verify that this transaction was accepted by calling [`avm.getTxStatus`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-gettxstatus):
+We can verify that this transaction was accepted by calling [`avm.getTxStatus`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-gettxstatus):
 
 ```cpp
 curl -X POST --data '{
@@ -76,7 +76,7 @@ Which shows our transaction is accepted:
 }
 ```
 
-We can also call [`avm.getBalance`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-getbalance) to check that the AVAX was deducted from an address held by our user:
+We can also call [`avm.getBalance`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-getbalance) to check that the AVAX was deducted from an address held by our user:
 
 ```cpp
 curl -X POST --data '{
@@ -94,7 +94,7 @@ The amount deducted is the exported amount \(`5,000,000` in this example\) plus 
 
 ## Import AVAX to the P-Chain from the X-Chain
 
-Our transfer isn’t done just yet. We need to call the P-Chain’s [`platform.importAVAX`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-importavax) method to finish the transfer.
+Our transfer isn’t done just yet. We need to call the P-Chain’s [`platform.importAVAX`](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-importavax) method to finish the transfer.
 
 Your call should look like this:
 
@@ -176,7 +176,7 @@ Note that the balance we see is the amount exported from the X-Chain \(`5,000,00
 
 Now, let’s move AVAX on the P-Chain back to the X-Chain.
 
-To do so, call [`platform.exportAVAX`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-exportavax):
+To do so, call [`platform.exportAVAX`](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-exportavax):
 
 ```cpp
 curl -X POST --data '{
@@ -195,11 +195,11 @@ curl -X POST --data '{
 
 where `to` is the X-Chain address the AVAX is being sent to.
 
-This returns the transaction ID, and we can check that the transaction was committed with another call to [`platform.getTxStatus`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-gettxstatus). Again, make sure that the amount you’re sending exceeds the transaction fee.
+This returns the transaction ID, and we can check that the transaction was committed with another call to [`platform.getTxStatus`](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-gettxstatus). Again, make sure that the amount you’re sending exceeds the transaction fee.
 
 ## Import AVAX to the X-Chain from the P-Chain
 
-To finish our transfer from the P-Chain to the X-Chain, call [`avm.importAVAX`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-importavax):
+To finish our transfer from the P-Chain to the X-Chain, call [`avm.importAVAX`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-importavax):
 
 ```cpp
 curl -X POST --data '{
@@ -216,9 +216,9 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
 ```
 
-Note that `to` is the same address specified in our call to [`platform.exportAVAX`](https://docs.avax-dev.network/build/apis/platform-chain-p-chain-api#platform-exportavax).
+Note that `to` is the same address specified in our call to [`platform.exportAVAX`](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-exportavax).
 
-Just as before, we can call [`avm.getBalance`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-getbalance) to verify the funds were received. The balance should have increased by `3,000,000` minus the transaction fee.
+Just as before, we can call [`avm.getBalance`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-getbalance) to verify the funds were received. The balance should have increased by `3,000,000` minus the transaction fee.
 
 ## Export AVAX from the X-Chain to the C-Chain
 
@@ -280,7 +280,7 @@ The response contains a hex-encoded EVM address:
 }
 ```
 
-Now, you can use the address corresponding to the private key you exported and switch to using the C- prefix in the [`avm.exportAVAX`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-exportavax) call:
+Now, you can use the address corresponding to the private key you exported and switch to using the C- prefix in the [`avm.exportAVAX`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-exportavax) call:
 
 ```cpp
 curl -X POST --data '{  
@@ -367,7 +367,7 @@ The response should look like this:
 
 ## Import AVAX to the X-Chain from the C-Chain
 
-Lastly, we can finish up by importing AVAX from the C-Chain to the X-Chain, call [`avm.importAVAX`](https://docs.avax-dev.network/build/apis/exchange-chain-x-chain-api#avm-importavax).
+Lastly, we can finish up by importing AVAX from the C-Chain to the X-Chain, call [`avm.importAVAX`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-importavax).
 
 ```cpp
 curl -X POST --data '{  


### PR DESCRIPTION
Docs used absolute links to other doc files which made all the links
referencing old site (https://docs.avax-dev.network/) broken. Converting
to relative linking would solve that and future domain and path changes
as long as the relative positions and names of files remain.