### PR TITLE
Fixed wrong link in the truffle tutorial

### DIFF
--- a/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain.md
+++ b/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain.md
@@ -197,7 +197,7 @@ truffle(development)> .exit
 
 ### Fund your account
 
-Follow the steps in the [Transfer AVAX Between X-Chain, P-Chain, and C-Chain](../platform/transfer-avax-between-x-chain-and-p-chain.md) tutorial to fund the newly created account. You'll need to send at least `135422040` nAVAX to the account to cover the cost of contract deployments.
+Follow the steps in the [Transfer AVAX Between X-Chain and C-Chain](../platform/transfer-avax-between-x-chain-and-c-chain.md) tutorial to fund the newly created account. You'll need to send at least `135422040` nAVAX to the account to cover the cost of contract deployments.
 
 ### Unlock your account
 


### PR DESCRIPTION
Tutorial linked to X<>P tutorial, instead of X<>C