### PR TITLE
Update AVM Transaction Serialization docs with learnings from ongoing trustwallet work 

### DIFF
--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -143,7 +143,7 @@ Let’s make a transferable input:
     // input:
     0x00, 0x00, 0x00, 0x05, 0x00, 0x00, 0x00, 0x00,
     0x07, 0x5b, 0xcd, 0x15, 0x00, 0x00, 0x00, 0x02,
-    0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x03
+    0x00, 0x00, 0x00, 0x03, 0x00, 0x00, 0x00, 0x07
 ]
 ```
 
@@ -653,13 +653,13 @@ Let’s make a payment input with:
 
 * **`TypeId`**: `5`
 * **`Amount`**: `123456789`
-* **`AddressIndices`**: \[`7`,`3`\]
+* **`AddressIndices`**: \[`3`,`7`\]
 
 ```text
 [
     TypeID         <- 0x00000005
     Amount         <- 123456789 = 0x00000000075bcd15,
-    AddressIndices <- [0x00000007, 0x00000003]
+    AddressIndices <- [0x00000003, 0x00000007]
 ]
 =
 [
@@ -670,9 +670,9 @@ Let’s make a payment input with:
     // length:
     0x00, 0x00, 0x00, 0x02,
     // sig[0]
-    0x00, 0x00, 0x00, 0x07,
-    // sig[1]
     0x00, 0x00, 0x00, 0x03,
+    // sig[1]
+    0x00, 0x00, 0x00, 0x07,
 ]
 ```
 
@@ -728,15 +728,15 @@ Let’s make a [secp256k1](cryptographic-primitives.md#secp-256-k1-addresses) mi
 
 * **`TypeId`**: `8`
 * **`AddressIndices`**:
-* `0x00000007`
 * `0x00000003`
+* `0x00000007`
 * **`MintOutput`**: `“Example SECP256K1 Mint Output from above”`
 * **`TransferOutput`**: `“Example SECP256K1 Transfer Output from above”`
 
 ```text
 [
     TypeID <- 0x00000008
-    AddressIndices <- [0x00000007, 0x00000003]
+    AddressIndices <- [0x00000003, 0x00000007]
     MintOutput <- 0x00000006000000000000d431000000010000000251025c61fbcfc078f69334f834be6dd26d55a955c3344128e060128ede3523a24a461c89
     TransferOutput <- 0x000000070000000000003039000000000000d431000000010000000251025c61fbcfc078f69334f834be6dd26d55a955c3344128e060128ede3523a24a461c8943ab0859
 ]
@@ -747,9 +747,9 @@ Let’s make a [secp256k1](cryptographic-primitives.md#secp-256-k1-addresses) mi
     // number of address_indices:
     0x00, 0x00, 0x00, 0x02,
     // address_indices[0]:
-    0x00, 0x00, 0x00, 0x07,
-    // address_indices[1]:
     0x00, 0x00, 0x00, 0x03,
+    // address_indices[1]:
+    0x00, 0x00, 0x00, 0x07,
     // mint output
     0x00, 0x00, 0x00, 0x06, 0x00, 0x00, 0x00, 0x00,
     0x00, 0x00, 0xd4, 0x31, 0x00, 0x00, 0x00, 0x01,
@@ -825,8 +825,8 @@ Let’s make an NFT mint operation with:
 
 * **`TypeId`**: `12`
 * **`AddressIndices`**:
-  * `0x00000007`
   * `0x00000003`
+  * `0x00000007`
 * **`GroupID`**: `12345`
 * **`Payload`**: `0x431100`
 * **`Locktime`**: `54321`
@@ -838,8 +838,8 @@ Let’s make an NFT mint operation with:
 [
     TypeID         <- 0x0000000c
     AddressIndices <- [
-        0x00000007,
         0x00000003,
+        0x00000007,
     ]
     GroupID        <- 0x00003039
     Payload        <- 0x431100
@@ -856,9 +856,9 @@ Let’s make an NFT mint operation with:
     // number of address indices:
     0x00, 0x00, 0x00, 0x02,
     // address index 0:
-    0x00, 0x00, 0x00, 0x07,
-    // address index 1:
     0x00, 0x00, 0x00, 0x03,
+    // address index 1:
+    0x00, 0x00, 0x00, 0x07,
     // groupID:
     0x00, 0x00, 0x30, 0x39,
     // length of payload:

--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -12,10 +12,10 @@ Transferable outputs wrap an output with an asset ID.
 
 ### What Transferable Output Contains
 
-A transferable output contains an `AssetID` and an `Output`.
+A transferable output contains an `AssetID` and an [`Output`](#Outputs).
 
 * **`AssetID`** is a 32-byte array that defines which asset this output references.
-* **`Output`** is an output, as defined below. For example, this can be a SECP256K1 transfer output.
+* **`Output`** is an output, as defined [below](#Outputs). For example, this can be a [SECP256K1 transfer output](#SECP256K1-Transfer-Output).
 
 ### Gantt Transferable Output Specification
 
@@ -81,7 +81,7 @@ A transferable input contains a `TxID`, `UTXOIndex` `AssetID` and an `Input`.
 * **`TxID`** is a 32-byte array that defines which transaction this input is consuming an output from.
 * **`UTXOIndex`** is an int that defines which utxo this input is consuming in the specified transaction.
 * **`AssetID`** is a 32-byte array that defines which asset this input references.
-* **`Input`** is an input, as defined below. This will be a SECP256K1 transfer input
+* **`Input`** is an input, as defined below. This can currently only be a [SECP256K1 transfer input](#SECP256K1-Transfer-Input)
 
 ### Gantt Transferable Input Specification
 
@@ -157,7 +157,7 @@ A transferable operation contains an `AssetID`, `UTXOIDs`, and `TransferOp`.
 
 * **`AssetID`** is a 32-byte array that defines which asset this operation changes.
 * **`UTXOIDs`** is an array of TxID-OutputIndex tuples. This array must be sorted in lexicographical order.
-* **`TransferOp`** is a transferable operation object.
+* **`TransferOp`** is a [transferable operation object](#Operations).
 
 ### Gantt Transferable Op Specification
 
@@ -242,7 +242,7 @@ Let’s make a transferable operation:
 
 ## Outputs
 
-Outputs have four possible types: `SECP256K1TransferOutput`, `SECP256K1MintOutput`, `NFTTransferOutput` and `NFTMintOutput`.
+Outputs have four possible types: [`SECP256K1TransferOutput`](#SECP256K1-Transfer-Output), [`SECP256K1MintOutput`](#SECP256K1-Mint-Output), [`NFTTransferOutput`](#NFT-Transfer-Output) and [`NFTMintOutput`](#NFT-Mint-Output).
 
 ## SECP256K1 Transfer Output
 
@@ -689,9 +689,9 @@ A [secp256k1](cryptographic-primitives.md#secp-256-k1-addresses) mint operation 
 A secp256k1 Mint operation contains a `TypeID`, `AddressIndices`, `MintOutput`, and `TransferOutput`.
 
 * **`TypeID`** is the ID for this output type. It is `0x00000008`.
-* **`AddressIndices`** is a list of unique ints that define the private keys that are being used to spend the UTXO. Each UTXO has an array of addresses that can spend the UTXO. Each int represents the index in this address array that will sign this transaction. The array must be sorted low to high.
-* **`MintOutput`** is a SECP256K1 Mint output.
-* **`TransferOutput`** is a SECP256K1 Transfer output
+* **`AddressIndices`** is a list of unique ints that define the private keys that are being used to spend the [UTXO](#UTXO). Each UTXO has an array of addresses that can spend the UTXO. Each int represents the index in this address array that will sign this transaction. The array must be sorted low to high.
+* **`MintOutput`** is a [SECP256K1 Mint output](#SECP256K1-Mint-Output).
+* **`TransferOutput`** is a [SECP256K1 Transfer output](#SECP256K1-Transfer-Output).
 
 ### **Gantt SECP256K1 Mint Operation Specification**
 
@@ -784,7 +784,7 @@ An NFT mint operation contains a `TypeID`, `AddressIndices`, `GroupID`, `Payload
 * **`AddressIndices`** is a list of unique ints that define the private keys that are being used to spend the UTXO. Each UTXO has an array of addresses that can spend the UTXO. Each int represents the index in this address array that will sign this transaction. The array must be sorted low to high.
 * **`GroupID`** is an int that specifies the group this NFT is issued to.
 * **`Payload`** is an arbitrary string of bytes no longer than 1024 bytes.
-* **`Output`** is a locktime, threshold, and an array of unique addresses that correspond to the private keys that can be used to spend this output. Addresses must be sorted lexicographically.
+* **`Output`** is not a `TransferableOutput`, but rather is a locktime, threshold, and an array of unique addresses that correspond to the private keys that can be used to spend this output. Addresses must be sorted lexicographically.
 
 ### **Gantt NFT Mint Op Specification**
 
@@ -891,7 +891,7 @@ An NFT transfer operation contains a `TypeID`, `AddressIndices` and an untyped `
 
 * **`TypeID`** is the ID for this output type. It is `0x0000000d`.
 * **`AddressIndices`** is a list of unique ints that define the private keys that are being used to spend the UTXO. Each UTXO has an array of addresses that can spend the UTXO. Each int represents the index in this address array that will sign this transaction. The array must be sorted low to high.
-* **`NFTTransferOutput`** is the output of this operation and must be an NFT Transfer Output. This output doesn’t have the **`TypeId`**, because the type is known by the context of being in this operation.
+* **`NFTTransferOutput`** is the output of this operation and must be an [NFT Transfer Output](#NFT-Transfer-Output). This output doesn’t have the **`TypeId`**, because the type is known by the context of being in this operation.
 
 ### **Gantt NFT Transfer Op Specification**
 
@@ -1005,7 +1005,7 @@ Initial state describes the initial state of an asset when it is created. It con
 Initial state contains a `FxID` and an array of `Output`.
 
 * **`FxID`** is an int that defines which feature extension this state is part of. For SECP256K1 assets, this is `0x00000000`. For NFT assets, this is `0x00000001`.
-* **`Outputs`** is a variable length array of outputs, as defined above.
+* **`Outputs`** is a variable length array of [outputs](#Outputs), as defined above.
 
 ### Gantt Initial State Specification
 
@@ -1143,11 +1143,11 @@ Let’s make a payment input with:
 
 ## NFT Credential
 
-An NFT credential is the same as an secp256k1 credential with a different TypeID. The TypeID for an NFT credential is `0x0000000e`.
+An NFT credential is the same as an [secp256k1 credential](#secp256k1-credential) with a different TypeID. The TypeID for an NFT credential is `0x0000000e`.
 
 ## Unsigned Transactions
 
-Unsigned transactions contain the full content of a transaction with only the signatures missing. Unsigned transactions have four possible types: `CreateAssetTx`, `OperationTx`, `ImportTx`, and `ExportTx`. They all embed `BaseTx`, which contains common fields and operations.
+Unsigned transactions contain the full content of a transaction with only the signatures missing. Unsigned transactions have four possible types: [`CreateAssetTx`](#What-Unsigned-Create-Asset-Tx-Contains), [`OperationTx`](#What-Unsigned-Operation-Tx-Contains), [`ImportTx`](#What-Unsigned-Import-Tx-Contains), and [`ExportTx`](#What-Unsigned-Export-Tx-Contains). They all embed [`BaseTx`](#What-Base-Tx-Contains), which contains common fields and operations.
 
 ### What Base Tx Contains
 
@@ -1156,8 +1156,8 @@ A base tx contains a `TypeID`, `NetworkID`, `BlockchainID`, `Outputs`, `Inputs`,
 * **`TypeID`** is the ID for this type. It is `0x00000000`.
 * **`NetworkID`** is an int that defines which network this transaction is meant to be issued to. This value is meant to support transaction routing and is not designed for replay attack prevention.
 * **`BlockchainID`** is a 32-byte array that defines which blockchain this transaction was issued to. This is used for replay attack prevention for transactions that could potentially be valid across network or blockchain.
-* **`Outputs`** is an array of transferable output objects. Outputs must be sorted lexicographically by their serialized representation. The total quantity of the assets created in these outputs must be less than or equal to the total quantity of each asset consumed in the inputs minus the transaction fee.
-* **`Inputs`** is an array of transferable input objects. Inputs must be sorted and unique. Inputs are sorted first lexicographically by their **`TxID`** and then by the **`UTXOIndex`** from low to high. If there are inputs that have the same **`TxID`** and **`UTXOIndex`**, then the transaction is invalid as this would result in a double spend.
+* **`Outputs`** is an array of [transferable output objects](#Transferable-Output). Outputs must be sorted lexicographically by their serialized representation. The total quantity of the assets created in these outputs must be less than or equal to the total quantity of each asset consumed in the inputs minus the transaction fee.
+* **`Inputs`** is an array of [transferable input objects](#Transferable-Input). Inputs must be sorted and unique. Inputs are sorted first lexicographically by their **`TxID`** and then by the **`UTXOIndex`** from low to high. If there are inputs that have the same **`TxID`** and **`UTXOIndex`**, then the transaction is invalid as this would result in a double spend.
 * **`Memo`** Memo field contains arbitrary bytes, up to 256 bytes.
 
 ### Gantt Base Tx Specification
@@ -1276,7 +1276,7 @@ An unsigned create asset tx contains a `BaseTx`, `Name`, `Symbol`, `Denomination
 * **`Name`** is a human readable string that defines the name of the asset this transaction will create. The name is not guaranteed to be unique. The name must consist of only printable ASCII characters and must be no longer than 128 characters.
 * **`Symbol`** is a human readable string that defines the symbol of the asset this transaction will create. The symbol is not guaranteed to be unique. The symbol must consist of only printable ASCII characters and must be no longer than 4 characters.
 * **`Denomination`** is a byte that defines the divisibility of the asset this transaction will create. For example, the AVAX token is divisible into billionths. Therefore, the denomination of the AVAX token is 9. The denomination must be no more than 32.
-* **`InitialStates`** is a variable length array that defines the feature extensions this asset supports, and the initial state of those feature extensions.
+* **`InitialStates`** is a variable length array that defines the feature extensions this asset supports, and the [initial state](#Initial-State) of those feature extensions.
 
 ### Gantt Unsigned Create Asset Tx Specification
 
@@ -1396,7 +1396,7 @@ Let’s make an unsigned base tx that uses the inputs and outputs from the previ
 An unsigned operation tx contains a `BaseTx`, and `Ops`. The `TypeID` for this type is `0x00000002`.
 
 * **`BaseTx`**
-* **`Ops`** is a variable-length array of Transferable Ops.
+* **`Ops`** is a variable-length array of [Transferable Ops](#Transferable-Ops).
 
 ### Gantt Unsigned Operation Tx Specification
 
@@ -1499,7 +1499,7 @@ An unsigned import tx contains a `BaseTx`, `SourceChain` and `Ins`. \* The `Type
 
 * **`BaseTx`**
 * **`SourceChain`** is a 32-byte source blockchain ID.
-* **`Ins`** is a variable length array of Transferable Inputs.
+* **`Ins`** is a variable length array of [Transferable Inputs](#Transferable-Input).
 
 ### Gantt Unsigned Import Tx Specification
 
@@ -1607,7 +1607,7 @@ Let’s make an unsigned import tx that uses the inputs from the previous exampl
 An unsigned export tx contains a `BaseTx`, `DestinationChain`, and `Outs`. The `TypeID` for this type is `0x00000004`.
 
 * **`DestinationChain`** is the 32 byte ID of the chain where the funds are being exported to.
-* **`Outs`** is a variable length array of Transferable Outputs.
+* **`Outs`** is a variable length array of [Transferable Outputs](#Transferable-Output).
 
 ### Gantt Unsigned Export Tx Specification
 
@@ -1711,7 +1711,7 @@ Let’s make an unsigned export tx that uses the outputs from the previous examp
 
 ## Signed Transaction
 
-A signed transaction is an unsigned transaction with the addition of an array of credentials.
+A signed transaction is an unsigned transaction with the addition of an array of [credentials](#Credentials).
 
 ### What Signed Transaction Contains
 
@@ -1719,7 +1719,7 @@ A signed transaction contains a `CodecID`, `UnsignedTx`, and `Credentials`.
 
 * **`CodecID`** The only current valid codec id is `00 00`.
 * **`UnsignedTx`** is an unsigned transaction, as described above.
-* **`Credentials`** is an array of credentials. Each credential will be paired with the input in the same index at this credential.
+* **`Credentials`** is an array of [credentials](#Credentials). Each credential will be paired with the input in the same index at this credential.
 
 ### Gantt Signed Transaction Specification
 
@@ -1832,7 +1832,7 @@ A UTXO contains a `CodecID`, `TxID`, `UTXOIndex`, `AssetID`, and `Output`.
 * **`TxID`** is a 32-byte transaction ID. Transaction IDs are calculated by taking sha256 of the bytes of the signed transaction.
 * **`UTXOIndex`** is an int that specifies which output in the transaction specified by **`TxID`** that this utxo was created by.
 * **`AssetID`** is a 32-byte array that defines which asset this utxo references.
-* **`Output`** is the output object that created this utxo. The serialization of Outputs was defined above.
+* **`Output`** is the [output](#Transferable-Output) object that created this utxo. The serialization of Outputs was defined above.
 
 ### Gantt UTXO Specification
 

--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -42,8 +42,8 @@ message TransferableOutput {
 
 Let’s make a transferable output:
 
-* `AssetID: 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
-* `Output: "Example SECP256K1 Transfer Output from below"`
+* `AssetID`: `0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
+* `Output`: `"Example SECP256K1 Transfer Output from below"`
 
 ```text
 [
@@ -114,10 +114,10 @@ message TransferableInput {
 
 Let’s make a transferable input:
 
-* `TxID: 0xf1e1d1c1b1a191817161514131211101f0e0d0c0b0a090807060504030201000`
-* `UTXOIndex: 5`
-* `AssetID: 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
-* `Input: "Example SECP256K1 Transfer Input from below"`
+* `TxID`: `0xf1e1d1c1b1a191817161514131211101f0e0d0c0b0a090807060504030201000`
+* `UTXOIndex`: `5`
+* `AssetID`: `0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
+* `Input`: `"Example SECP256K1 Transfer Input from below"`
 
 ```text
 [
@@ -192,12 +192,12 @@ message TransferableOp {
 
 Let’s make a transferable operation:
 
-* `AssetID: 0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
-* `UTXOIDs:`
-  * `UTXOID:`
-    * `TxID: 0xf1e1d1c1b1a191817161514131211101f0e0d0c0b0a090807060504030201000`
-    * `UTXOIndex: 5`
-* `Op: "Example Transfer Op from below"`
+* `AssetID`: `0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
+* `UTXOIDs`:
+  * `UTXOID`:
+    * `TxID`: `0xf1e1d1c1b1a191817161514131211101f0e0d0c0b0a090807060504030201000`
+    * `UTXOIndex`: `5`
+* `Op`: `"Example Transfer Op from below"`
 
 ```text
 [
@@ -292,13 +292,13 @@ message SECP256K1TransferOutput {
 
 Let’s make a secp256k1 transfer output with:
 
-* **`TypeID`**: 7
-* **`Amount`**: 12345
-* **`Locktime`**: 54321
-* **`Threshold`**: 1
+* **`TypeID`**: `7`
+* **`Amount`**: `12345`
+* **`Locktime`**: `54321`
+* **`Threshold`**: `1`
 * **`Addresses`**:
-* 0x51025c61fbcfc078f69334f834be6dd26d55a955
-* 0xc3344128e060128ede3523a24a461c8943ab0859
+* `0x51025c61fbcfc078f69334f834be6dd26d55a955`
+* `0xc3344128e060128ede3523a24a461c8943ab0859`
 
 ```text
 [
@@ -378,12 +378,12 @@ message SECP256K1MintOutput {
 
 Let’s make a SECP256K1 mint output with:
 
-* **`TypeID`**: 6
-* **`Locktime`**: 54321
-* **`Threshold`**: 1
+* **`TypeID`**: `6`
+* **`Locktime`**: `54321`
+* **`Threshold`**: `1`
 * **`Addresses`**:
-* 0x51025c61fbcfc078f69334f834be6dd26d55a955
-* 0xc3344128e060128ede3523a24a461c8943ab0859
+* `0x51025c61fbcfc078f69334f834be6dd26d55a955`
+* `0xc3344128e060128ede3523a24a461c8943ab0859`
 
 ```text
 [
@@ -469,14 +469,14 @@ message NFTTransferOutput {
 
 Let’s make an NFT transfer output with:
 
-* **`TypeID`**: 11
-* **`GroupID`**: 12345
-* **`Payload`**: 0x431100
-* **`Locktime`**: 54321
-* **`Threshold`**: 1
+* **`TypeID`**: `11`
+* **`GroupID`**: `12345`
+* **`Payload`**: `0x431100`
+* **`Locktime`**: `54321`
+* **`Threshold`**: `1`
 * **`Addresses`**:
-* 0x51025c61fbcfc078f69334f834be6dd26d55a955
-* 0xc3344128e060128ede3523a24a461c8943ab0859
+* `0x51025c61fbcfc078f69334f834be6dd26d55a955`
+* `0xc3344128e060128ede3523a24a461c8943ab0859`
 
 ```text
 [
@@ -565,13 +565,13 @@ message NFTMintOutput {
 
 Let’s make an NFT mint output with:
 
-* **`TypeID`**: 10
-* **`GroupID`**: 12345
-* **`Locktime`**: 54321
-* **`Threshold`**: 1
+* **`TypeID`**: `10`
+* **`GroupID`**: `12345`
+* **`Locktime`**: `54321`
+* **`Threshold`**: `1`
 * **`Addresses`**:
-* 0x51025c61fbcfc078f69334f834be6dd26d55a955
-* 0xc3344128e060128ede3523a24a461c8943ab0859
+* `0x51025c61fbcfc078f69334f834be6dd26d55a955`
+* `0xc3344128e060128ede3523a24a461c8943ab0859`
 
 ```text
 [
@@ -651,9 +651,9 @@ message SECP256K1TransferInput {
 
 Let’s make a payment input with:
 
-* **`TypeId`**: 5
-* **`Amount`**: 123456789
-* **`AddressIndices`**: \[7,3\]
+* **`TypeId`**: `5`
+* **`Amount`**: `123456789`
+* **`AddressIndices`**: \[`7`,`3`\]
 
 ```text
 [
@@ -726,12 +726,12 @@ message SECP256K1MintOperation {
 
 Let’s make a [secp256k1](cryptographic-primitives.md#secp-256-k1-addresses) mint operation with:
 
-* **`TypeId`**: 8
+* **`TypeId`**: `8`
 * **`AddressIndices`**:
-* 0x00000007
-* 0x00000003
-* **`MintOutput`**: “Example SECP256K1 Mint Output from above”
-* **`TransferOutput`**: “Example SECP256K1 Transfer Output from above”
+* `0x00000007`
+* `0x00000003`
+* **`MintOutput`**: `“Example SECP256K1 Mint Output from above”`
+* **`TransferOutput`**: `“Example SECP256K1 Transfer Output from above”`
 
 ```text
 [
@@ -823,16 +823,16 @@ message NFTMintOp {
 
 Let’s make an NFT mint operation with:
 
-* **`TypeId`**: 12
+* **`TypeId`**: `12`
 * **`AddressIndices`**:
-  * 0x00000007
-  * 0x00000003
-* **`GroupID`**: 12345
-* **`Payload`**: 0x431100
-* **`Locktime`**: 54321
-* **`Threshold`**: 1
+  * `0x00000007`
+  * `0x00000003`
+* **`GroupID`**: `12345`
+* **`Payload`**: `0x431100`
+* **`Locktime`**: `54321`
+* **`Threshold`**: `1`
 * **`Addresses`**:
-* 0xc3344128e060128ede3523a24a461c8943ab0859
+* `0xc3344128e060128ede3523a24a461c8943ab0859`
 
 ```text
 [
@@ -935,17 +935,17 @@ message NFTTransferOp {
 
 Let’s make an NFT transfer operation with:
 
-* **`TypeID`**: 13
+* **`TypeID`**: `13`
 * **`AddressIndices`**:
-* 0x00000007
-* 0x00000003
-* **`GroupID`**: 12345
-* **`Payload`**: 0x431100
-* **`Locktime`**: 54321
-* **`Threshold`**: 1
+* `0x00000007`
+* `0x00000003`
+* **`GroupID`**: `12345`
+* **`Payload`**: `0x431100`
+* **`Locktime`**: `54321`
+* **`Threshold`**: `1`
 * **`Addresses`**:
-* 0xc3344128e060128ede3523a24a461c8943ab0859
-* 0x51025c61fbcfc078f69334f834be6dd26d55a955
+* `0xc3344128e060128ede3523a24a461c8943ab0859`
+* `0x51025c61fbcfc078f69334f834be6dd26d55a955`
 
 ```text
 [
@@ -1032,8 +1032,8 @@ message InitialState {
 
 Let’s make an initial state:
 
-* `FxID: 0x00000000`
-* `InitialState: ["Example SECP256K1 Transfer Output from above"]`
+* `FxID`: `0x00000000`
+* `InitialState`: `["Example SECP256K1 Transfer Output from above"]`
 
 ```text
 [
@@ -1099,7 +1099,7 @@ message SECP256K1Credential {
 
 Let’s make a payment input with:
 
-* **`TypeID`**: 9
+* **`TypeID`**: `9`
 * **`signatures`**:
 * `0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1e1d1f202122232425262728292a2b2c2e2d2f303132333435363738393a3b3c3d3e3f00`
 * `0x404142434445464748494a4b4c4d4e4f505152535455565758595a5b5c5e5d5f606162636465666768696a6b6c6e6d6f707172737475767778797a7b7c7d7e7f00`
@@ -1529,9 +1529,9 @@ message ImportTx {
 
 Let’s make an unsigned import tx that uses the inputs from the previous examples:
 
-* `BaseTx`: “Example BaseTx as defined above” but with `TypeID` set to `3`
+* `BaseTx`: `“Example BaseTx as defined above”`, but with `TypeID` set to `3`
 * `SourceChain`: `0x0000000000000000000000000000000000000000000000000000000000000000`
-* `Ins`: “Example SECP256K1 Transfer Input as defined above”
+* `Ins`: `“Example SECP256K1 Transfer Input as defined above”`
 
 ```text
 [
@@ -1637,9 +1637,9 @@ message ExportTx {
 
 Let’s make an unsigned export tx that uses the outputs from the previous examples:
 
-* `BaseTx`: “Example BaseTx as defined above” with `TypeID` set to `4`
+* `BaseTx`: `“Example BaseTx as defined above”`, but with `TypeID` set to `4`
 * `DestinationChain`: `0x0000000000000000000000000000000000000000000000000000000000000000`
-* `Outs`: “Example SECP256K1 Transfer Output as defined above”
+* `Outs`: `“Example SECP256K1 Transfer Output as defined above”`
 
 ```text
 [
@@ -1870,7 +1870,7 @@ Let’s make a UTXO from the signed transaction created above:
 
 * **`CodecID`**: `0`
 * **`TxID`**: `0xf966750f438867c3c9828ddcdbe660e21ccdbb36a9276958f011ba472f75d4e7`
-* **`UTXOIndex`**: 0 = 0x00000000
+* **`UTXOIndex`**: `0` = `0x00000000`
 * **`AssetID`**: `0x000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f`
 * **`Output`**: `"Example SECP256K1 Transferable Output as defined above"`
 


### PR DESCRIPTION
## Summary
I've been using [the docs](https://docs.avax.network/build/references/avm-transaction-serialization) (along with our code) to figure out how to implement our notion of a Transaction for the x-chain for the [Trustwallet wallet-core work](https://github.com/EvanJRichard/wallet-core). While doing so, I noticed a bug that some fields that should be sorted were unsorted. I fixed that, and while I was at it I added some quality of life improvements and consistency tweaks that I hope will make it easier for the next person who comes along to work from these docs: 

### Changelog

- encoding is sometimes not correct, fix it
- we often to refer to Output, clarify as TransferableOutput vs TransactionOutput vs the Output that NFTMintOp uses
- definition of TransferableInput says "This will be a SECP256K1 etc." - clarify as "At time of writing this can only be a SECP256K1 etc."
- clarify when we mean TransferableInput vs Input, TransferableOp vs Operation, TransferableOutput vs Output
- NFTMintOp references an Output object that is very different from what we mean when we say Output elsewhere in the docs, highlight that this is the case
- Clarify that InitialState wants an Output not a TransferableOutput
- Sometimes the example for an object uses backtick code to define the variables, sometimes not. Examples standardized to one style.
- Add in-document markdown anchors to clarify things/provide cross-references

### Testing
No code, so no testing. Compiled the markdown locally and poked around, nothing obviously wrong or broken.

### See also
I didn't see any other encoding errors but I worry some still lurk.