### PR TITLE
Add nodeID param to peers and current/pending validators calls

### DIFF
--- a/build/avalanchego-apis/info-api.md
+++ b/build/avalanchego-apis/info-api.md
@@ -253,7 +253,9 @@ Get a description of peer connections.
 #### **Signature**
 
 ```cpp
-info.peers() -> 
+info.peers({
+    nodeIDs: string[] // optional
+}) -> 
 {
     numPeers: int,
     peers:[]{
@@ -267,13 +269,18 @@ info.peers() ->
 }
 ```
 
+* `nodeIDs` is an optional parameter to specify what nodeID's descriptions should be returned. If this parameter is left empty, descriptions for all active connections will be returned. If the node is not connected to a specified nodeID, it will be omitted from the response.
+
 #### **Example Call**
 
 ```cpp
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"info.peers"
+    "method" :"info.peers",
+    "params": {
+        "nodeIDs": []
+    }
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/info
 ```
 

--- a/build/avalanchego-apis/platform-chain-p-chain-api.md
+++ b/build/avalanchego-apis/platform-chain-p-chain-api.md
@@ -785,7 +785,8 @@ The top level field `delegators` was [deprecated](deprecated-api-calls.md#getcur
 
 ```cpp
 platform.getCurrentValidators({
-    subnetID: string //optional
+    subnetID: string, //optional
+    nodeIDs: string[], //optional
 }) -> {
     validators: []{
         txID: string,
@@ -821,6 +822,7 @@ platform.getCurrentValidators({
 ```
 
 * `subnetID` is the subnet whose current validators are returned. If omitted, returns the current validators of the Primary Network.
+* `nodeIDs` is a list of the nodeIDs of current validators to request. If omitted, all current validators are returned. If a specified nodeID is not in the set of current validators, it will not be included in the response.
 * `validators`:
   * `txID` is the validator transaction.
   * `startTime` is the Unix time when the validator starts validating the Subnet.
@@ -983,7 +985,8 @@ List the validators in the pending validator set of the specified Subnet. Each v
 
 ```cpp
 platform.getPendingValidators({
-    subnetID: string //optional
+    subnetID: string, //optional
+    nodeIDs: string[], //optional
 }) -> {
     validators: []{
         txID: string,
@@ -1006,6 +1009,7 @@ platform.getPendingValidators({
 ```
 
 * `subnetID` is the subnet whose current validators are returned. If omitted, returns the current validators of the Primary Network.
+* `nodeIDs` is a list of the nodeIDs of pending validators to request. If omitted, all pending validators are returned. If a specified nodeID is not in the set of pending validators, it will not be included in the response.
 * `validators`:
   * `txID` is the validator transaction.
   * `startTime` is the Unix time when the validator starts validating the Subnet.


### PR DESCRIPTION
This PR adds the nodeID parameter to the API calls `info.peers`, `platform.getCurrentValidators`, and `platform.getPendingValidators`. The corresponding PR in avalanchego: https://github.com/ava-labs/avalanchego/pull/747 has been merged to dev and should be in the next release.