### PR TITLE
Fix the endpoint for the example call to eth_getAssetBalance on C-Chain

### DIFF
--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -96,7 +96,7 @@ curl -X POST --data '{
         "3RvKBAmQnfYionFXMfW5P8TDZgZiogKbHjM8cjpu16LKAgF5T"
     ],
     "id": 1
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/rpc
 ```
 
 **Example Response**


### PR DESCRIPTION
The example call in the docs gives an endpoint on the X chain, so it will fail if someone just pastes the sample curl code 