### PR TITLE
fixing command in tutorial

### DIFF
--- a/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain.md
+++ b/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain.md
@@ -212,6 +212,7 @@ Community member [Cinque McFarlane-Blake](https://github.com/cinquemb) has made 
 ```text
 wget -nd -m https://raw.githubusercontent.com/ava-labs/avalanche-docs/master/scripts/make_accounts.js;
 ```
+**Note**: If you followed the steps at the beginning of this tutorial when setting up your `truffle-config.js`, then you will need to modify the `make_accounts.js` script to use port 9650 instead of port 9545 (the default used by truffle). 
 
 You can run the script with:
 

--- a/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain.md
+++ b/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain.md
@@ -192,7 +192,7 @@ This prints the account:
 ### Unlock your account:
 
 ```text
-truffle(development)> await web3.eth.personal.unlockAccount(account[0])
+truffle(development)> await web3.eth.personal.unlockAccount(account)
 ```
 
 This returns:


### PR DESCRIPTION
There is a command in the tutorial for using truffle with the avalanche C-Chain that indexes into an `account` variable that doesn't need to be indexed into (it's a string, not the first element of a list). When I tried indexing into the variable while trying to fund an account following this setup I got the following error:
```
truffle(development)> await web3.eth.personal.unlockAccount(account[0])
Uncaught:
Error: Provided address "0" is invalid, the capitalization checksum test failed, or its an indrect IBAN address which can't be converted.
    at evalmachine.<anonymous>:1:27
    at Personal.send [as unlockAccount] (/Users/matthewrusso/.nvm/versions/node/v14.5.0/lib/node_modules/truffle/build/webpack:/node_modules/web3-eth/node_modules/web3-core-method/src/index.js:617:1)
    at Method.toPayload (/Users/matthewrusso/.nvm/versions/node/v14.5.0/lib/node_modules/truffle/build/webpack:/node_modules/web3-eth/node_modules/web3-core-method/src/index.js:183:1)
    at Method.formatInput (/Users/matthewrusso/.nvm/versions/node/v14.5.0/lib/node_modules/truffle/build/webpack:/node_modules/web3-eth/node_modules/web3-core-method/src/index.js:148:1)
    at Array.map (<anonymous>)
    at /Users/matthewrusso/.nvm/versions/node/v14.5.0/lib/node_modules/truffle/build/webpack:/node_modules/web3-eth/node_modules/web3-core-method/src/index.js:150:1
    at Method.inputAddressFormatter (/Users/matthewrusso/.nvm/versions/node/v14.5.0/lib/node_modules/truffle/build/webpack:/node_modules/web3-core-helpers/src/formatters.js:475:1)
```
Executing with the full account string corrected the issue:
```
truffle(development)> await web3.eth.personal.unlockAccount(account)
true
```
This PR simply corrects this typo.