### PR TITLE
Update upgrade-your-avalanchego-node.md

### DIFF
--- a/build/tutorials/nodes-and-staking/upgrade-your-avalanchego-node.md
+++ b/build/tutorials/nodes-and-staking/upgrade-your-avalanchego-node.md
@@ -148,6 +148,8 @@ Pull the latest code:
 git pull
 ```
 
+NOTE: if the master branch has not been updated with the latest release tag, you can get to it directly via a `git checkout tags/<tag>` (where `<tag>` is the latest release tag; for example `v1.3.2`) instead of `git pull`. Note that your local copy will be in a 'detached HEAD' state, which is not an issue if you do not make changes to the source that you want push back to the repository (in which case you should check out to a branch and to the ordinary merges). 
+
 Check that your local code is up to date. Do:
 
 ```text
@@ -155,6 +157,8 @@ git rev-parse HEAD
 ```
 
 and check that the first 7 characters printed match the Latest commit field on our [Github.](https://github.com/ava-labs/avalanchego)
+
+NOTE: if you used the `git checkout tags/<tag>` then these first 7 characters should match commit hash of that tag.
 
 Now build the binary:
 


### PR DESCRIPTION
When upgrading from source at times the latest release is not always merged into master. Please add the proposed notes so that we can run the latest release from source, but by checking out the release tag commit rather than master.