### PR TITLE
Increase minimum disk size to 40 GB free

### DIFF
--- a/build/get-started.md
+++ b/build/get-started.md
@@ -27,7 +27,7 @@ This tutorial is primarily geared toward developers and people interested in how
 
 Avalanche is an incredibly lightweight protocol, so the minimum computer requirements are quite modest.
 
-* Hardware: CPU &gt; 2 GHz, RAM &gt; 4 GB, Storage &gt; 10 GB free space
+* Hardware: CPU &gt; 2 GHz, RAM &gt; 4 GB, Storage &gt; 40 GB free space
 * OS: Ubuntu 18.04/20.04 or MacOS &gt;= Catalina
 
 ## Run an Avalanche Node and Send Funds

--- a/build/tutorials/nodes-and-staking/set-up-an-avalanche-node-with-microsoft-azure.md
+++ b/build/tutorials/nodes-and-staking/set-up-an-avalanche-node-with-microsoft-azure.md
@@ -162,7 +162,7 @@ Once your deployment has finished, select “Go to resource”
 
 ## Change the Provisioned Disk Size <a id="00dc"></a>
 
-By default, the Ubuntu VM will be provisioned with a 30 GB Premium SSD, whilst this should be sufficient, I personally didn’t want the hassle of potentially needing to extend this later into the staking period. I have included the steps below if you want to increase it to 64 GB or if you ever need to increase it at a later date.
+By default, the Ubuntu VM will be provisioned with a 30 GB Premium SSD. You should increase this to 64 GB, to allow for database growth.
 
 ![Image for post](https://miro.medium.com/max/880/1*2uJoRLC586qLEhr1RNNeTg.png)
 


### PR DESCRIPTION
The live chain database is now 20 GB and growing. The number is chosen to leave some head room, until pruning is implemented.