### PR TITLE
Update upgrade-your-avalanchego-node.md

### DIFF
--- a/build/tutorials/nodes-and-staking/upgrade-your-avalanchego-node.md
+++ b/build/tutorials/nodes-and-staking/upgrade-your-avalanchego-node.md
@@ -148,7 +148,7 @@ Pull the latest code:
 git pull
 ```
 
-NOTE: if the master branch has not been updated with the latest release tag, you can get to it directly via first running `git fetch --all --tags` and then `git checkout tags/<tag>` \(where `<tag>` is the latest release tag; for example `v1.3.2`\) instead of `git pull`. Note that your local copy will be in a 'detached HEAD' state, which is not an issue if you do not make changes to the source that you want push back to the repository \(in which case you should check out to a branch and to the ordinary merges\).
+NOTE: if the master branch has not been updated with the latest release tag, you can get to it directly via first running `git fetch --all --tags` and then `git checkout --force tags/<tag>` \(where `<tag>` is the latest release tag; for example `v1.3.2`\) instead of `git pull`. Note that your local copy will be in a 'detached HEAD' state, which is not an issue if you do not make changes to the source that you want push back to the repository \(in which case you should check out to a branch and to the ordinary merges\). Note also that the `--force` flag will disregard any local changes you might have.
 
 Check that your local code is up to date. Do:
 


### PR DESCRIPTION
Added the `--force` flag to the `git checkout`. This will wipe out any local changes that you made (though probably you shouldn't have done any if this is a running node.) This is necessary because this morning when doing the v1.4.0 upgrade the checkout command informed that:

error: Your local changes to the following files would be overwritten by checkout:
	go.sum
Please commit your changes or stash them before you switch branches.
Aborting

I'm not familiar with golang, but understand that go.sum is about checksums of dependent modules. Was it modified or generated by running the build or the node? Would it make sense to either include go.sum in the committed version or to list it in the gitignore as to avoid that error message (in which case this pull request might not be needed.)