### PR TITLE
Fix typo

### DIFF
--- a/build/references/network-protocol.md
+++ b/build/references/network-protocol.md
@@ -329,7 +329,7 @@ The OpCode used by `PullQuery` messages is: `0x07`.
 
 ### What PullQuery contains
 
-A `Put` message contains a `SubnetID`, `RequestID`, and `ContainerID`.
+A `PullQuery` message contains a `SubnetID`, `RequestID`, and `ContainerID`.
 
 **`SubnetID`** defines which subnet this message is destined for.
 


### PR DESCRIPTION
Fixes a small typo. `Put` is referenced instead of `PullQuery`