### PR TITLE
Minor documentation tweaks

### DIFF
--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -153,7 +153,7 @@ Transferable operations describe a set of UTXOs with a provided transfer operati
 
 ### What Transferable Op Contains
 
-A transferable operation contains an `AssetID`, `UTXOIDs`, and `TransferOp`.
+A transferable operation contains an `AssetID`, `UTXOIDs`, and a `TransferOp`.
 
 * **`AssetID`** is a 32-byte array that defines which asset this operation changes.
 * **`UTXOIDs`** is an array of TxID-OutputIndex tuples. This array must be sorted in lexicographical order.
@@ -1401,13 +1401,13 @@ An unsigned operation tx contains a `BaseTx`, and `Ops`. The `TypeID` for this t
 ### Gantt Unsigned Operation Tx Specification
 
 ```text
-+---------+--------------+-------------------------------------+
-| base_tx : BaseTx       |                 size(base_tx) bytes |
-+---------+--------------+-------------------------------------+
-| ops     : []TransferOp |                 4 + size(ops) bytes |
-+---------+--------------+-------------------------------------+
-                         | 4 + size(ops) + size(base_tx) bytes |
-                         +-------------------------------------+
++---------+------------------+-------------------------------------+
+| base_tx : BaseTx           |                 size(base_tx) bytes |
++---------+------------------+-------------------------------------+
+| ops     : []TransferableOp |                 4 + size(ops) bytes |
++---------+------------------+-------------------------------------+
+                             | 4 + size(ops) + size(base_tx) bytes |
+                             +-------------------------------------+
 ```
 
 ### Proto Unsigned Operation Tx Specification

--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -15,7 +15,7 @@ Transferable outputs wrap an output with an asset ID.
 A transferable output contains an `AssetID` and an [`Output`](avm-transaction-serialization.md#outputs).
 
 * **`AssetID`** is a 32-byte array that defines which asset this output references.
-* **`Output`** is an output, as defined [below](avm-transaction-serialization.md#outputs). For example, this can be a [SECP256K1 transfer output](avm-transaction-serialization.md#secp256k1-transfer-output).
+* **`Output`** is an output, as defined [below](avm-transaction-serialization.md#outputs). For example, this can be a [SECP256K1 transfer output](avm-transaction-serialization.md#secp-256-k1-transfer-output).
 
 ### Gantt Transferable Output Specification
 

--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -78,7 +78,7 @@ Transferable inputs describe a specific UTXO with a provided transfer input.
 
 A transferable input contains a `TxID`, `UTXOIndex` `AssetID` and an `Input`.
 
-* **`TxID`** is a 32-byte array that defines which transaction this input is consuming an output from.
+* **`TxID`** is a 32-byte array that defines which transaction this input is consuming an output from. Transaction IDs are calculated by taking sha256 of the bytes of the signed transaction.
 * **`UTXOIndex`** is an int that defines which utxo this input is consuming in the specified transaction.
 * **`AssetID`** is a 32-byte array that defines which asset this input references.
 * **`Input`** is an input, as defined below. This can currently only be a [SECP256K1 transfer input](avm-transaction-serialization.md#secp256k1-transfer-input)

--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -1424,7 +1424,7 @@ message OperationTx {
 Let’s make an unsigned operation tx that uses the inputs and outputs from the previous examples:
 
 * `BaseTx`: `"Example BaseTx above" with TypeID set to 2`
-* **`Ops`**: \[`"Example Transfer Op as defined above"`\]
+* **`Ops`**: \[`"Example Transferable Op as defined above"`\]
 
 ```text
 [

--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -15,7 +15,7 @@ Transferable outputs wrap an output with an asset ID.
 A transferable output contains an `AssetID` and an [`Output`](avm-transaction-serialization.md#outputs).
 
 * **`AssetID`** is a 32-byte array that defines which asset this output references.
-* **`Output`** is an output, as defined [below](avm-transaction-serialization.md#outputs). For example, this can be a [SECP256K1 transfer output](avm-transaction-serialization.md#secp-256-k1-transfer-output).
+* **`Output`** is an output, as defined [below](avm-transaction-serialization.md#outputs). For example, this can be a [SECP256K1 transfer output](avm-transaction-serialization.md#secp256k1-transfer-output).
 
 ### Gantt Transferable Output Specification
 

--- a/build/references/avm-transaction-serialization.md
+++ b/build/references/avm-transaction-serialization.md
@@ -1396,7 +1396,7 @@ Let’s make an unsigned base tx that uses the inputs and outputs from the previ
 An unsigned operation tx contains a `BaseTx`, and `Ops`. The `TypeID` for this type is `0x00000002`.
 
 * **`BaseTx`**
-* **`Ops`** is a variable-length array of [Transferable Ops](avm-transaction-serialization.md#transferable-ops).
+* **`Ops`** is a variable-length array of [Transferable Ops](avm-transaction-serialization.md#transferable-op).
 
 ### Gantt Unsigned Operation Tx Specification
 

--- a/build/references/command-line-interface.md
+++ b/build/references/command-line-interface.md
@@ -288,9 +288,9 @@ For example if `chain-config-dir` has the default value, then `config.json` can 
 
 For more information about C-Chain configs, see [here](command-line-interface.md#config-file).
 
-### C-Chain / Coreth <a id="config-file"></a>
+### C-Chain / Coreth <a id="coreth-config"></a>
 
-`--config-file` \(json\):
+`--coreth-config` \(json\):
 
 \(This argument is deprecated in favor of using [Chain Configs](command-line-interface.md#chain-configs).\)
 

--- a/build/references/command-line-interface.md
+++ b/build/references/command-line-interface.md
@@ -286,11 +286,11 @@ For example if `chain-config-dir` has the default value, then `config.json` can 
 }
 ```
 
-For more information about C-Chain configs, see [here](command-line-interface.md#coreth-config).
+For more information about C-Chain configs, see [here](command-line-interface.md#config-file).
 
-### C-Chain / Coreth <a id="coreth-config"></a>
+### C-Chain / Coreth <a id="config-file"></a>
 
-`--coreth-config` \(json\):
+`--config-file` \(json\):
 
 \(This argument is deprecated in favor of using [Chain Configs](command-line-interface.md#chain-configs).\)
 


### PR DESCRIPTION
## Summary
In the course of my other work, either my own development or talking to user-devs on Discord and similar, I sometimes notice minor errors and ambiguities in the documentation. This PR proposes to address these TODOs I've accumulated.
- coreth notes on config file point to a flag that doesn't exist, according to a discord user
- Fix some broken links in AVM txn serialization
- Disambiguate some language in AVM txn serialization

### Testing
Hand-tested the new URLs in browser, seems fine.

### Other notes
The coreth changes come from [feedback from a user on discord](https://discord.com/channels/578992315641626624/578992911991963648/844323627331485697), `big.wampa`. 
>"Note to the devs that the documentation here: https://docs.avax.network/build/references/command-line-interface#c-chain--coreth as well as provided by the `--help` flag seems to be inaccurate in that `--coreth-config` doesn't seem to parse, where --config-file does."
Does this mean we need to change the `--help` flag in [coreth](https://github.com/ava-labs/coreth) too?