### PR TITLE
Fix initial empty network dashboard

### DIFF
--- a/dashboards/network.json
+++ b/dashboards/network.json
@@ -2618,8 +2618,8 @@
     "list": []
   },
   "time": {
-    "from": "2021-07-29T22:45:35.398Z",
-    "to": "2021-07-29T23:24:30.770Z"
+    "from": "now-1h",
+    "to": "now"
   },
   "timepicker": {
     "refresh_intervals": [


### PR DESCRIPTION
Fix default time period to 1 hour relative  instead of fixed time period in the past to prevent an initial empty dashboard