### PR TITLE
docs: removed words caused confusion

### DIFF
--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -4,7 +4,7 @@ description: The C-Chain is an instance of the Ethereum Virtual Machine (EVM)
 
 # Contract Chain \(C-Chain\) API
 
-_Note: Ethereum has its own notion of `networkID` and `chainID`. These have no relationship to Avalanche’s view of networkID and chainID and are purely internal to the_ [_C-Chain_](../../learn/platform-overview/#contract-chain-c-chain)_. On Mainnet, the C-Chain uses `1` and `43114` for these values. On the Fuji Testnet, it uses `1` and `43113` for these values. `networkID` and `chainID` can also be obtained using the `net_version` and `eth_chainId` methods shown below._
+_Note: Ethereum has its own notion of `networkID` and `chainID`. These have no relationship to Avalanche’s view of networkID and chainID and are purely internal to the_ [_C-Chain_](../../learn/platform-overview/#contract-chain-c-chain)_. On Mainnet, the C-Chain uses `1` and `43114` for these values. On the Fuji Testnet, it uses `1` and `43113` for these values. `networkID` and `chainID` can also be obtained using the `net_version` and `eth_chainId` methods.
 
 ## Deploying a Smart Contract
 


### PR DESCRIPTION
https://avalancheavax.slack.com/archives/G01CW5QK80M/p1627944611009000

```
Emre  4:50 PM
is there a way to get the evm definition of chain ID using avlanche js ?
4:50
I can see this in our docs:
4:51
Note: Ethereum has its own notion of networkID and chainID. These have no relationship to Avalanche's view of networkID and chainID and are purely internal to the C-Chain. On Mainnet, the C-Chain uses 1 and 43114 for these values. On the Fuji Testnet, it uses 1 and 43113 for these values. networkID and chainID can also be obtained using the net_version and eth_chainId methods shown below.

Emre  4:51 PM
but there is nothing below
```