### PR TITLE
add dynamic blockchain ID notes

### DIFF
--- a/build/tutorials/platform/create-a-subnet.md
+++ b/build/tutorials/platform/create-a-subnet.md
@@ -8,6 +8,8 @@ When a subnet is created, a threshold and a set of keys are specified. \(Actuall
 
 In this tutorial, we’ll create a new subnet with 2 control keys and a threshold of 2.
 
+_Note: IDs of Blockchains, Subnets, Transactions and Addresses can be different for each run/network. It means that some inputs, endpoints etc. in the tutorial can be different when you try._
+
 ### Generate the Control Keys <a id="generate-the-control-keys"></a>
 
 First, let’s generate the 2 control keys. To do so we call [`platform.createAddress`](../../avalanchego-apis/platform-chain-p-chain-api.md#platform-createaddress) This generates a new private key and stores it for a user.

--- a/build/tutorials/platform/create-a-virtual-machine-vm.md
+++ b/build/tutorials/platform/create-a-virtual-machine-vm.md
@@ -12,6 +12,8 @@ A blockchain can run as a separate process from AvalancheGo and can communicate 
 
 Before we get to the implementation of a VM, we’ll look at the interface that a VM must implement to be compatible with AvalancheGo's consensus engine. We’ll show and explain all the code in snippets. If you want to see all the code in one place, see [this repository.](https://github.com/ava-labs/timestampvm/)
 
+_Note: IDs of Blockchains, Subnets, Transactions and Addresses can be different for each run/network. It means that some inputs, endpoints etc. in the tutorial can be different when you try._
+
 ## Interfaces
 
 ### `block.ChainVM`
@@ -689,7 +691,7 @@ type Service struct{ vm *VM }
 
 Note that this struct has a reference to the VM, so it can query and update state.
 
-This VM's API has two methods. One allows a client to get a block by its ID. The other allows a client to propose the next block of this blockchain.
+This VM's API has two methods. One allows a client to get a block by its ID. The other allows a client to propose the next block of this blockchain. The blockchain ID in the endpoint changes, since every blockchain has an unique ID. For more information, see [Interacting with the New Blockchain](./create-custom-blockchain.md#interact-with-the-new-blockchain).
 
 #### timestampvm.getBlock
 

--- a/build/tutorials/platform/create-avm-blockchain.md
+++ b/build/tutorials/platform/create-avm-blockchain.md
@@ -6,6 +6,8 @@ One of the core features of Avalanche is the ability to create new blockchains. 
 
 If you're interested in building custom blockchains, see [Create a Virtual Machine \(VM\)](create-a-virtual-machine-vm.md) and [Create a Custom Blockchain](create-a-virtual-machine-vm.md).
 
+_Note: IDs of Blockchains, Subnets, Transactions and Addresses can be different for each run/network. It means that some inputs, endpoints etc. in the tutorial can be different when you try._
+
 ### Prerequisites
 
 You will need a running node, a user on the node, and some AVAX in the address controlled by the user. All of that is covered in the [Run an Avalanche Node](../nodes-and-staking/run-avalanche-node.md) tutorial.
@@ -273,12 +275,12 @@ More information can be found in the [Adding a Subnet Validator](../nodes-and-st
 
 You can interact with this new instance of the AVM almost the same way you’d interact with the [X-Chain](../../../learn/platform-overview/#exchange-chain-x-chain). There are some small differences:
 
-* The API endpoint of your blockchain is `127.0.0.1:9650/ext/bc/xAd5n5PQFV6RRo8UgH54Gf5tJs8oQdctQS2ygp5F2dKZDckYH`. You can also alias this chain ID with `myxchain` for simpler API URLs. More information:
+* The API endpoint of your blockchain is `127.0.0.1:9650/ext/bc/xAd5n5PQFV6RRo8UgH54Gf5tJs8oQdctQS2ygp5F2dKZDckYH`. The last pasrt in the endpoint is the blockchain ID. This can be a different ID when you create your blockchain. You can also alias this chain ID with `myxchain` for simpler API URLs. More information:
 
   [admin.aliasChain](https://docs.avax.network/build/avalanchego-apis/admin-api#admin-aliaschain)
 
-* Addresses are prepended with `xAd5n5PQFV6RRo8UgH54Gf5tJs8oQdctQS2ygp5F2dKZDckYH-` rather than `X-`.
-* Fees are paid with the first asset specified in the genesis data, as noted above, rather than AVAX..
+* Addresses are prepended with custom blockchain's ID `xAd5n5PQFV6RRo8UgH54Gf5tJs8oQdctQS2ygp5F2dKZDckYH-` rather than `X-`. This can be a different ID when you create your blockchain.
+* Fees are paid with the first asset specified in the genesis data, as noted above, rather than AVAX...
 
 ### Verify Balance
 

--- a/build/tutorials/platform/create-avm-blockchain.md
+++ b/build/tutorials/platform/create-avm-blockchain.md
@@ -275,7 +275,7 @@ More information can be found in the [Adding a Subnet Validator](../nodes-and-st
 
 You can interact with this new instance of the AVM almost the same way you’d interact with the [X-Chain](../../../learn/platform-overview/#exchange-chain-x-chain). There are some small differences:
 
-* The API endpoint of your blockchain is `127.0.0.1:9650/ext/bc/xAd5n5PQFV6RRo8UgH54Gf5tJs8oQdctQS2ygp5F2dKZDckYH`. The last pasrt in the endpoint is the blockchain ID. This can be a different ID when you create your blockchain. You can also alias this chain ID with `myxchain` for simpler API URLs. More information:
+* The API endpoint of your blockchain is `127.0.0.1:9650/ext/bc/xAd5n5PQFV6RRo8UgH54Gf5tJs8oQdctQS2ygp5F2dKZDckYH`. The last part in the endpoint is the blockchain ID. This can be a different ID when you create your blockchain. You can also alias this chain ID with `myxchain` for simpler API URLs. More information:
 
   [admin.aliasChain](https://docs.avax.network/build/avalanchego-apis/admin-api#admin-aliaschain)
 

--- a/build/tutorials/platform/create-custom-blockchain.md
+++ b/build/tutorials/platform/create-custom-blockchain.md
@@ -6,6 +6,8 @@ Avalanche supports creating blockchains with virtual machines in subnets. In thi
 
 If you want a blockchain that has capabilities of X-Chain \(AVM\), see [Create AVM Blockchain](../nodes-and-staking/run-avalanche-node.md).
 
+_Note: IDs of Blockchains, Subnets, Transactions and Addresses can be different for each run/network. It means that some inputs, endpoints etc. in the tutorial can be different when you try._
+
 ### Prerequisites
 
 You will need a running node, a user on the node, and some AVAX in the address controlled by the user. All of that is covered in the [Run an Avalanche Node](../nodes-and-staking/run-avalanche-node.md) tutorial.
@@ -178,7 +180,7 @@ More information can be found in the [Adding a Subnet Validator](../nodes-and-st
 
 ## Interacting with the New Blockchain <a id="interact-with-the-new-blockchain"></a>
 
-You can interact with this new instance of the VM. The API endpoint of your blockchain is `127.0.0.1:9650/ext/bc/sw813hGSWH8pdU9uzaYy9fCtYFfY7AjDd2c9rm64SbApnvjmk`.
+You can interact with this new instance of the VM. The API endpoint of the blockchain is `127.0.0.1:9650/ext/bc/sw813hGSWH8pdU9uzaYy9fCtYFfY7AjDd2c9rm64SbApnvjmk`. The last part in the endpoint is the blockchain ID, which is `sw813hGSWH8pdU9uzaYy9fCtYFfY7AjDd2c9rm64SbApnvjmk`. Every blockchain ID is different from each other, so this is not a static ID. Your blockchain ID and the endpoint can be different.
 
 You can also alias this chain ID with `timestampbc`, or whatever you like, for simpler API URLs. More information: [admin.aliasChain](https://docs.avax.network/build/avalanchego-apis/admin-api#admin-aliaschain)
 


### PR DESCRIPTION
Explicitly warns users that IDs can be different on each different run/network.