### PR TITLE
fix old import/export avm docs

### DIFF
--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -507,7 +507,7 @@ Finalize the transfer of a non-AVAX or AVAX from the X-Chain to the C-Chain. Bef
 avax.import({
     to: string,
     sourceChain: string,
-    baseFee: int, \\ optional
+    baseFee: int, // optional
     username: string,
     password:string,
 }) -> {txID: string}

--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -517,7 +517,7 @@ avax.import({
 
 * `to` is the address the asset is sent to. This must be the same as the `to` argument in the corresponding call to the C-Chain's `export`.
 * `sourceChain` is the ID or alias of the chain the asset is being imported from. To import funds from the X-Chain, use `"X"`.
-* `baseFee` is the base fee that should be used when creating the transaction. If ommitted, a suggested fee will be used.
+* `baseFee` is the base fee that should be used when creating the transaction. If omitted, a suggested fee will be used.
 * `username` is the user that controls the address that transaction will be sent from.
 * `password` is `username`‘s password.
 

--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -263,6 +263,7 @@ avax.export({
     to: string,
     amount: int,
     assetID: string,
+    baseFee: int,
     username: string,
     password:string,
 }) -> {txID: string}
@@ -271,7 +272,9 @@ avax.export({
 * `to` is the X-Chain address the asset is sent to.
 * `amount` is the amount of the asset to send.
 * `assetID` is the ID of the asset. To export AVAX use `"AVAX"` as the `assetID`.
-* The asset is sent from addresses controlled by `username` and `password`.
+* `baseFee` is the base fee that should be used when creating the transaction. If ommitted, a suggested fee will be used.
+* `username` is the user that controls the address that transaction will be sent from.
+* `password` is `username`‘s password.
 
 #### Example Call
 
@@ -306,17 +309,15 @@ curl -X POST --data '{
 
 **DEPRECATED—instead use** [**avax.export**](contract-chain-c-chain-api.md#avax-export).
 
-Send AVAX from the C-Chain to the X-Chain. After calling this method, you must call [`avm.importAVAX`](exchange-chain-x-chain-api.md#avm-importavax) on the X-Chain to complete the transfer.
+Send AVAX from the C-Chain to the X-Chain. After calling this method, you must call [`avm.import`](exchange-chain-x-chain-api.md#avm-import) with assetID `AVAX` on the X-Chain to complete the transfer.
 
 #### Signature
 
 ```go
-avax.exportAVAX({
+avax.export({
     to: string,
     amount: int,
-    destinationChain: string,
-    from: []string, //optional
-    changeAddr: string, //optional
+    baseFee: int,
     username: string,
     password:string,
 }) -> {txID: string}
@@ -324,12 +325,11 @@ avax.exportAVAX({
 
 **Request**
 
-* `from` is the C-Chain addresses the AVAX is sent from. They should be in hex format.
-* `to` is the X-Chain address the AVAX is sent to. It should be in bech32 format.
-* `amount` is the amount of nAVAX to send.
-* `destinationChain` is the chain the AVAX is sent to. To export funds to the X-Chain, use `"X"`.
-* `changeAddr` is the C-Chain address where any change is sent to. It should be in hex format.
-* The AVAX is sent from addresses controlled by `username`
+* `to` is the X-Chain address the asset is sent to.
+* `amount` is the amount of the asset to send.
+* `baseFee` is the base fee that should be used when creating the transaction. If ommitted, a suggested fee will be used.
+* `username` is the user that controls the address that transaction will be sent from.
+* `password` is `username`‘s password.
 
 **Response**
 
@@ -346,7 +346,6 @@ curl -X POST --data '{
         "from": ["0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC"],
         "to":"X-avax1q9c6ltuxpsqz7ul8j0h0d0ha439qt70sr3x2m0",
         "amount": 500,
-        "destinationChain": "X",
         "changeAddr": "0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC",
         "username":"myUsername",
         "password":"myPassword"
@@ -500,7 +499,7 @@ This gives response:
 
 ### avax.import
 
-Finalize the transfer of a non-AVAX or AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`avm.export`](exchange-chain-x-chain-api.md#avm-export) method to initiate the transfer.
+Finalize the transfer of a non-AVAX or AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`avm.export`](exchange-chain-x-chain-api.md#avm-export) method with assetID `AVAX` to initiate the transfer.
 
 #### Signature
 
@@ -508,6 +507,7 @@ Finalize the transfer of a non-AVAX or AVAX from the X-Chain to the C-Chain. Bef
 avax.import({
     to: string,
     sourceChain: string,
+    baseFee: int, \\ optional
     username: string,
     password:string,
 }) -> {txID: string}
@@ -517,7 +517,9 @@ avax.import({
 
 * `to` is the address the asset is sent to. This must be the same as the `to` argument in the corresponding call to the C-Chain's `export`.
 * `sourceChain` is the ID or alias of the chain the asset is being imported from. To import funds from the X-Chain, use `"X"`.
-* `username` is the user that controls `to`.
+* `baseFee` is the base fee that should be used when creating the transaction. If ommitted, a suggested fee will be used.
+* `username` is the user that controls the address that transaction will be sent from.
+* `password` is `username`‘s password.
 
 **Response**
 
@@ -555,7 +557,7 @@ curl -X POST --data '{
 
 **DEPRECATED—instead use** [**avax.import**](contract-chain-c-chain-api.md#avax-import)
 
-Finalize a transfer of AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`avm.exportAVAX`](exchange-chain-x-chain-api.md#avm-exportavax) method to initiate the transfer.
+Finalize a transfer of AVAX from the X-Chain to the C-Chain. Before this method is called, you must call the X-Chain's [`avm.export`](exchange-chain-x-chain-api.md#avm-export) method with assetID `AVAX` to initiate the transfer.
 
 #### Signature
 
@@ -563,6 +565,7 @@ Finalize a transfer of AVAX from the X-Chain to the C-Chain. Before this method 
 avax.importAVAX({
     to: string,
     sourceChain: string,
+    baseFee: int, \\ optional
     username: string,
     password:string,
 }) -> {txID: string}
@@ -572,7 +575,9 @@ avax.importAVAX({
 
 * `to` is the address the AVAX is sent to. It should be in hex format.
 * `sourceChain` is the ID or alias of the chain the AVAX is being imported from. To import funds from the X-Chain, use `"X"`.
-* `username` is the user that controls `to`.
+* `baseFee` is the base fee that should be used when creating the transaction. If ommitted, a suggested fee will be used.
+* `username` is the user that controls the address that transaction will be sent from.
+* `password` is `username`‘s password.
 
 **Response**
 

--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -565,7 +565,7 @@ Finalize a transfer of AVAX from the X-Chain to the C-Chain. Before this method 
 avax.importAVAX({
     to: string,
     sourceChain: string,
-    baseFee: int, \\ optional
+    baseFee: int, // optional
     username: string,
     password:string,
 }) -> {txID: string}

--- a/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -575,7 +575,7 @@ avax.importAVAX({
 
 * `to` is the address the AVAX is sent to. It should be in hex format.
 * `sourceChain` is the ID or alias of the chain the AVAX is being imported from. To import funds from the X-Chain, use `"X"`.
-* `baseFee` is the base fee that should be used when creating the transaction. If ommitted, a suggested fee will be used.
+* `baseFee` is the base fee that should be used when creating the transaction. If omitted, a suggested fee will be used.
 * `username` is the user that controls the address that transaction will be sent from.
 * `password` is `username`‘s password.
 

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -631,23 +631,6 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
 ```
 
-```cpp
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :1,
-    "method" :"avm.export",
-    "params" :{
-        "to":"C-avax1q9c6ltuxpsqz7ul8j0h0d0ha439qt70sr3x2m0",
-        "amount": 10,
-        "assetID": "2YmsQfMaCczE4mLG1DPYUnRURNGfhjj4qrqnLRR3LmZ3GxDWPt",
-        "from":["X-avax1s65kep4smpr9cnf6uh9cuuud4ndm2z4jguj3gp"],
-        "changeAddr":"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
-        "username":"myUsername",
-        "password":"myPassword"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
 #### **Example Response**
 
 ```cpp

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -581,7 +581,7 @@ curl -X POST --data '{
 
 ### avm.export
 
-Send an asset from the X-Chain to the P-Chain or C-Chain. After calling this method, you must call [C-Chain's `avax.import`](contract-chain-c-chain-api.md#avax-import) or [P-Chain's `avax.importAVAX`](platform-chain-p-chain-api.md#avax-importAVAX) to complete the transfer.
+Send an asset from the X-Chain to the P-Chain or C-Chain. After calling this method, you must call the [C-Chain's `avax.import`](contract-chain-c-chain-api.md#avax-import) or the [P-Chain's `avax.importAVAX`](platform-chain-p-chain-api.md#avax-importAVAX) to complete the transfer.
 
 #### **Signature**
 

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -581,7 +581,7 @@ curl -X POST --data '{
 
 ### avm.export
 
-Send a non-AVAX from the X-Chain to the P-Chain or C-Chain. After calling this method, you must call [`avax.import`](contract-chain-c-chain-api.md#avax-import) on the C-Chain to complete the transfer.
+Send an asset from the X-Chain to the P-Chain or C-Chain. After calling this method, you must call [C-Chain's `avax.import`](contract-chain-c-chain-api.md#avax-import) or [P-Chain's `avax.importAVAX`](platform-chain-p-chain-api.md#avax-importAVAX) to complete the transfer.
 
 #### **Signature**
 
@@ -603,10 +603,12 @@ avm.export({
 
 * `to` is the P-Chain or C-Chain address the asset is sent to.
 * `amount` is the amount of the asset to send.
-* `assetID` is the asset id of the asset which is sent.
+* `assetID` is the asset id of the asset which is sent. Use `AVAX` for AVAX exports.
 * `from` are the addresses that you want to use for this operation. If omitted, uses any of your addresses as needed.
 * `changeAddr` is the address any change will be sent to. If omitted, change is sent to one of the addresses controlled by the user.
 * The asset is sent from addresses controlled by `username`
+* `password` is `username`‘s password.
+
 * `txID` is this transaction’s ID.
 * `changeAddr` in the result is the address where any change was sent.
 
@@ -619,7 +621,24 @@ curl -X POST --data '{
     "method" :"avm.export",
     "params" :{
         "to":"C-avax1q9c6ltuxpsqz7ul8j0h0d0ha439qt70sr3x2m0",
-        "amount": 500,
+        "amount": 10,
+        "assetID": "AVAX",
+        "from":["X-avax1s65kep4smpr9cnf6uh9cuuud4ndm2z4jguj3gp"],
+        "changeAddr":"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
+        "username":"myUsername",
+        "password":"myPassword"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
+```
+
+```cpp
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"avm.export",
+    "params" :{
+        "to":"C-avax1q9c6ltuxpsqz7ul8j0h0d0ha439qt70sr3x2m0",
+        "amount": 10,
         "assetID": "2YmsQfMaCczE4mLG1DPYUnRURNGfhjj4qrqnLRR3LmZ3GxDWPt",
         "from":["X-avax1s65kep4smpr9cnf6uh9cuuud4ndm2z4jguj3gp"],
         "changeAddr":"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
@@ -1140,7 +1159,7 @@ This gives response:
 
 ### avm.import
 
-Finalize a transfer of AVAX from the P-Chain or C-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](platform-chain-p-chain-api.md#platform-exportavax) or C-Chain’s [`avax.export`](contract-chain-c-chain-api.md#avax-export) method to initiate the transfer.
+Finalize a transfer of asset from the P-Chain or C-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](platform-chain-p-chain-api.md#platform-exportavax) or C-Chain’s [`avax.export`](contract-chain-c-chain-api.md#avax-export) method to initiate the transfer.
 
 #### **Signature**
 

--- a/build/avalanchego-apis/exchange-chain-x-chain-api.md
+++ b/build/avalanchego-apis/exchange-chain-x-chain-api.md
@@ -1159,7 +1159,7 @@ This gives response:
 
 ### avm.import
 
-Finalize a transfer of asset from the P-Chain or C-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](platform-chain-p-chain-api.md#platform-exportavax) or C-Chain’s [`avax.export`](contract-chain-c-chain-api.md#avax-export) method to initiate the transfer.
+Finalize a transfer of an asset from the P-Chain or C-Chain to the X-Chain. Before this method is called, you must call the P-Chain’s [`platform.exportAVAX`](platform-chain-p-chain-api.md#platform-exportavax) or C-Chain’s [`avax.export`](contract-chain-c-chain-api.md#avax-export) method to initiate the transfer.
 
 #### **Signature**
 

--- a/build/avalanchego-apis/platform-chain-p-chain-api.md
+++ b/build/avalanchego-apis/platform-chain-p-chain-api.md
@@ -43,7 +43,7 @@ platform.addDelegator(
         username: string,
         password: string
     }
-) -> 
+) ->
 {
     txID: string,
     changeAddr: string
@@ -125,7 +125,7 @@ platform.addValidator(
         username: string,
         password: string
     }
-) -> 
+) ->
 {
     txID: string,
     changeAddr: string
@@ -200,7 +200,7 @@ platform.addSubnetValidator(
         username: string,
         password: string
     }
-) -> 
+) ->
 {
     txID: string,
     changeAddr: string,
@@ -310,7 +310,7 @@ platform.createBlockchain(
         username: string,
         password: string
     }
-) -> 
+) ->
 {
     txID: string,
     changeAddr: string
@@ -382,7 +382,7 @@ platform.createSubnet(
         username: string,
         password: string
     }
-) -> 
+) ->
 {
     txID: string,
     changeAddr: string
@@ -430,7 +430,7 @@ curl -X POST --data '{
 
 ### platform.exportAVAX
 
-Send AVAX from an address on the P-Chain to an address on the X-Chain. After issuing this transaction, you must call the X-Chain’s [`avm.importAVAX`](exchange-chain-x-chain-api.md#avm-importavax) method to complete the transfer.
+Send AVAX from an address on the P-Chain to an address on the X-Chain. After issuing this transaction, you must call the X-Chain’s [`avm.import`](exchange-chain-x-chain-api.md#avm-import) method with assetID `AVAX` to complete the transfer.
 
 #### **Signature**
 
@@ -444,7 +444,7 @@ platform.exportAVAX(
         username: string,
         password: string
     }
-) -> 
+) ->
 {
     txID: string,
     changeAddr: string
@@ -492,7 +492,7 @@ curl -X POST --data '{
 
 ### platform.exportKey
 
-Get the private key that controls a given address.  
+Get the private key that controls a given address.
 The returned private key can be added to a user with [`platform.importKey`](platform-chain-p-chain-api.md#platform-importkey).
 
 #### **Signature**
@@ -947,7 +947,7 @@ Get the minimum amount of AVAX required to validate the Primary Network and the 
 #### **Signature**
 
 ```cpp
-platform.getMinStake() -> 
+platform.getMinStake() ->
 {
     minValidatorStake : uint64,
     minDelegatorStake : uint64
@@ -1086,7 +1086,7 @@ platform.getRewardUTXOs({
 
 * `txID` is the ID of the staking or delegating transaction
 * `numFetched` is the number of returned UTXOs
-* `utxos` is an array of encoded reward UTXOs 
+* `utxos` is an array of encoded reward UTXOs
 * `encoding` specifies the format for the returned UTXOs. Can be either "cb58" or "hex" and defaults to "cb58".
 
 #### **Example Call**
@@ -1181,8 +1181,8 @@ platform.getSubnets(
 ```
 
 * `ids` are the IDs of the subnets to get information about. If omitted, gets information about all subnets.
-* `id` is the Subnet’s ID.  
-* `threshold` signatures from addresses in `controlKeys` are needed to add a validator to the subnet.  
+* `id` is the Subnet’s ID.
+* `threshold` signatures from addresses in `controlKeys` are needed to add a validator to the subnet.
 
 See [here](../tutorials/nodes-and-staking/add-a-validator.md) for information on adding a validator to a Subnet.
 
@@ -1434,7 +1434,7 @@ platform.getUTXOs(
         sourceChain: string, //optional
         encoding: string, //optional
     },
-) -> 
+) ->
 {
     numFetched: int,
     utxos: []string,
@@ -1627,7 +1627,7 @@ curl -X POST --data '{
 
 Complete a transfer of AVAX from the X-Chain to the P-Chain.
 
-Before this method is called, you must call the X-Chain’s [`avm.exportAVAX`](exchange-chain-x-chain-api.md#avm-exportavax) method to initiate the transfer.
+Before this method is called, you must call the X-Chain’s [`avm.export`](exchange-chain-x-chain-api.md#avm-export) method with assetID `AVAX` to initiate the transfer.
 
 #### **Signature**
 
@@ -1637,22 +1637,20 @@ platform.importAVAX(
         from: []string, //optional
         to: string,
         changeAddr: string, //optional
-        sourceChain: string,
         username: string,
         password: string
     }
-) -> 
+) ->
 {
     tx: string,
     changeAddr: string
 }
 ```
 
-* `to` is the ID of the address the AVAX is imported to. This must be the same as the `to` argument in the corresponding call to the X-Chain’s `exportAVAX`.
-* `sourceChain` is the ID or alias of the chain the AVAX is being imported from. To import funds from the X-Chain, use `"X"`.
+* `to` is the ID of the address the AVAX is imported to. This must be the same as the `to` argument in the corresponding call to the X-Chain’s `export`.
 * `from` are the addresses that you want to use for this operation. If omitted, uses any of your addresses as needed.
 * `changeAddr` is the address any change will be sent to. If omitted, change is sent to one of the addresses controlled by the user.
-* `username` is the user that controls the address specified in `to`.
+* `username` is the user that controls from and change addresses.
 * `password` is `username`‘s password.
 
 #### **Example Call**
@@ -1662,7 +1660,6 @@ curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.importAVAX",
     "params": {
-        "sourceChain": "X",
         "to": "P-avax1apzq2zt0uaaatum3wdz83u4z7dv4st7l5m5n2a",
         "from": ["P-avax1gss39m5sx6jn7wlyzeqzm086yfq2l02xkvmecy"],
         "changeAddr": "P-avax103y30cxeulkjfe3kwfnpt432ylmnxux8r73r8u",

--- a/build/tutorials/platform/transfer-avax-between-x-chain-and-c-chain.md
+++ b/build/tutorials/platform/transfer-avax-between-x-chain-and-c-chain.md
@@ -113,15 +113,15 @@ Response:
 Now, import the same private key to the C-Chain:
 
 ```cpp
-curl -X POST --data '{  
-    "jsonrpc":"2.0",    
-    "id"     :1,    
-    "method" :"avax.importKey", 
-    "params" :{ 
-        "username" :"myUsername",   
-        "password":"myPassword",    
-        "privateKey":"PrivateKey-2w4XiXxPfQK4TypYqnohRL8DRNTz9cGiGmwQ1zmgEqD9c9KWLq"    
-    }   
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"avax.importKey",
+    "params" :{
+        "username" :"myUsername",
+        "password":"myPassword",
+        "privateKey":"PrivateKey-2w4XiXxPfQK4TypYqnohRL8DRNTz9cGiGmwQ1zmgEqD9c9KWLq"
+    }
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
 ```
 
@@ -141,20 +141,20 @@ Now we have everything we need to transfer the tokens.
 
 ### Transfer from the X-Chain to C-Chain
 
-Use the address corresponding to the private key you exported and switch to using the C- prefix in the [`avm.exportAVAX`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-exportavax) call:
+Use the address corresponding to the private key you exported and switch to using the C- prefix in the [`avm.export`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-export) call:
 
 ```cpp
-curl -X POST --data '{  
-    "jsonrpc":"2.0",    
-    "id"     :1,    
-    "method" :"avm.exportAVAX", 
-    "params" :{ 
-        "to":"C-avax1jggdngzc9l87rgurmfu0z0n0v4mxlqta0h3k6e",   
-        "destinationChain": "C",    
-        "amount": 5000000,  
-        "username":"myUsername",    
-        "password":"myPassword" 
-    }   
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"avm.export`",
+    "params" :{
+        "destinationChain": "C",
+        "assetID": "AVAX",
+        "amount": 5000000,
+        "username":"myUsername",
+        "password":"myPassword"
+    }
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
 ```
 
@@ -163,14 +163,14 @@ Since your keystore user owns the corresponding private key on the C-Chain, you 
 ```cpp
 curl -X POST --data '{
     "jsonrpc":"2.0",
-    "id"     :1,    
-    "method" :"avax.importAVAX",    
-    "params" :{ 
-        "to":"0x4b879aff6b3d24352Ac1985c1F45BA4c3493A398",  
-        "sourceChain":"X",  
-        "username":"myUsername",    
-        "password":"myPassword" 
-    }   
+    "id"     :1,
+    "method" :"avax.importAVAX",
+    "params" :{
+        "to":"0x4b879aff6b3d24352Ac1985c1F45BA4c3493A398",
+        "sourceChain":"X",
+        "username":"myUsername",
+        "password":"myPassword"
+    }
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
 ```
 
@@ -179,12 +179,12 @@ where `to` is a hex-encoded EVM address of your choice.
 The response looks like this:
 
 ```cpp
-{   
-    "jsonrpc": "2.0",   
-    "result": { 
-        "txID": "LWTRsiKnEUJC58y8ezAk6hhzmSMUCtemLvm3LZFw8fxDQpns3" 
-    },  
-    "id": 1 
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "txID": "LWTRsiKnEUJC58y8ezAk6hhzmSMUCtemLvm3LZFw8fxDQpns3"
+    },
+    "id": 1
 }
 ```
 
@@ -197,16 +197,16 @@ Once your AVAX has been transferred to the C-Chain, you can use it to deploy and
 Now, you can move AVAX back from the C-Chain to the X-Chain. First we need to export:
 
 ```cpp
-curl -X POST --data '{  
-    "jsonrpc":"2.0",    
-    "id"     :1,    
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
     "method" :"avax.exportAVAX",
-    "params" :{ 
-        "to":"X-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q",   
-        "amount": 5000000,  
-        "username":"myUsername",    
-        "password":"myPassword" 
-    }   
+    "params" :{
+        "to":"X-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q",
+        "amount": 5000000,
+        "username":"myUsername",
+        "password":"myPassword"
+    }
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
 ```
 
@@ -215,28 +215,28 @@ where `to` is the bech32 encoded address of an X-Chain address you hold. Make su
 The response should look like this:
 
 ```cpp
-{   
-    "jsonrpc": "2.0",   
-    "result": { 
-        "txID": "2ZDt3BNwzA8vm4CMP42pWD242VZy7TSWYUXEuBifkDh4BxbCvj"    
-    },  
-    "id": 1 
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "txID": "2ZDt3BNwzA8vm4CMP42pWD242VZy7TSWYUXEuBifkDh4BxbCvj"
+    },
+    "id": 1
 }
 ```
 
-To finish the transfer, call [`avm.importAVAX`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-importavax).
+To finish the transfer, call [`avm.import`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-import).
 
 ```cpp
-curl -X POST --data '{  
-    "jsonrpc":"2.0",    
-    "id"     :1,    
-    "method": "avm.importAVAX", 
-    "params": { 
-        "username":"myUsername",    
-        "password":"myPassword",    
-        "sourceChain": "C", 
-        "to":"X-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q"    
-    }   
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method": "avm.import",
+    "params": {
+        "username":"myUsername",
+        "password":"myPassword",
+        "sourceChain": "C",
+        "to":"X-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q"
+    }
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
 ```
 
@@ -245,12 +245,12 @@ where `to` is the bech32 encoded address the X-Chain address which you sent the 
 The response should look like this:
 
 ```cpp
-{   
-    "jsonrpc": "2.0",   
-    "result": { 
-        "txID": "2kxwWpHvZPhMsJcSTmM7a3Da7sExB8pPyF7t4cr2NSwnYqNHni"    
-    },  
-    "id": 1 
+{
+    "jsonrpc": "2.0",
+    "result": {
+        "txID": "2kxwWpHvZPhMsJcSTmM7a3Da7sExB8pPyF7t4cr2NSwnYqNHni"
+    },
+    "id": 1
 }
 ```
 

--- a/build/tutorials/platform/transfer-avax-between-x-chain-and-c-chain.md
+++ b/build/tutorials/platform/transfer-avax-between-x-chain-and-c-chain.md
@@ -149,8 +149,8 @@ curl -X POST --data '{
     "id"     :1,
     "method" :"avm.export",
     "params" :{
-        "destinationChain": "C",
         "assetID": "AVAX",
+        "to": "C-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q"
         "amount": 5000000,
         "username":"myUsername",
         "password":"myPassword"
@@ -164,7 +164,7 @@ Since your keystore user owns the corresponding private key on the C-Chain, you 
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"avax.importAVAX",
+    "method" :"avax.import",
     "params" :{
         "to":"0x4b879aff6b3d24352Ac1985c1F45BA4c3493A398",
         "sourceChain":"X",
@@ -203,6 +203,7 @@ curl -X POST --data '{
     "method" :"avax.exportAVAX",
     "params" :{
         "to":"X-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q",
+        "assetID": "AVAX",
         "amount": 5000000,
         "username":"myUsername",
         "password":"myPassword"

--- a/build/tutorials/platform/transfer-avax-between-x-chain-and-c-chain.md
+++ b/build/tutorials/platform/transfer-avax-between-x-chain-and-c-chain.md
@@ -147,7 +147,7 @@ Use the address corresponding to the private key you exported and switch to usin
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"avm.export`",
+    "method" :"avm.export",
     "params" :{
         "destinationChain": "C",
         "assetID": "AVAX",

--- a/build/tutorials/platform/transfer-avax-between-x-chain-and-p-chain.md
+++ b/build/tutorials/platform/transfer-avax-between-x-chain-and-p-chain.md
@@ -77,7 +77,7 @@ As you may have noticed while transferring AVAX using the Avalanche Wallet, a cr
 
 ### Step 1 - Export AVAX from the X-Chain
 
-To export AVAX, call the X-Chain’s [`avm.exportAVAX`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-exportavax) method.
+To export AVAX, call the X-Chain’s [`avm.export`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-export) method with `AVAX` assetID.
 
 Your call should look like this:
 
@@ -85,10 +85,11 @@ Your call should look like this:
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"avm.exportAVAX",
+    "method" :"avm.export",
     "params" :{
         "to":"P-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q",
         "destinationChain": "P",
+        "assetID": "AVAX",
         "amount": 5000000,
         "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
         "username":"myUsername",
@@ -271,13 +272,13 @@ This returns the transaction ID, and we can check that the transaction was commi
 
 ### Step 2 - Import AVAX to X-Chain
 
-To finish our transfer from the P-Chain to the X-Chain, call [`avm.importAVAX`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-importavax):
+To finish our transfer from the P-Chain to the X-Chain, call [`avm.import`](../../avalanchego-apis/exchange-chain-x-chain-api.md#avm-import):
 
 ```cpp
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"avm.importAVAX",
+    "method" :"avm.import",
     "params" :{
         "to":"X-avax1fjn5rffqvny7uk3tjegjs6snwjs3hhgcpcxfax",
         "sourceChain":"P",

--- a/build/tutorials/platform/transfer-avax-between-x-chain-and-p-chain.md
+++ b/build/tutorials/platform/transfer-avax-between-x-chain-and-p-chain.md
@@ -88,7 +88,6 @@ curl -X POST --data '{
     "method" :"avm.export",
     "params" :{
         "to":"P-avax1wkmfja9ve3lt3n9ye4qp3l3gj9k2mz7ep45j7q",
-        "destinationChain": "P",
         "assetID": "AVAX",
         "amount": 5000000,
         "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",


### PR DESCRIPTION
we removed import,export AVAX from avm recently. PR fixes some old docs mentioning these APIs. Also fixes some invalid signatures for import/export apis in general.