### PR TITLE
Update monitoring-installer.sh. Improve idempotency of script

### DIFF
--- a/scripts/monitoring-installer.sh
+++ b/scripts/monitoring-installer.sh
@@ -84,11 +84,11 @@ install_prometheus() {
   fi
   echo "Attempting to download: $promFileName"
   wget -nv --show-progress -O prometheus.tar.gz $promFileName
-  mkdir prometheus
+  mkdir -p prometheus
   tar xvf prometheus.tar.gz -C prometheus --strip-components=1
   echo "Installing..."
-  sudo useradd -M -r -s /bin/false prometheus
-  sudo mkdir /etc/prometheus /var/lib/prometheus
+  id -u prometheus &>/dev/null || sudo useradd -M -r -s /bin/false prometheus
+  sudo mkdir -p /etc/prometheus /var/lib/prometheus
   sudo apt-get install -y apt-transport-https
   cd prometheus
   sudo cp {prometheus,promtool} /usr/local/bin/


### PR DESCRIPTION
Add `-p` flag for mkdir even if 1-level directory created. This ensures script doesn't exit fail fast if directory already exists

Add check if `prometheus` user already exists. If not script won't try to create one and fail fast because it already exists