### PR TITLE
Fix staking port type

### DIFF
--- a/docs/build/references/command-line-interface.md
+++ b/docs/build/references/command-line-interface.md
@@ -234,7 +234,7 @@ Enables signature verification. When set to `false`, signatures won’t be check
 
 ## Staking
 
-`--staking-port` (string):
+`--staking-port` (int):
 
 The port through which the staking server will connect to the Avalanche network externally. Defaults to `9651`.
 


### PR DESCRIPTION
The config code uses `uint16(v.GetUint(StakingPortKey))`