### PR TITLE
Fix c chain api admin example calls

### DIFF
--- a/docs/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/docs/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -780,7 +780,7 @@ curl -X POST --data '{
     "id"     :1,
     "method" :"admin.setLogLevel",
     "params": {
-        "level":"info",
+        "level":"info"
     }
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/admin
 ```

--- a/docs/build/avalanchego-apis/contract-chain-c-chain-api.md
+++ b/docs/build/avalanchego-apis/contract-chain-c-chain-api.md
@@ -879,7 +879,7 @@ admin.memoryProfile() -> {success:bool}
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
-    "method" :"admin.setLogLevel",
+    "method" :"admin.memoryProfile",
     "params": {}
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/admin
 ```


### PR DESCRIPTION
Fixed two c-chain admin API examples.

## Testing Setup

```bash
docker run \
    -dit \
    -p 9650:9650 \
    --name avanode \
    --rm \
    avaplatform/avalanchego:v1.7.2 \
        /bin/bash -c '\
            apt update; \
            apt install -y procps screen; \
            mkdir -p "${HOME}/.avalanchego/configs/chains/C"; \
            echo -e "{\n  \"coreth-admin-api-enabled\": true\n}" > "${HOME}/.avalanchego/configs/chains/C/config.json"; \
            sleep 3; \
            screen /avalanchego/build/avalanchego \
                --http-host= \
                --log-display-highlight=plain \
                --network-id=local \
                --staking-enabled=false'
```

## admin.setLogLevel

```bash
# Before making syntax change:
$ curl -X POST --data '{
    "jsonrpc":"2.0",
    "id"     :1,
    "method" :"admin.setLogLevel",
    "params": {
        "level":"info",
    }
}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/admin
{"jsonrpc":"2.0","error":{"code":-32700,"message":"invalid character '}' looking for beginning of object key string","data":{"jsonrpc":"","method":"","params":null,"id":null}},"id":null}

# After fixing syntax (remove comma):
$ curl -X POST --data '{
    "jsonrpc":"2.0",
    "id"     :1,
    "method" :"admin.setLogLevel",
    "params": { 
        "level":"info"                                              
    }
}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/admin
{"jsonrpc":"2.0","result":{"success":true},"id":1}
```

## admin.memoryProfile

Code example simply used the wrong API endpoint (someone made cut-and-paste mistake).

```bash
# Verbatim old example doesn't even run with wrong endpoint:
$ curl -X POST --data '{
>     "jsonrpc":"2.0",
>     "id"     :1,
>     "method" :"admin.setLogLevel",
>     "params": {}
> }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/admin
{"jsonrpc":"2.0","error":{"code":-32000,"message":"failed to parse log level: unknown level:  ","data":null},"id":1}

# Correct endpoint:
$ curl -X POST --data '{
>     "jsonrpc":"2.0",
>     "id"     :1,
>     "method" :"admin.memoryProfile",
>     "params": {}
> }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/admin
{"jsonrpc":"2.0","result":{"success":true},"id":1}
```