### PR TITLE
fix dead link to token whitepaper

### DIFF
--- a/docs/learn/platform-overview/staking.md
+++ b/docs/learn/platform-overview/staking.md
@@ -12,7 +12,7 @@ To resist [sybil attacks](https://support.avalabs.org/en/articles/4064853-what-i
 
 ## Staking Parameters on Avalanche
 
-When a validator is done validating the [Primary Network](http://support.avalabs.org/en/articles/4135650-what-is-the-primary-network), it receives back the AVAX tokens it staked. It may receive a reward for helping to secure the network. A validator only receives a [validation reward](http://support.avalabs.org/en/articles/4587396-what-are-validator-staking-rewards) if it is sufficiently responsive and correct during the time it validates. Read the [Avalanche token whitepaper](https://files.avalabs.org/papers/token.pdf) to learn more about AVAX and the mechanics of staking.
+When a validator is done validating the [Primary Network](http://support.avalabs.org/en/articles/4135650-what-is-the-primary-network), it receives back the AVAX tokens it staked. It may receive a reward for helping to secure the network. A validator only receives a [validation reward](http://support.avalabs.org/en/articles/4587396-what-are-validator-staking-rewards) if it is sufficiently responsive and correct during the time it validates. Read the [Avalanche token whitepaper](https://www.avalabs.org/whitepapers) to learn more about AVAX and the mechanics of staking.
 
 :::caution
 Staking rewards are sent to your wallet address at the end of the staking term **as long as all of these parameters are met**.


### PR DESCRIPTION
Hi, 

When reading the doc i notice this link was not working. 
I m not sure if it is temporary or if the whitepapers have been moved from "https://files.avalabs.org/" to "https://www.avalabs.org/whitepapers"

I did not use the direct link to the token whitepaper "https://assets.website-files.com/5d80307810123f5ffbb34d6e/6008d7bc56430d6b8792b8d1_Avalanche%20Native%20Token%20Dynamics.pdf" because it is an external domain and looks like a randomly generated link that is probably regularly changing to avoid scraping (my guess) so i rather use the link sending to all whitepaper page.

Hope it helps other people. Charles.