### PR TITLE
Update run-avalanche-node for Go verision1.17.x

### DIFF
--- a/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
+++ b/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
@@ -48,7 +48,10 @@ Building the node from source is recommended if you're a developer looking to ex
 
 If you want to build the node from source, you're first going to need to install Go 1.16.8 or later. Follow the instructions [here](https://golang.org/doc/install).
 
-Run `go version`. **It should be 1.16.8 or above.** Run `echo $GOPATH`. **It should not be empty.**
+Run `go version`. **It should be 1.16.8 or above.** 
+Run `echo $GOPATH`. **It should not be empty.**
+
+**If your go version 1.17.x then run `export GO111MODULE=off` before downloading AvalancheGo repository.**
 
 Download the AvalancheGo repository:
 


### PR DESCRIPTION
'go get' has been deprecated for installing binaries since Go 1.17 and will be become impossible in Go 1.18. For 1.17 'export GO111MODULE=off' is enough. But with go 1.18 'go get' command need to change with 'go install' command.