### PR TITLE
Main dashboard: 2 broken links to network dashboard

### DIFF
--- a/dashboards/main.json
+++ b/dashboards/main.json
@@ -664,7 +664,7 @@
           "links": [
             {
               "title": "Networking Dashboard",
-              "url": "/d/mdn45aXzGi/avalanche-general?orgId=1&refresh=10s"
+              "url": "/d/jB1TgdZ7z/network?orgId=1&refresh=10s"
             }
           ],
           "mappings": [],
@@ -887,7 +887,7 @@
           "links": [
             {
               "title": "Networking Dashboard",
-              "url": "/d/mdn45aXzGi/avalanche-general?orgId=1&refresh=10s"
+              "url": "/d/jB1TgdZ7z/network?orgId=1&refresh=10s"
             }
           ],
           "mappings": [],


### PR DESCRIPTION
updated two broken links.
See https://github.com/neuhaus/avalanche-docs/blob/patch-2/dashboards/network.json#L3202