### PR TITLE
[build/tutorials/smart-contracts] Incorrect EIP number

### DIFF
--- a/docs/build/tutorials/smart-contracts/add-avalanche-to-metamask-programmatically.md
+++ b/docs/build/tutorials/smart-contracts/add-avalanche-to-metamask-programmatically.md
@@ -2,9 +2,9 @@
 
 Adding new networks to Metamask is not a trivial task for people that are not technically savvy, and it can be error prone. To help easier onboarding of users to your application it is useful to simplify that process as much as possible. This tutorial will show how to build a simple button in your front-end application that will automate the process of adding the Avalanche network to MetaMask.
 
-## EIP-3038 & MetaMask
+## EIP-3035 & MetaMask
 
-[EIP-3038](https://eips.ethereum.org/EIPS/eip-3085) is an [Ethereum Improvement Proposal](https://eips.ethereum.org/) that defines an RPC method for adding Ethereum-compatible chains to wallet applications.
+[EIP-3035](https://eips.ethereum.org/EIPS/eip-3085) is an [Ethereum Improvement Proposal](https://eips.ethereum.org/) that defines an RPC method for adding Ethereum-compatible chains to wallet applications.
 
 Since March 2021 Metamask has implemented that EIP as part of their Metamask [Custom Networks API](https://consensys.net/blog/metamask/connect-users-to-layer-2-networks-with-the-metamask-custom-networks-api/).
 


### PR DESCRIPTION
Instead of EIP-3038, needs to be 3035