### PR TITLE
remove errant usage of cpp markdown hint

### DIFF
--- a/docs/build/avalanchego-apis/admin.md
+++ b/docs/build/avalanchego-apis/admin.md
@@ -47,7 +47,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -93,7 +93,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -136,7 +136,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -188,7 +188,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -207,7 +207,9 @@ curl -X POST --data '{
 
 Dynamically loads any virtual machines installed on the node as plugins. See [here](../tutorials/platform/subnets/create-a-virtual-machine-vm.md/#installing-a-vm) for more information on how to install a virtual machine on a node.
 
-```cpp
+#### Signature
+
+```sh
 admin.loadVMs() -> {
     newVMs: map[string][]string
     failedVMs: map[string]string,
@@ -229,7 +231,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -267,7 +269,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -300,7 +302,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -349,7 +351,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -382,7 +384,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -414,7 +416,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,

--- a/docs/build/avalanchego-apis/auth.md
+++ b/docs/build/avalanchego-apis/auth.md
@@ -33,7 +33,7 @@ Creates a new authorization token that grants access to one or more API endpoint
 
 #### **Signature**
 
-```cpp
+```sh
 auth.newToken(
     {
         password: string,
@@ -48,7 +48,7 @@ auth.newToken(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "auth.newToken",
@@ -64,7 +64,7 @@ This call will generate an authorization token that allows access to API endpoin
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -78,7 +78,7 @@ This authorization token should be included in API calls by giving header `Autho
 
 For example, to call [`info.peers`](info.md#infopeers) with this token:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -94,7 +94,7 @@ Revoke a previously generated token. The given token will no longer grant access
 
 #### **Signature**
 
-```cpp
+```sh
 auth.revokeToken(
     {
         password: string,
@@ -108,7 +108,7 @@ auth.revokeToken(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "auth.revokeToken",
@@ -122,7 +122,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -138,7 +138,7 @@ Change this node’s authorization token password. Any authorization tokens crea
 
 #### **Signature**
 
-```cpp
+```sh
 auth.changePassword(
     {
         oldPassword: string,
@@ -152,7 +152,7 @@ auth.changePassword(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "auth.changePassword",
@@ -166,7 +166,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {

--- a/docs/build/avalanchego-apis/c-chain.md
+++ b/docs/build/avalanchego-apis/c-chain.md
@@ -19,13 +19,13 @@ _Note: Ethereum has its own notion of `networkID` and `chainID`. These have no r
 
 To interact with C-Chain via the JSON-RPC endpoint:
 
-```cpp
+```
 /ext/bc/C/rpc
 ```
 
 To interact with other instances of the EVM via the JSON-RPC endpoint:
 
-```cpp
+```
 /ext/bc/blockchainID/rpc
 ```
 
@@ -40,13 +40,13 @@ On the [public api node](../tools/public-api.md#supported-apis), it only support
 
 To interact with C-Chain via the websocket endpoint:
 
-```cpp
+```
 /ext/bc/C/ws
 ```
 
 For example, to interact with the C-Chain's Ethereum APIs via websocket on localhost you can use:
 
-```cpp
+```
 ws://127.0.0.1:9650/ext/bc/C/ws
 ```
 
@@ -54,7 +54,7 @@ Note: on localhost, use `ws://`. When using the [Public API](../tools/public-api
 
 To interact with other instances of the EVM via the websocket endpoint:
 
-```cpp
+```
 /ext/bc/blockchainID/ws
 ```
 
@@ -87,7 +87,7 @@ In addition to the standard Ethereum APIs, Avalanche offers `eth_getAssetBalance
 
 **Signature**
 
-```cpp
+```sh
 eth_getAssetBalance({
     address: string,
     blk: BlkNrOrHash,
@@ -101,7 +101,7 @@ eth_getAssetBalance({
 
 **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "eth_getAssetBalance",
@@ -116,7 +116,7 @@ curl -X POST --data '{
 
 **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "id": 1,
@@ -130,7 +130,7 @@ Get the base fee for the next block.
 
 #### **Signature**
 
-```cpp
+```sh
 eth_baseFee() -> {}
 ```
 
@@ -138,7 +138,7 @@ eth_baseFee() -> {}
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -149,7 +149,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "id": 1,
@@ -163,7 +163,7 @@ Get the priority fee needed to be included in a block.
 
 #### **Signature**
 
-```cpp
+```sh
 eth_maxPriorityFeePerGas() -> {}
 ```
 
@@ -171,7 +171,7 @@ eth_maxPriorityFeePerGas() -> {}
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -182,7 +182,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "id": 1,
@@ -198,13 +198,13 @@ For more information on dynamic fees see the [C-Chain section of the transaction
 
 To interact with the `avax` specific RPC calls on the C-Chain:
 
-```cpp
+```
 /ext/bc/C/avax
 ```
 
 To interact with other instances of the EVM AVAX endpoints:
 
-```cpp
+```
 /ext/bc/blockchainID/avax
 ```
 
@@ -238,7 +238,7 @@ avax.getAtomicTx({
 
 #### Example Call
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -252,7 +252,7 @@ curl -X POST --data '{
 
 #### Example Response
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -270,7 +270,7 @@ Export an asset from the C-Chain to the X-Chain. After calling this method, you 
 
 #### Signature
 
-```cpp
+```
 avax.export({
     to: string,
     amount: int,
@@ -290,7 +290,7 @@ avax.export({
 
 #### Example Call
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -307,7 +307,7 @@ curl -X POST --data '{
 
 #### Example Response
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -349,7 +349,7 @@ avax.export({
 
 #### Example Call
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -367,7 +367,7 @@ curl -X POST --data '{
 
 #### Example Response
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -403,7 +403,7 @@ avax.exportKey({
 
 #### Example Call
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -418,7 +418,7 @@ curl -X POST --data '{
 
 #### Example Response
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -435,7 +435,7 @@ Gets the UTXOs that reference a given address.
 
 #### **Signature**
 
-```cpp
+```sh
 avax.getUTXOs(
     {
         addresses: string,
@@ -470,7 +470,7 @@ avax.getUTXOs(
 
 Suppose we want all UTXOs that reference at least one of `C-avax1yzt57wd8me6xmy3t42lz8m5lg6yruy79m6whsf`.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -489,7 +489,7 @@ curl -X POST --data '{
 
 This gives response:
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -539,7 +539,7 @@ avax.import({
 
 #### Example Call
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -555,7 +555,7 @@ curl -X POST --data '{
 
 #### Example Response
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -597,7 +597,7 @@ avax.importAVAX({
 
 #### Example Call
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -613,7 +613,7 @@ curl -X POST --data '{
 
 #### Example Response
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -647,7 +647,7 @@ avax.importKey({
 
 #### Example Call
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -662,7 +662,7 @@ curl -X POST --data '{
 
 #### Example Response
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -678,7 +678,7 @@ Send a signed transaction to the network. `encoding` specifies the format of the
 
 #### **Signature**
 
-```cpp
+```sh
 avax.issueTx({
     tx: string,
     encoding: string, //optional
@@ -689,7 +689,7 @@ avax.issueTx({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -703,7 +703,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -719,7 +719,7 @@ Get the status of an atomic transaction sent to the network.
 
 #### **Signature**
 
-```cpp
+```sh
 avax.getAtomicTxStatus({txID: string}) -> {
   status: string,
   blockHeight: string // returned when status is Accepted
@@ -735,7 +735,7 @@ avax.getAtomicTxStatus({txID: string}) -> {
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -748,7 +748,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -798,7 +798,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -831,7 +831,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -864,7 +864,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -897,7 +897,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -930,7 +930,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,

--- a/docs/build/avalanchego-apis/deprecated-api-calls.md
+++ b/docs/build/avalanchego-apis/deprecated-api-calls.md
@@ -13,7 +13,7 @@ sidebar_position: 6
 
 In v1.0.0, the signature was:
 
-```cpp
+```
 platform.getCurrentValidators({subnetID: string}) ->
 {
     validators: []{
@@ -49,7 +49,7 @@ platform.getCurrentValidators({subnetID: string}) ->
 
 In later versions, the signature was as follows. Note that each validator contains a list of its delegators. Please see the next note for current behavior.
 
-```cpp
+```
 platform.getCurrentValidators({subnetID: string}) ->
 {
     validators: []{
@@ -97,7 +97,7 @@ platform.getCurrentValidators({subnetID: string}) ->
 
 Since v1.0.6, top level `delegators` field is removed. The signature is now:
 
-```cpp
+```
 platform.getCurrentValidators({subnetID: string}) ->
 {
     validators: []{
@@ -135,13 +135,13 @@ platform.getCurrentValidators({subnetID: string}) ->
 
 Before v1.0.4, the signature was:
 
-```cpp
+```
 platform.getTxStatus({txID: string} -> status: string
 ```
 
 v1.0.4 added an argument `includeReason`. If `false` or not provided, this method's response was the same as before. If `true`, this method's response had this new format:
 
-```cpp
+```
 {
   status: string,
   reason: string //optional

--- a/docs/build/avalanchego-apis/health.md
+++ b/docs/build/avalanchego-apis/health.md
@@ -27,7 +27,7 @@ The node runs a set of health checks every 30 seconds, including a health check 
 
 #### **Signature**
 
-```cpp
+```sh
 health.health() -> {
     checks: []{
         checkName: {
@@ -58,7 +58,7 @@ More information on these measurements can be found in the documentation for the
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -70,7 +70,7 @@ curl -X POST --data '{
 
 In this example response, the C-Chain’s health check is failing.
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {

--- a/docs/build/avalanchego-apis/info.md
+++ b/docs/build/avalanchego-apis/info.md
@@ -24,13 +24,13 @@ Given a blockchain’s alias, get its ID. (See [`admin.aliasChain`](admin.md#adm
 
 #### **Signature**
 
-```cpp
+```sh
 info.getBlockchainID({alias:string}) -> {blockchainID:string}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -43,7 +43,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -59,13 +59,13 @@ Get the ID of the network this node is participating in.
 
 #### **Signature**
 
-```cpp
+```sh
 info.getNetworkID() -> {networkID:int}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -75,7 +75,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -91,13 +91,13 @@ Get the name of the network this node is participating in.
 
 #### **Signature**
 
-```cpp
+```sh
 info.getNetworkName() -> {networkName:string}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -107,7 +107,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -123,13 +123,13 @@ Get the ID of this node.
 
 #### **Signature**
 
-```cpp
+```sh
 info.getNodeID() -> {nodeID: string}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -139,7 +139,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -161,7 +161,7 @@ info.getNodeIP() -> {ip: string}
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -171,7 +171,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -187,7 +187,7 @@ Get the version of this node.
 
 #### **Signature**
 
-```cpp
+```sh
 info.getNodeVersion() -> {
     version: string,
     databaseVersion: string,
@@ -205,7 +205,7 @@ where:
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -215,7 +215,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -236,8 +236,9 @@ curl -X POST --data '{
 ### info.getVMs
 
 Get the virtual machines installed on this node.
+#### **Signature**
 
-```cpp
+```
 info.getVMs() -> {
     vms: map[string][]string
 }
@@ -256,7 +257,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -291,7 +292,7 @@ Check whether a given chain is done bootstrapping
 
 #### **Signature**
 
-```cpp
+```sh
 info.isBootstrapped({chain: string}) -> {isBootstrapped: bool}
 ```
 
@@ -299,7 +300,7 @@ info.isBootstrapped({chain: string}) -> {isBootstrapped: bool}
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -312,7 +313,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -328,7 +329,7 @@ Get a description of peer connections.
 
 #### **Signature**
 
-```cpp
+```sh
 info.peers({
     nodeIDs: string[] // optional
 }) ->
@@ -359,7 +360,7 @@ info.peers({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -372,7 +373,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -420,7 +421,7 @@ Get the fees of the network.
 
 #### **Signature**
 
-```cpp
+```sh
 info.getTxFee() ->
 {
     creationTxFee: uint64,
@@ -433,7 +434,7 @@ info.getTxFee() ->
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -443,7 +444,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -460,7 +461,7 @@ Returns the network's observed uptime of this node.
 
 #### **Signature**
 
-```cpp
+```sh
 info.uptime() ->
 {
     rewardingStakePercentage: float64,
@@ -473,7 +474,7 @@ info.uptime() ->
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -483,7 +484,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,

--- a/docs/build/avalanchego-apis/ipc.md
+++ b/docs/build/avalanchego-apis/ipc.md
@@ -41,7 +41,7 @@ Register a blockchain so it publishes accepted vertices to a Unix domain socket.
 
 #### **Signature**
 
-```cpp
+```sh
 ipcs.publishBlockchain({blockchainID: string}) -> {consensusURL: string, decisionsURL: string}
 ```
 
@@ -51,7 +51,7 @@ ipcs.publishBlockchain({blockchainID: string}) -> {consensusURL: string, decisio
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "ipcs.publishBlockchain",
@@ -64,7 +64,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "result":{
@@ -81,7 +81,7 @@ Deregister a blockchain so that it no longer publishes to a Unix domain socket.
 
 #### **Signature**
 
-```cpp
+```sh
 ipcs.unpublishBlockchain({blockchainID: string}) -> {success: bool}
 ```
 
@@ -89,7 +89,7 @@ ipcs.unpublishBlockchain({blockchainID: string}) -> {success: bool}
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "ipcs.unpublishBlockchain",
@@ -102,7 +102,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "result":{

--- a/docs/build/avalanchego-apis/issuing-api-calls.md
+++ b/docs/build/avalanchego-apis/issuing-api-calls.md
@@ -43,7 +43,7 @@ where:
 
 To call this method, then:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :4,
@@ -65,7 +65,7 @@ That’s it!
 
 If the call is successful, the response will look like this:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -84,7 +84,7 @@ If the API method invoked returns an error then the response will have a field `
 
 Such a response would look like:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "error": {

--- a/docs/build/avalanchego-apis/keystore.md
+++ b/docs/build/avalanchego-apis/keystore.md
@@ -27,7 +27,7 @@ Create a new user with the specified username and password.
 
 #### **Signature**
 
-```cpp
+```sh
 keystore.createUser(
     {
         username:string,
@@ -41,7 +41,7 @@ keystore.createUser(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -55,7 +55,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -71,13 +71,13 @@ Delete a user.
 
 #### **Signature**
 
-```cpp
+```sh
 keystore.deleteUser({username: string, password:string}) -> {success: bool}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -91,7 +91,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -105,7 +105,7 @@ Export a user. The user can be imported to another node with [`keystore.importUs
 
 #### **Signature**
 
-```cpp
+```sh
 keystore.exportUser(
     {
         username:string,
@@ -122,7 +122,7 @@ keystore.exportUser(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -136,7 +136,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -153,7 +153,7 @@ Import a user. `password` must match the user’s password. `username` doesn’t
 
 #### **Signature**
 
-```cpp
+```sh
 keystore.importUser(
     {
         username:string,
@@ -168,7 +168,7 @@ keystore.importUser(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -183,7 +183,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -199,13 +199,13 @@ List the users in this keystore.
 
 #### **Signature**
 
-```cpp
+```sh
 keystore.ListUsers() -> {users:[]string}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -215,7 +215,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,

--- a/docs/build/avalanchego-apis/metrics.md
+++ b/docs/build/avalanchego-apis/metrics.md
@@ -16,7 +16,7 @@ The API allows clients to get statistics about a node’s health and performance
 
 To get the node metrics:
 
-```cpp
+```sh
 curl -X POST 127.0.0.1:9650/ext/metrics
 ```
 

--- a/docs/build/avalanchego-apis/p-chain.md
+++ b/docs/build/avalanchego-apis/p-chain.md
@@ -8,7 +8,7 @@ This API allows clients to interact with the [P-Chain](../../learn/platform-over
 
 ## Endpoint
 
-```cpp
+```
 /ext/P
 ```
 
@@ -38,7 +38,7 @@ Note that once you issue the transaction to add a node as a delegator, there is 
 
 #### **Signature**
 
-```cpp
+```sh
 platform.addDelegator(
     {
         nodeID: string,
@@ -71,7 +71,7 @@ platform.addDelegator(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.addDelegator",
@@ -92,7 +92,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -123,7 +123,7 @@ Note that once you issue the transaction to add a node as a validator, there is 
 
 #### **Signature**
 
-```cpp
+```sh
 platform.addValidator(
     {
         nodeID: string,
@@ -160,7 +160,7 @@ platform.addValidator(
 
 In this example, we use shell command `date` to compute Unix times 10 minutes and 2 days in the future. (Note: If you’re on a Mac, replace `$(date` with `$(gdate`. If you don’t have `gdate` installed, do `brew install coreutils`.)
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.addValidator",
@@ -182,7 +182,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -199,7 +199,7 @@ Add a validator to a subnet other than the Primary Network. The Validator must v
 
 #### **Signature**
 
-```cpp
+```sh
 platform.addSubnetValidator(
     {
         nodeID: string,
@@ -230,9 +230,9 @@ platform.addSubnetValidator(
 * `password` is `username`‘s password.
 * `txID` is the transaction ID.
 
-#### **Example call**
+#### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.addSubnetvalidator",
@@ -251,9 +251,9 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/P
 ```
 
-#### **Example response**
+#### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -270,7 +270,7 @@ Create a new address controlled by the given user.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.createAddress({
     username: string,
     password: string
@@ -279,7 +279,7 @@ platform.createAddress({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createAddress",
@@ -293,7 +293,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -309,7 +309,7 @@ Create a new blockchain. Currently only supports the creation of new instances o
 
 #### **Signature**
 
-```cpp
+```sh
 platform.createBlockchain(
     {
         subnetID: string,
@@ -344,7 +344,7 @@ platform.createBlockchain(
 
 In this example we’re creating a new instance of the Timestamp Virtual Machine. `genesisData` came from calling `timestamp.buildGenesis`.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createBlockchain",
@@ -365,7 +365,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -384,7 +384,7 @@ The subnet’s ID is the same as this transaction’s ID.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.createSubnet(
     {
         controlKeys: []string,
@@ -409,7 +409,7 @@ platform.createSubnet(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createSubnet",
@@ -430,7 +430,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -446,7 +446,7 @@ Send AVAX from an address on the P-Chain to an address on the X-Chain. After iss
 
 #### **Signature**
 
-```cpp
+```sh
 platform.exportAVAX(
     {
         amount: int,
@@ -473,7 +473,7 @@ platform.exportAVAX(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.exportAVAX",
@@ -491,7 +491,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -509,7 +509,7 @@ The returned private key can be added to a user with [`platform.importKey`](p-ch
 
 #### **Signature**
 
-```cpp
+```sh
 platform.exportKey({
     username: string,
     password: string,
@@ -523,7 +523,7 @@ platform.exportKey({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -538,7 +538,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -554,7 +554,7 @@ Get the balance of AVAX controlled by a given address.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getBalance({
     address:string
 }) -> {
@@ -578,7 +578,7 @@ platform.getBalance({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
   "jsonrpc":"2.0",
   "id"     : 1,
@@ -591,7 +591,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -620,7 +620,7 @@ Get a block by its ID.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getBlock({
     blockID: string
     encoding: string // optional
@@ -644,7 +644,7 @@ platform.getBlock({
 
 ##### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getBlock",
@@ -658,7 +658,7 @@ curl -X POST --data '{
 
 ##### **Example Response**
 
-```cpp
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -673,7 +673,7 @@ curl -X POST --data '{
 
 ##### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getBlock",
@@ -687,7 +687,7 @@ curl -X POST --data '{
 
 ##### **Example Response**
 
-```cpp
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -702,7 +702,7 @@ curl -X POST --data '{
 
 ##### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getBlock",
@@ -715,7 +715,7 @@ curl -X POST --data '{
 ```
 ##### **Example Response**
 
-```cpp
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -783,7 +783,7 @@ Get all the blockchains that exist (excluding the P-Chain).
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getBlockchains() ->
 {
     blockchains: []{
@@ -803,7 +803,7 @@ platform.getBlockchains() ->
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getBlockchains",
@@ -814,7 +814,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -873,7 +873,7 @@ Get the status of a blockchain.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getBlockchainStatus(
     {
         blockchainID: string
@@ -891,7 +891,7 @@ platform.getBlockchainStatus(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getBlockchainStatus",
@@ -904,7 +904,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -920,7 +920,7 @@ Returns an upper bound on the number of AVAX that exist. This is an upper bound 
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getCurrentSupply() -> {supply: int}
 ```
 
@@ -928,7 +928,7 @@ platform.getCurrentSupply() -> {supply: int}
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getCurrentSupply",
@@ -939,7 +939,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -959,7 +959,7 @@ The top level field `delegators` was [deprecated](deprecated-api-calls.md#getcur
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getCurrentValidators({
     subnetID: string, //optional
     nodeIDs: string[], //optional
@@ -1023,7 +1023,7 @@ platform.getCurrentValidators({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getCurrentValidators",
@@ -1034,7 +1034,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1086,7 +1086,7 @@ Returns the height of the last accepted block.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getHeight() ->
 {
     height: int,
@@ -1095,7 +1095,7 @@ platform.getHeight() ->
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getHeight",
@@ -1106,7 +1106,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1122,7 +1122,7 @@ Returns the maximum amount of nAVAX staking to the named node during a particula
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getMaxStakeAmount(
     {
         subnetID: string,
@@ -1143,7 +1143,7 @@ platform.getMaxStakeAmount(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getMaxStakeAmount",
@@ -1159,7 +1159,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1175,7 +1175,7 @@ Get the minimum amount of AVAX required to validate the Primary Network and the 
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getMinStake() -> 
 {
     minValidatorStake : uint64,
@@ -1185,7 +1185,7 @@ platform.getMinStake() ->
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1195,7 +1195,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1212,7 +1212,7 @@ List the validators in the pending validator set of the specified Subnet. Each v
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getPendingValidators({
     subnetID: string, //optional
     nodeIDs: string[], //optional
@@ -1256,7 +1256,7 @@ platform.getPendingValidators({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getPendingValidators",
@@ -1267,7 +1267,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1302,7 +1302,7 @@ Returns the UTXOs that were rewarded after the provided transaction's staking or
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getRewardUTXOs({
     txID: string,
     encoding: string //optional
@@ -1320,7 +1320,7 @@ platform.getRewardUTXOs({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getRewardUTXOs",
@@ -1333,7 +1333,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1354,7 +1354,7 @@ Retrieve an assetID for a subnet’s staking asset. Currently, this only returns
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getStakingAssetID({
     subnetID: string //optional
 }) -> {
@@ -1367,7 +1367,7 @@ platform.getStakingAssetID({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getStakingAssetID",
@@ -1380,7 +1380,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1396,7 +1396,7 @@ Get info about the Subnets.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getSubnets(
     {ids: []string}
 ) ->
@@ -1417,7 +1417,7 @@ See [here](../tutorials/nodes-and-staking/add-a-validator.md) for information on
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getSubnets",
@@ -1428,7 +1428,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1453,13 +1453,13 @@ Get the amount of nAVAX staked by a set of addresses. The amount returned does n
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getStake({addresses: []string}) -> {staked: int}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getStake",
@@ -1476,7 +1476,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1492,13 +1492,13 @@ Get the current P-Chain timestamp.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getTimestamp() -> {time: string}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getTimestamp",
@@ -1526,13 +1526,13 @@ Get the total amount of nAVAX staked on the Primary Network.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getTotalStake() -> {stake: int}
 ```
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getTotalStake",
@@ -1544,7 +1544,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1562,7 +1562,7 @@ Optional `encoding` parameter to specify the format for the returned transaction
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getTx({
     txID: string,
     encoding: string //optional
@@ -1576,7 +1576,7 @@ platform.getTx({
 
 ##### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getTx",
@@ -1605,7 +1605,7 @@ curl -X POST --data '{
 
 ##### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getTx",
@@ -1684,7 +1684,7 @@ See [here](deprecated-api-calls.md#gettxstatus) for notes on previous behavior.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getTxStatus({
     txID: string
 }) -> {status: string}
@@ -1699,7 +1699,7 @@ platform.getTxStatus({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getTxStatus",
@@ -1712,7 +1712,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1728,7 +1728,7 @@ Gets the UTXOs that reference a given set of addresses.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getUTXOs(
     {
         addresses: []string,
@@ -1764,7 +1764,7 @@ platform.getUTXOs(
 
 Suppose we want all UTXOs that reference at least one of `P-avax1s994jad0rtwvlfpkpyg2yau9nxt60qqfv023qx` and `P-avax1fquvrjkj7ma5srtayfvx7kncu7um3ym73ztydr`.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1779,7 +1779,7 @@ curl -X POST --data '{
 
 This gives response:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1803,7 +1803,7 @@ This gives response:
 
 Since `numFetched` is the same as `limit`, we can tell that there may be more UTXOs that were not fetched. We call the method again, this time with `startIndex`:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1822,7 +1822,7 @@ curl -X POST --data '{
 
 This gives response:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1847,7 +1847,7 @@ Since `numFetched` is less than `limit`, we know that we are done fetching UTXOs
 
 Suppose we want to fetch the UTXOs exported from the X Chain to the P Chain in order to build an ImportTx. Then we need to call GetUTXOs with the sourceChain argument in order to retrieve the atomic UTXOs:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1862,7 +1862,7 @@ curl -X POST --data '{
 
 This gives response:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1886,7 +1886,7 @@ Get the validators and their weights of a subnet or the Primary Network at a giv
 
 #### **Signature**
 
-```cpp
+```sh
 platform.getValidatorsAt(
     {
         height: int,
@@ -1913,7 +1913,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1937,7 +1937,7 @@ Before this method is called, you must call the X-Chain’s [`avm.export`](x-cha
 
 #### **Signature**
 
-```cpp
+```sh
 platform.importAVAX(
     {
         from: []string, //optional
@@ -1961,7 +1961,7 @@ platform.importAVAX(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.importAVAX",
@@ -1978,7 +1978,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1995,7 +1995,7 @@ Give a user control over an address by providing the private key that controls t
 
 #### **Signature**
 
-```cpp
+```sh
 platform.importKey({
     username: string,
     password: string,
@@ -2007,7 +2007,7 @@ platform.importKey({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -2022,7 +2022,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id": 1,
@@ -2038,7 +2038,7 @@ Issue a transaction to the Platform Chain.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.issueTx({
     tx: string,
     encoding: string, //optional
@@ -2051,7 +2051,7 @@ platform.issueTx({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.issueTx",
@@ -2065,7 +2065,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -2081,7 +2081,7 @@ List addresses controlled by the given user.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.listAddresses({
     username: string,
     password: string
@@ -2090,7 +2090,7 @@ platform.listAddresses({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.listAddresses",
@@ -2104,7 +2104,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -2120,7 +2120,7 @@ Sample validators from the specified Subnet.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.sampleValidators(
     {
         size: int,
@@ -2138,7 +2138,7 @@ platform.sampleValidators(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -2151,7 +2151,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "id": 1,
@@ -2170,7 +2170,7 @@ Get the Subnet that validates a given blockchain.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.validatedBy(
     {
         blockchainID: string
@@ -2183,7 +2183,7 @@ platform.validatedBy(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.validatedBy",
@@ -2196,7 +2196,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -2212,7 +2212,7 @@ Get the IDs of the blockchains a Subnet validates.
 
 #### **Signature**
 
-```cpp
+```sh
 platform.validates(
     {
         subnetID: string
@@ -2225,7 +2225,7 @@ platform.validates(
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.validates",
@@ -2238,7 +2238,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {

--- a/docs/build/avalanchego-apis/x-chain.mdx
+++ b/docs/build/avalanchego-apis/x-chain.mdx
@@ -34,7 +34,7 @@ Note: addresses should not include a chain prefix (ie. X-) in calls to the stati
 
 #### **Signature**
 
-```cpp
+```sh
 avm.buildGenesis({
     networkID: int,
     genesisData: JSON,
@@ -49,7 +49,7 @@ Encoding specifies the encoding format to use for arbitrary bytes ie. the genesi
 
 `genesisData` has this form:
 
-```cpp
+```json
 {
 "genesisData" :
     {
@@ -101,7 +101,7 @@ Encoding specifies the encoding format to use for arbitrary bytes ie. the genesi
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "id"     : 1,
@@ -164,7 +164,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -181,7 +181,7 @@ Create a new address controlled by the given user.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.createAddress({
     username: string,
     password: string
@@ -190,7 +190,7 @@ avm.createAddress({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "avm.createAddress",
@@ -204,7 +204,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -220,7 +220,7 @@ Create a new fixed-cap, fungible asset. A quantity of it is created at initializ
 
 #### **Signature**
 
-```cpp
+```sh
 avm.createFixedCapAsset({
     name: string,
     symbol: string,
@@ -251,7 +251,7 @@ avm.createFixedCapAsset({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -279,7 +279,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -296,7 +296,7 @@ Mint units of a variable-cap asset created with [`avm.createVariableCapAsset`](x
 
 #### **Signature**
 
-```cpp
+```sh
 avm.mint({
     amount: int,
     assetID: string,
@@ -321,7 +321,7 @@ avm.mint({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -340,7 +340,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -357,7 +357,7 @@ Create a new variable-cap, fungible asset. No units of the asset exist at initia
 
 #### **Signature**
 
-```cpp
+```sh
 avm.createVariableCapAsset({
     name: string,
     symbol: string,
@@ -389,7 +389,7 @@ avm.createVariableCapAsset({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -423,7 +423,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -440,7 +440,7 @@ Create a new non-fungible asset. No units of the asset exist at initialization. 
 
 #### **Signature**
 
-```cpp
+```sh
 avm.createNFTAsset({
     name: string,
     symbol: string,
@@ -470,7 +470,7 @@ avm.createNFTAsset({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -496,7 +496,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -513,7 +513,7 @@ Mint non-fungible tokens which were created with [`avm.createNFTAsset`](x-chain.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.mintNFT({
     assetID: string,
     payload: string,
@@ -541,7 +541,7 @@ avm.mintNFT({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -560,7 +560,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -579,7 +579,7 @@ you must call the [C-Chain's `avax.import`](c-chain.md#avaximport) or the
 
 #### **Signature**
 
-```cpp
+```sh
 avm.export({
     to: string,
     amount: int,
@@ -608,7 +608,7 @@ avm.export({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -627,7 +627,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -645,7 +645,7 @@ The returned private key can be added to a user with [`avm.importKey`](x-chain.m
 
 #### **Signature**
 
-```cpp
+```sh
 avm.exportKey({
     username: string,
     password: string,
@@ -658,7 +658,7 @@ avm.exportKey({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -673,7 +673,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -689,7 +689,7 @@ Get the balances of all assets controlled by a given address.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.getAllBalances({address:string}) -> {
     balances: []{
         asset: string,
@@ -700,7 +700,7 @@ avm.getAllBalances({address:string}) -> {
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -713,7 +713,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -738,7 +738,7 @@ Get information about an asset.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.getAssetDescription({assetID: string}) -> {
     assetId: string,
     name: string,
@@ -754,7 +754,7 @@ avm.getAssetDescription({assetID: string}) -> {
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -767,7 +767,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -786,7 +786,7 @@ Get the balance of an asset controlled by a given address.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.getBalance({
     address: string,
     assetID: string
@@ -798,7 +798,7 @@ avm.getBalance({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
   "jsonrpc":"2.0",
   "id"     : 1,
@@ -812,7 +812,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -839,7 +839,7 @@ Note: Indexing (`index-transactions`) must be enabled in the X-chain config.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.getAddressTxs({
     address: string,
     cursor: uint64,     // optional, leave empty to get the first page
@@ -864,7 +864,7 @@ avm.getAddressTxs({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
   "jsonrpc":"2.0",
   "id"     : 1,
@@ -879,7 +879,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -898,7 +898,7 @@ Returns the specified transaction. The `encoding` parameter sets the format of t
 
 #### **Signature**
 
-```cpp
+```sh
 avm.getTx({
     txID: string,
     encoding: string, //optional
@@ -910,7 +910,7 @@ avm.getTx({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1024,7 +1024,7 @@ Get the status of a transaction sent to the network.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.getTxStatus({txID: string}) -> {status: string}
 ```
 
@@ -1037,7 +1037,7 @@ avm.getTxStatus({txID: string}) -> {status: string}
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1050,7 +1050,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1066,7 +1066,7 @@ Gets the UTXOs that reference a given address. If sourceChain is specified, then
 
 #### **Signature**
 
-```cpp
+```sh
 avm.getUTXOs({
     addresses: []string,
     limit: int, //optional
@@ -1100,7 +1100,7 @@ avm.getUTXOs({
 
 Suppose we want all UTXOs that reference at least one of `X-avax1yzt57wd8me6xmy3t42lz8m5lg6yruy79m6whsf` and `X-avax1x459sj0ssujguq723cljfty4jlae28evjzt7xz`.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1115,7 +1115,7 @@ curl -X POST --data '{
 
 This gives response:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1139,7 +1139,7 @@ This gives response:
 
 Since `numFetched` is the same as `limit`, we can tell that there may be more UTXOs that were not fetched. We call the method again, this time with `startIndex`:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :2,
@@ -1158,7 +1158,7 @@ curl -X POST --data '{
 
 This gives response:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1183,7 +1183,7 @@ Since `numFetched` is less than `limit`, we know that we are done fetching UTXOs
 
 Suppose we want to fetch the UTXOs exported from the P Chain to the X Chain in order to build an ImportTx. Then we need to call GetUTXOs with the sourceChain argument in order to retrieve the atomic UTXOs:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1199,7 +1199,7 @@ curl -X POST --data '{
 
 This gives response:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1223,7 +1223,7 @@ Finalize a transfer of an asset from the P-Chain or C-Chain to the X-Chain. Befo
 
 #### **Signature**
 
-```cpp
+```sh
 avm.import({
     to: string,
     sourceChain: string,
@@ -1239,7 +1239,7 @@ avm.import({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1255,7 +1255,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1271,7 +1271,7 @@ Give a user control over an address by providing the private key that controls t
 
 #### **Signature**
 
-```cpp
+```sh
 avm.importKey({
     username: string,
     password: string,
@@ -1283,7 +1283,7 @@ avm.importKey({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1298,7 +1298,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1314,7 +1314,7 @@ Send a signed transaction to the network. `encoding` specifies the format of the
 
 #### **Signature**
 
-```cpp
+```sh
 avm.issueTx({
     tx: string,
     encoding: string, //optional
@@ -1325,7 +1325,7 @@ avm.issueTx({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -1339,7 +1339,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1355,7 +1355,7 @@ List addresses controlled by the given user.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.listAddresses({
     username: string,
     password: string
@@ -1364,7 +1364,7 @@ avm.listAddresses({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "avm.listAddresses",
@@ -1378,7 +1378,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1394,7 +1394,7 @@ Send a quantity of an asset to an address.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.send({
     amount: int,
     assetID: string,
@@ -1416,7 +1416,7 @@ avm.send({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1436,7 +1436,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1453,7 +1453,7 @@ Sends multiple transfers of `amount` of `assetID`, to a specified address from a
 
 #### **Signature**
 
-```cpp
+```sh
 avm.sendMultiple({
     outputs: []{
       assetID: string,
@@ -1476,7 +1476,7 @@ avm.sendMultiple({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1505,7 +1505,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1522,7 +1522,7 @@ Send a non-fungible token.
 
 #### **Signature**
 
-```cpp
+```sh
 avm.sendNFT({
     assetID: string,
     groupID: number,
@@ -1542,7 +1542,7 @@ avm.sendNFT({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1561,7 +1561,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -1582,7 +1582,7 @@ This call is made to the wallet API endpoint:
 
 #### Signature
 
-```cpp
+```
 wallet.issueTx({
     tx: string,
     encoding: string, //optional
@@ -1593,7 +1593,7 @@ wallet.issueTx({
 
 #### Example call
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -1607,7 +1607,7 @@ curl -X POST --data '{
 
 #### Example response
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1627,7 +1627,7 @@ This call is made to the wallet API endpoint:
 
 #### **Signature**
 
-```cpp
+```sh
 wallet.send({
     amount: int,
     assetID: string,
@@ -1649,7 +1649,7 @@ wallet.send({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1669,7 +1669,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1690,7 +1690,7 @@ This call is made to the wallet API endpoint:
 
 #### **Signature**
 
-```cpp
+```sh
 wallet.sendMultiple({
     outputs: []{
       assetID: string,
@@ -1713,7 +1713,7 @@ wallet.sendMultiple({
 
 #### **Example Call**
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1742,7 +1742,7 @@ curl -X POST --data '{
 
 #### **Example Response**
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -1858,7 +1858,7 @@ Calling **NewSet** or **NewBloom** resets the filter, and must be followed with 
 
 #### **Example Response**
 
-```cpp
+```json
 2021/05/11 15:59:35 {"txID":"22HWKHrREyXyAiDnVmGp3TQQ79tHSSVxA9h26VfDEzoxvwveyk"}
 ```
 

--- a/docs/build/references/avalanchego-config-flags.md
+++ b/docs/build/references/avalanchego-config-flags.md
@@ -15,7 +15,7 @@ Path to a JSON file that specifies this node's configuration. Command line argum
 
 Example JSON config file:
 
-```javascript
+```json
 {
     "log-level": "debug"
 }
@@ -1205,7 +1205,7 @@ The consensus parameters of a subnet default to the same values used for the Pri
 
 Path to JSON file that defines aliases for Virtual Machine IDs. Defaults to `~/.avalanchego/configs/vms/aliases.json`. This flag is ignored if `--vm-aliases-file-content` is specified. Example content:
 
-```javascript
+```json
 {
   "tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH": [
     "timestampvm",

--- a/docs/build/tools/ortelius.md
+++ b/docs/build/tools/ortelius.md
@@ -59,7 +59,7 @@ curl "http://localhost:8080/v2"
 
 **Example Response**
 
-```javascript
+```json
 {
   "network_id": 1,
   "chains": {
@@ -99,7 +99,7 @@ curl "http://localhost:8080/v2/search?query=2jEugPDFN89KXLEXtf5"
 
 **Example Response**
 
-```javascript
+```json
 {
   "count": 1,
   "results": [
@@ -190,7 +190,7 @@ curl "http://localhost:8080/v2/aggregates?startTime=2020-09-21T00:00:00Z&endTime
 
 **Example Response**
 
-```javascript
+```json
 {
   "startTime": "2020-09-21T00:00:00Z",
   "endTime": "2020-10-21T00:00:00Z",
@@ -218,7 +218,7 @@ curl "http://localhost:8080/v2/txfeeAggregates?startTime=2020-09-21T00:00:00Z&en
 
 **Example Response**
 
-```javascript
+```json
 {
   "aggregates": {
     "startTime": "2020-09-21T00:00:00Z",
@@ -248,7 +248,7 @@ curl "http://localhost:8080/v2/addressChains?address=X-fujiABC"
 
 **Example Response**
 
-```javascript
+```json
 {
   "addressChains": {
     "avax14q43wu6wp8fs745dt6y5s0a02vx57ypq4xc5s3": [
@@ -283,7 +283,7 @@ curl "http://localhost:8080/v2/transactions?chainID=1111111111111111111111111111
 
 **Example Response**
 
-```javascript
+```json
 {
   "startTime": "0001-01-01T00:00:00Z",
   "endTime": "2020-11-16T04:18:07Z",
@@ -363,7 +363,7 @@ curl "http://localhost:8080/v2/transactions/2jEugPDFN89KXLEXtf5oKp5spsJawTht2zP4
 
 **Example Response**
 
-```javascript
+```json
 {
   "id": "2jEugPDFN89KXLEXtf5oKp5spsJawTht2zP4kKJjkQwwRsDdLX",
   "chainID": "11111111111111111111111111111111LpoYY",
@@ -444,7 +444,7 @@ curl "http://localhost:8080/v2/addresses?address=X-avax1y8cyrzn2kg4udccs5d625gka
 
 **Example Response**
 
-```javascript
+```json
 {
   "addresses": [
     {
@@ -477,7 +477,7 @@ curl "http://localhost:8080/v2/addresses/avax1y8cyrzn2kg4udccs5d625gkac7a99pe452
 
 **Example Response**
 
-```javascript
+```json
 {
   "address": "avax1y8cyrzn2kg4udccs5d625gkac7a99pe452cy5u",
   "publicKey": null,
@@ -506,7 +506,7 @@ curl "http://localhost:8080/v2/assets"
 
 **Example Response**
 
-```javascript
+```json
 {
   "assets": [
     {
@@ -537,7 +537,7 @@ curl "http://localhost:8080/v2/assets/FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDND
 
 **Example Response**
 
-```javascript
+```json
 {
   "id": "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z",
   "chainID": "2oYMBNV4eNHyqk2fjjV5nVQLDbtmNJzq5s3qs3Lo6ftnC6FByM",
@@ -572,7 +572,7 @@ curl "http://localhost:8080/v2/outputs?address=X-avax1y8cyrzn2kg4udccs5d625gkac7
 
 **Example Response**
 
-```javascript
+```json
 {
   "outputs": [
     {
@@ -606,7 +606,7 @@ curl "http://localhost:8080/v2/outputs/114RMPhYM7do7cDX7KWSqFeLkbUXFrLKcqPL4GMdj
 
 **Example Response**
 
-```javascript
+```json
 {
   "id": "114RMPhYM7do7cDX7KWSqFeLkbUXFrLKcqPL4GMdjTvemPzvc",
   "transactionID": "dhU8aMRrtMWvBWSh41aTxUbwArYootNUBcL3N3UJXVPL8H9ip",
@@ -636,7 +636,7 @@ curl "http://localhost:8080/v2/ctxdata/10"
 
 **Example Response**
 
-```javascript
+```json
 {
     "blockNumber": "10",
     "header": {
@@ -719,7 +719,7 @@ curl "http://localhost:8080/v2/ctransactions?toAddress=0x34ec164fd085ae43906eab6
 
 **Example Response**
 
-```javascript
+```json
 {
     "Transactions": [
         {
@@ -770,7 +770,7 @@ curl "http://localhost:8080/v2/rawtransaction/pxiBJkwnaKhaJdYkkfAVRZXrJj47jJF3QA
 
 **Example Response**
 
-```javascript
+```json
 {
     "tx": "0x00000000000000000001ed5f38341..."
 }
@@ -788,7 +788,7 @@ curl "http://localhost:8080/x"
 
 **Example Response**
 
-```javascript
+```json
 {
   "networkID": 1,
   "vm": "avm",

--- a/docs/build/tutorials/nodes-and-staking/add-a-validator.md
+++ b/docs/build/tutorials/nodes-and-staking/add-a-validator.md
@@ -28,7 +28,7 @@ Get your node’s ID by calling [`info.getNodeID`](../../avalanchego-apis/info.m
 
 ![getNodeID postman](/img/getNodeID-postman.png)
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -38,7 +38,7 @@ curl -X POST --data '{
 
 The response has your node’s ID:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -80,7 +80,7 @@ We can also add a node to the validator set by making API calls to our node. To 
 
 This method’s signature is:
 
-```cpp
+```
 platform.addValidator(
     {
         nodeID: string,
@@ -102,7 +102,7 @@ Let’s go through and examine these arguments.
 
 This is the node ID of the validator being added. To get your node’s ID, call [`info.getNodeID`](../../avalanchego-apis/info.md#infogetnodeid):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "info.getNodeID",
@@ -113,7 +113,7 @@ curl -X POST --data '{
 
 The response has your node’s ID:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -151,7 +151,7 @@ These parameters are the username and password of the user that pays the transac
 
 Now let’s issue the transaction. We use the shell command `date` to compute the Unix time 10 minutes and 30 days in the future to use as the values of `startTime` and `endTime`, respectively. (Note: If you’re on a Mac, replace `$(date` with `$(gdate`. If you don’t have `gdate` installed, do `brew install coreutils`.) In this example we stake 2,000 AVAX (2 x 1012 nAVAX).
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.addValidator",
@@ -172,7 +172,7 @@ curl -X POST --data '{
 
 The response has the transaction ID, as well as the address the change went to.
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -185,7 +185,7 @@ The response has the transaction ID, as well as the address the change went to.
 
 We can check the transaction’s status by calling [`platform.getTxStatus`](../../avalanchego-apis/p-chain.md#platformgettxstatus):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getTxStatus",
@@ -198,7 +198,7 @@ curl -X POST --data '{
 
 The status should be `Committed`, meaning the transaction was successful. We can call [`platform.getPendingValidators`](../../avalanchego-apis/p-chain.md#platformgetpendingvalidators) and see that the node is now in the pending validator set for the Primary Network:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getPendingValidators",
@@ -209,7 +209,7 @@ curl -X POST --data '{
 
 The response should include the node we just added:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {

--- a/docs/build/tutorials/nodes-and-staking/set-up-node-with-installer.md
+++ b/docs/build/tutorials/nodes-and-staking/set-up-node-with-installer.md
@@ -243,7 +243,7 @@ Done!
 
 File that configures node operation is `~/.avalanchego/configs/node.json`. You can edit it to add or change configuration options. The documentation of configuration options can be found [here](../../references/avalanchego-config-flags.md). Default configuration may look like this:
 
-```javascript
+```json
 {
   "dynamic-public-ip": "opendns",
   "http-host": ""

--- a/docs/build/tutorials/nodes-and-staking/setting-up-node-monitoring.md
+++ b/docs/build/tutorials/nodes-and-staking/setting-up-node-monitoring.md
@@ -191,7 +191,7 @@ Make sure that all of them have `State` as `UP`.
 
 :::info
 If you run your AvalancheGo node with TLS enabled on your API port, you will need to manually edit the `/etc/prometheus/prometheus.yml` file and change the `avalanchego` job to look like this:
-```cpp
+```yaml
   - job_name: 'avalanchego'
     metrics_path: '/ext/metrics'
     scheme: 'https'

--- a/docs/build/tutorials/nodes-and-staking/upgrade-your-avalanchego-node.mdx
+++ b/docs/build/tutorials/nodes-and-staking/upgrade-your-avalanchego-node.mdx
@@ -126,13 +126,13 @@ You are now ready to run the new version of the node.
 
 If you are using the pre-built binaries on MacOS:
 
-```cpp
+```
 ./avalanchego-<VERSION>/build/avalanchego
 ```
 
 If you are using the pre-built binaries on Linux:
 
-```cpp
+```
 ./avalanchego-<VERSION>-linux/avalanchego
 ```
 

--- a/docs/build/tutorials/platform/subnets/create-a-subnet.md
+++ b/docs/build/tutorials/platform/subnets/create-a-subnet.md
@@ -23,7 +23,7 @@ First, let’s generate the 2 control keys. To do so we call [`platform.createAd
 
 To generate the first key:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createAddress",
@@ -37,7 +37,7 @@ curl -X POST --data '{
 
 This gives the first control key (again, it actually gives the _address_ of the first control key). The key is held by the user we just specified.
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -49,7 +49,7 @@ This gives the first control key (again, it actually gives the _address_ of the 
 
 Generate the second key:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createAddress",
@@ -63,7 +63,7 @@ curl -X POST --data '{
 
 The response contains the second control key, which is held by the user we just specified:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -77,7 +77,7 @@ The response contains the second control key, which is held by the user we just 
 
 To create a subnet, we call [`platform.createSubnet`](../../../avalanchego-apis/p-chain.md#platformcreatesubnet).
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createSubnet",
@@ -96,7 +96,7 @@ curl -X POST --data '{
 
 The response gives us the transaction’s ID, which is also the ID of the newly created Subnet.
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -111,7 +111,7 @@ The response gives us the transaction’s ID, which is also the ID of the newly 
 
 We can call [`platform.getSubnets`](../../../avalanchego-apis/p-chain.md#platformgetsubnets) to get all Subnets that exist:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getSubnets",
@@ -122,7 +122,7 @@ curl -X POST --data '{
 
 The response confirms that our subnet was created:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -151,7 +151,7 @@ Suppose that the Subnet has ID `3fbrm3z38NoDB4yMC3hg5pRvc72XqnAGiu7NgaEp1dwZ8AD9
 
 To add the validator, we’ll call API method [`platform.addSubnetValidator`](../../../avalanchego-apis/p-chain.md#platformaddsubnetvalidator). Its signature is:
 
-```cpp
+```
 platform.addSubnetValidator(
     {
         nodeID: string,
@@ -196,7 +196,7 @@ We use the shell command `date` to compute the Unix time 10 minutes and 30 days 
 
 Example:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.addSubnetValidator",
@@ -216,7 +216,7 @@ curl -X POST --data '{
 
 The response has the transaction ID, as well as the address the change went to.
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -229,7 +229,7 @@ The response has the transaction ID, as well as the address the change went to.
 
 We can check the transaction’s status by calling [`platform.getTxStatus`](../../../avalanchego-apis/p-chain.md#platformgettxstatus):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getTxStatus",
@@ -242,7 +242,7 @@ curl -X POST --data '{
 
 The status should be `Committed`, meaning the transaction was successful. We can call [`platform.getPendingValidators`](../../../avalanchego-apis/p-chain.md#platformgetpendingvalidators) and see that the node is now in the pending validator set for the Primary Network. This time, we specify the subnet ID:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getPendingValidators",
@@ -253,7 +253,7 @@ curl -X POST --data '{
 
 The response should include the node we just added:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {

--- a/docs/build/tutorials/platform/subnets/create-a-virtual-machine-vm.md
+++ b/docs/build/tutorials/platform/subnets/create-a-virtual-machine-vm.md
@@ -1248,7 +1248,7 @@ Get a block by its ID. If no ID is provided, get the latest block.
 
 **Signature**
 
-```cpp
+```sh
 timestampvm.getBlock({id: string}) ->
     {
         id: string,
@@ -1278,7 +1278,7 @@ curl -X POST --data '{
 
 **Example Response**
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -1351,7 +1351,7 @@ Propose the next block on this blockchain.
 
 **Signature**
 
-```cpp
+```sh
 timestampvm.proposeBlock({data: string}) -> {success: bool}
 ```
 
@@ -1372,7 +1372,7 @@ curl -X POST --data '{
 
 **Example Response**
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -1456,7 +1456,7 @@ Each VM has a pre-defined, static ID. For instance, the default ID of the Timest
 
 It's possible to give an alias for these IDs. For example, we can alias `TimestampVM` by creating a JSON file at `~/.avalanchego/configs/vms/aliases.json` with:
 
-```javascript
+```json
 {
   "tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH": [
     "timestampvm",

--- a/docs/build/tutorials/platform/subnets/create-avm-blockchain.md
+++ b/docs/build/tutorials/platform/subnets/create-avm-blockchain.md
@@ -41,7 +41,7 @@ Each blockchain has some genesis state when it’s created. Each VM defines the 
 
 The [AVM’s documentation](../../../avalanchego-apis/x-chain.mdx) specifies that the argument to [`avm.buildGenesis`](../../../avalanchego-apis/x-chain.mdx#avm.buildGenesis) should look like this:
 
-```cpp
+```json
 {
 "genesisData":
     {
@@ -95,7 +95,7 @@ To create the byte representation of this genesis state, call [`avm.buildGenesis
 
 Note that this call is made to the AVM’s static API endpoint, `/ext/vm/avm`:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "id"     : 1,
@@ -156,7 +156,7 @@ curl -X POST --data '{
 
 This returns the byte representation of your blockchain’s genesis state:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -170,7 +170,7 @@ This returns the byte representation of your blockchain’s genesis state:
 
 Now let’s create the new blockchain. To do so, we call [`platform.createBlockchain`](../../../avalanchego-apis/p-chain.md#platformcreateblockchain). Your call should look like the one below. You have to change `subnetID` to the subnet that will validate your blockchain, and supply a `username` that controls a sufficient number of the subnet’s control keys. As a reminder, you can find out what a subnet’s threshold and control keys are by calling [`platform.getSubnets`](../../../avalanchego-apis/p-chain.md#platformgetsubnets).
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createBlockchain",
@@ -188,7 +188,7 @@ curl -X POST --data '{
 
 The response contains the transaction ID:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -205,7 +205,7 @@ After a few seconds, the transaction to create our blockchain should have been a
 
 To check, call [`platform.getBlockchains`](../../../avalanchego-apis/p-chain.md#platformgetblockchains). This returns a list of all blockchains that exist.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -216,7 +216,7 @@ curl -X POST --data '{
 
 The response confirms that the blockchain was created:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -255,7 +255,7 @@ The response confirms that the blockchain was created:
 
 Every blockchain needs a set of validators to validate and process transactions on it. You can check if a node is validating a given blockchain by calling [`platform.getBlockchainStatus`](../../../avalanchego-apis/p-chain.md#platformgetblockchainstatus) on that node:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -266,7 +266,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/P
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -295,7 +295,7 @@ You can interact with this new instance of the AVM almost the same way you’d i
 
 In the genesis data we specified that address `avax1dmrwka6uck44zkaamagq46hhntta67yxfy9h9z` has 100,000,000 units of the asset with alias `asset1`. Let’s verify that:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -307,7 +307,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/myxchain
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -327,7 +327,7 @@ curl -X POST --data '{
 
 Let's send some `asset1` to another address. First, create a recipient address:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "avm.createAddress",
@@ -339,7 +339,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/myxchain
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -351,7 +351,7 @@ curl -X POST --data '{
 
 Now let's send 1 unit of `asset1` to the new address with [`avm.send`](../../../avalanchego-apis/x-chain.mdx#avm.send).
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -368,7 +368,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/myxchain
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -381,7 +381,7 @@ curl -X POST --data '{
 
 We can verify transaction status with:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -392,7 +392,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/myxchain
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -404,7 +404,7 @@ curl -X POST --data '{
 
 Now we can confirm balances are changed accordingly:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -416,7 +416,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/myxchain
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -434,7 +434,7 @@ curl -X POST --data '{
 
 As mentioned above, transaction fees are paid with `asset1`. We can confirm 1,000,000 unit (default) is used as fee in our transaction. Let's check senders balance after the transaction.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -446,7 +446,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/myxchain
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -468,7 +468,7 @@ This address had 100,000,000 `asset1`, then we sent 1 unit to the other address 
 
 Our blockchain has another asset `asset2` named `myVarCapAsset`. It is a variable-cap asset. Let's mint more units of this asset with [`avm.mint`](../../../avalanchego-apis/x-chain.mdx#avm.mint). Address `avax16k8n4d8xmhplqn5vhhm342g6n9rkxuj8wn6u70` controls the mintable asset `asset2`, and it also has 5,000,000 unit `asset1`, which is enough to pay the transaction fee.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -488,7 +488,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/myxchain
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -501,7 +501,7 @@ curl -X POST --data '{
 
 Let's check the balance with [`avm.getAllBalances`](../../../avalanchego-apis/x-chain.mdx#avm.getAllBalances).
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -512,7 +512,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/myxchain
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {

--- a/docs/build/tutorials/platform/subnets/create-custom-blockchain.md
+++ b/docs/build/tutorials/platform/subnets/create-custom-blockchain.md
@@ -50,7 +50,7 @@ Each blockchain has some genesis state when it’s created. Each VM defines the 
 
 Let's generate a simple genesis data for TimestampVM:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "timestampvm.encode",
@@ -61,7 +61,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/vm/tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -80,7 +80,7 @@ Now let’s create the new blockchain. To do so, we call [`platform.createBlockc
 
 Recall that we used `tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH` as our VM ID in [Create A Virtual Machine(VM)](create-a-virtual-machine-vm.md#vm-aliases).
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createBlockchain",
@@ -98,7 +98,7 @@ curl -X POST --data '{
 
 The response contains the transaction ID:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -115,7 +115,7 @@ After a few seconds, the transaction to create our blockchain should have been a
 
 To check, call [`platform.getBlockchains`](../../../avalanchego-apis/p-chain.md#platformgetblockchains). This returns a list of all blockchains that exist.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -126,7 +126,7 @@ curl -X POST --data '{
 
 The response confirms that the blockchain was created:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -165,7 +165,7 @@ The response confirms that the blockchain was created:
 
 Every blockchain needs a set of validators to validate and process transactions on it. You can check if a node is validating a given blockchain by calling [`platform.getBlockchainStatus`](../../../avalanchego-apis/p-chain.md#platformgetblockchainstatus) on that node:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -176,7 +176,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/P
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -200,7 +200,7 @@ You can also alias this chain ID with `timestampbc`, or whatever you like, for s
 
 In the genesis we specified `fP1vxkpyLWnH9dD6BQA` as the genesis data. Let’s verify that:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "timestampvm.getBlock",
@@ -209,7 +209,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/sw813hGSWH8pdU9uzaYy9fCtYFfY7AjDd2c9rm64SbApnvjmk
 ```
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -224,7 +224,7 @@ curl -X POST --data '{
 
 As you can see our first block has `timestamp: 0`. Also the parent ID (`11111111111111111111111111111111LpoYY`) is the P-chain's ID. Let's decode the genesis data with VM's static API method. Recall that our TimestampVM ID is aliased with `timestampvm`:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "id"     : 1,
@@ -235,7 +235,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/vm/tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH
 ```
 
-```javascript
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -254,7 +254,7 @@ We can propose new blocks to our blockchain with some data in it.
 
 Let's get encoded data first. Blocks expect to have 32-length bytes. There is a `length` argument in encode method:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "id"     : 1,
@@ -268,7 +268,7 @@ curl -X POST --data '{
 
 Result:
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -281,7 +281,7 @@ Result:
 
 Now we can propose a new block with the data:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "timestampvm.proposeBlock",
@@ -294,7 +294,7 @@ curl -X POST --data '{
 
 Result:
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -306,7 +306,7 @@ Result:
 
 Let's check latest block to verify existence of our proposed block:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "timestampvm.getBlock",
@@ -317,7 +317,7 @@ curl -X POST --data '{
 
 Result:
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {

--- a/docs/build/tutorials/platform/subnets/create-evm-blockchain.md
+++ b/docs/build/tutorials/platform/subnets/create-evm-blockchain.md
@@ -185,7 +185,7 @@ Remind that our VM ID was `srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy`. C
 
 To create the byte representation of this genesis state, call `subnetevm.buildGenesis`.
 
-```cpp
+```sh
 curl -X POST --data '{
   "jsonrpc": "2.0",
   "id": 1,
@@ -237,7 +237,7 @@ curl -X POST --data '{
 
 This returns the byte representation of your blockchain’s genesis state:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -250,7 +250,7 @@ This returns the byte representation of your blockchain’s genesis state:
 
 You can also issue a `subnetevm.decodeBlock` to make sure your encoded genesis bytes are intact:
 
-```cpp
+```sh
 curl -X POST --data '{
     {
     "jsonrpc": "2.0",
@@ -265,7 +265,7 @@ curl -X POST --data '{
 
 This should return the same genesis block, provided in `subnetevm.buildGenesis` call. Order of fields can be different:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -322,7 +322,7 @@ Now let’s create the new blockchain. To do so, we call [`platform.createBlockc
 
 Now let's create the blockchain by issuing the `platform.createBlockchain` call:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.createBlockchain",
@@ -340,7 +340,7 @@ curl -X POST --data '{
 
 The response contains the transaction ID:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -357,7 +357,7 @@ After a few seconds, the transaction to create our blockchain should have been a
 
 To check, call [`platform.getBlockchains`](../../../avalanchego-apis/p-chain.md#platformgetblockchains). This returns a list of all blockchains that exist.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -368,7 +368,7 @@ curl -X POST --data '{
 
 The response confirms that the blockchain was created:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -401,7 +401,7 @@ The response confirms that the blockchain was created:
 
 Every blockchain needs a set of validators to validate and process transactions on it. You can check if a node is validating a given blockchain by calling [`platform.getBlockchainStatus`](../../../avalanchego-apis/p-chain.md#platformgetblockchainstatus) on that node:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -412,7 +412,7 @@ curl -X POST --data '{
 }' -H 'content-type:application/json;' 127.0.0.1:9650/ext/P
 ```
 
-```javascript
+```json
 {
   "jsonrpc": "2.0",
   "result": {
@@ -434,7 +434,7 @@ You can interact with this new instance of the EVM almost the same way you’d i
 
 We specified a chainID of `13213`, which is equivalent to `0x339d` in hex. Let's verify our chain ID with the RPC call:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "eth_chainId",

--- a/docs/build/tutorials/platform/transfer-avax-between-p-chain-and-c-chain.md
+++ b/docs/build/tutorials/platform/transfer-avax-between-p-chain-and-c-chain.md
@@ -85,7 +85,7 @@ In order to get around this, you can export a private key from the X-Chain and t
 
 First, export a private key from the X-Chain:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -100,7 +100,7 @@ curl -X POST --data '{
 
 Response:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -112,7 +112,7 @@ Response:
 
 Now, import the same private key to the C-Chain:
 
-```cpp
+```sh
 curl -X POST --data '{  
     "jsonrpc":"2.0",    
     "id"     :1,    
@@ -127,7 +127,7 @@ curl -X POST --data '{
 
 The response contains a hex-encoded EVM address:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -143,7 +143,7 @@ Now we have everything we need to transfer the tokens.
 
 Use the address corresponding to the private key you exported and switch to using the C- prefix in the [`platform.exportAVAX`](../../avalanchego-apis/p-chain.md#platformexportavax) call:
 
-```cpp
+```sh
 curl -X POST --data '{  
     "jsonrpc":"2.0",    
     "id"     :1,    
@@ -160,7 +160,7 @@ curl -X POST --data '{
 
 Since your keystore user owns the corresponding private key on the C-Chain, you can now import the AVAX to the address of your choice. It’s not necessary to import it to the same address that it was exported to; you can import the AVAX to an address that you own in MetaMask or another third-party service.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,    
@@ -178,7 +178,7 @@ where `to` is a hex-encoded EVM address of your choice.
 
 The response looks like this:
 
-```cpp
+```json
 {   
     "jsonrpc": "2.0",   
     "result": { 
@@ -196,7 +196,7 @@ Once your AVAX has been transferred to the C-Chain, you can use it to deploy and
 
 Now, you can move AVAX back from the C-Chain to the P-Chain. First we need to export:
 
-```cpp
+```sh
 curl -X POST --data '{  
     "jsonrpc":"2.0",    
     "id"     :1,    
@@ -215,7 +215,7 @@ where `to` is the bech32 encoded address of an P-Chain address you hold. Make su
 
 The response should look like this:
 
-```cpp
+```json
 {   
     "jsonrpc": "2.0",   
     "result": { 
@@ -227,7 +227,7 @@ The response should look like this:
 
 To finish the transfer, call P-Chain’s [`platform.importAVAX`](../../avalanchego-apis/p-chain.md#platformimportavax)
 
-```cpp
+```sh
 curl -X POST --data '{  
     "jsonrpc":"2.0",    
     "id"     :1,    
@@ -245,7 +245,7 @@ where `to` is the bech32 encoded address the P-Chain address which you sent the 
 
 The response should look like this:
 
-```cpp
+```json
 {   
     "jsonrpc": "2.0",   
     "result": { 

--- a/docs/build/tutorials/platform/transfer-avax-between-x-chain-and-c-chain.md
+++ b/docs/build/tutorials/platform/transfer-avax-between-x-chain-and-c-chain.md
@@ -85,7 +85,7 @@ In order to get around this, you can export a private key from the X-Chain and t
 
 First, export a private key from the X-Chain:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -100,7 +100,7 @@ curl -X POST --data '{
 
 Response:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -112,7 +112,7 @@ Response:
 
 Now, import the same private key to the C-Chain:
 
-```cpp
+```sh
 curl -X POST --data '{  
     "jsonrpc":"2.0",    
     "id"     :1,    
@@ -127,7 +127,7 @@ curl -X POST --data '{
 
 The response contains a hex-encoded EVM address:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -143,7 +143,7 @@ Now we have everything we need to transfer the tokens.
 
 Use the address corresponding to the private key you exported and switch to using the C- prefix in the [`avm.export`](../../avalanchego-apis/x-chain.mdx#avmexport) call:
 
-```cpp
+```sh
 curl -X POST --data '{  
     "jsonrpc":"2.0",    
     "id"     :1,    
@@ -160,7 +160,7 @@ curl -X POST --data '{
 
 Since your keystore user owns the corresponding private key on the C-Chain, you can now import the AVAX to the address of your choice. It’s not necessary to import it to the same address that it was exported to; you can import the AVAX to an address that you own in MetaMask or another third-party service.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,    
@@ -178,7 +178,7 @@ where `to` is a hex-encoded EVM address of your choice.
 
 The response looks like this:
 
-```cpp
+```json
 {   
     "jsonrpc": "2.0",   
     "result": { 
@@ -196,7 +196,7 @@ Once your AVAX has been transferred to the C-Chain, you can use it to deploy and
 
 Now, you can move AVAX back from the C-Chain to the X-Chain. First we need to export:
 
-```cpp
+```sh
 curl -X POST --data '{  
     "jsonrpc":"2.0",    
     "id"     :1,    
@@ -215,7 +215,7 @@ where `to` is the bech32 encoded address of an X-Chain address you hold. Make su
 
 The response should look like this:
 
-```cpp
+```json
 {   
     "jsonrpc": "2.0",   
     "result": { 
@@ -227,7 +227,7 @@ The response should look like this:
 
 To finish the transfer, call [`avm.import`](../../avalanchego-apis/x-chain.mdx#avmimport).
 
-```cpp
+```sh
 curl -X POST --data '{  
     "jsonrpc":"2.0",    
     "id"     :1,    
@@ -245,7 +245,7 @@ where `to` is the bech32 encoded address the X-Chain address which you sent the 
 
 The response should look like this:
 
-```cpp
+```json
 {   
     "jsonrpc": "2.0",   
     "result": { 

--- a/docs/build/tutorials/platform/transfer-avax-between-x-chain-and-p-chain.md
+++ b/docs/build/tutorials/platform/transfer-avax-between-x-chain-and-p-chain.md
@@ -81,7 +81,7 @@ To export AVAX, call the X-Chain’s [`avm.export`](../../avalanchego-apis/x-cha
 
 Your call should look like this:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -105,7 +105,7 @@ Make sure that the amount that you’re sending exceeds the transaction fee. Oth
 
 The response should look like this:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -118,7 +118,7 @@ The response should look like this:
 
 We can verify that this transaction was accepted by calling [`avm.getTxStatus`](../../avalanchego-apis/x-chain.mdx#avmgettxstatus):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "avm.getTxStatus",
@@ -131,7 +131,7 @@ curl -X POST --data '{
 
 Which shows our transaction is accepted:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -143,7 +143,7 @@ Which shows our transaction is accepted:
 
 We can also call [`avm.getBalance`](../../avalanchego-apis/x-chain.mdx#avmgetbalance) to check that the AVAX was deducted from an address held by our user:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -163,7 +163,7 @@ Our transfer isn’t done just yet. We need to call the P-Chain’s [`platform.i
 
 Your call should look like this:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.importAVAX",
@@ -180,7 +180,7 @@ curl -X POST --data '{
 
 This returns the transaction ID:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -193,7 +193,7 @@ This returns the transaction ID:
 
 We can check that the transaction was accepted with:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -206,7 +206,7 @@ curl -X POST --data '{
 
 It should be `Committed`, meaning the transfer is complete. We can also check the balance of the address with:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.getBalance",
@@ -219,7 +219,7 @@ curl -X POST --data '{
 
 The response should look like this:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -250,7 +250,7 @@ Same as before, this is also a two transaction operation:
 
 To do so, call [`platform.exportAVAX`](../../avalanchego-apis/p-chain.md#platformexportavax):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc": "2.0",
     "method": "platform.exportAVAX",
@@ -273,7 +273,7 @@ This returns the transaction ID, and we can check that the transaction was commi
 
 To finish our transfer from the P-Chain to the X-Chain, call [`avm.import`](../../avalanchego-apis/x-chain.mdx#avmimport):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,

--- a/docs/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain.md
+++ b/docs/build/tutorials/smart-contracts/using-truffle-with-the-avalanche-c-chain.md
@@ -365,7 +365,7 @@ truffle(development)> instance.store(1234)
 
 You should see something like:
 
-```javascript
+```json
 {
   tx: '0x10afbc5e0b9fa0c1ef1d9ec3cdd673e7947bd8760b22b8cdfe08f27f3a93ef1e',
   receipt: {

--- a/docs/build/tutorials/smart-contracts/verify-smart-contracts.md
+++ b/docs/build/tutorials/smart-contracts/verify-smart-contracts.md
@@ -38,7 +38,7 @@ The C-Chain Explorer can fetch constructor arguments automatically for simple sm
 
 The compile bytecode will identify if there are are external libraries. If you released with Remix, you will also see multiple transactions created.
 
-```javascript
+```json
 {
   "linkReferences": {
     "contracts/Storage.sol": {

--- a/docs/build/tutorials/smart-digital-assets/create-a-fix-cap-asset.md
+++ b/docs/build/tutorials/smart-digital-assets/create-a-fix-cap-asset.md
@@ -16,7 +16,7 @@ Our asset will exist on the [X-Chain](../../../learn/platform-overview/README.md
 
 The signature for this method is:
 
-```cpp
+```
 avm.createFixedCapAsset({
     name: string,
     symbol: string,
@@ -53,7 +53,7 @@ avm.createFixedCapAsset({
 
 Now, on to creating the asset. You’ll want to replace `address` with an address you control so that you will control all of the newly minted assets and be able to send it later in this tutorial.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -78,7 +78,7 @@ curl -X POST --data '{
 
 The response contains the asset’s ID, which is also the ID of this transaction:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -97,7 +97,7 @@ All 10,000,000 units of the asset (shares) are controlled by the address we spec
 
 To verify this, we call [`avm.getBalance`](../../avalanchego-apis/x-chain.mdx#avmgetbalance):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -111,7 +111,7 @@ curl -X POST --data '{
 
 The response confirms that our asset creation was successful and that the expected address holds all 10,000,000 shares:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -127,7 +127,7 @@ Now, let’s send 100 shares by calling [`avm.send`](../../avalanchego-apis/x-ch
 
 To send the shares, we need to prove that we control the user the shares are being sent from. Therefore, this time we’ll need to fill in `username` and `password`.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -146,7 +146,7 @@ curl -X POST --data '{
 
 The response from the above call should look like this:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -161,7 +161,7 @@ The response from the above call should look like this:
 
 After a second or two, the transaction should be finalized. We can check the status of the transaction with [`avm.getTxStatus`](../../avalanchego-apis/x-chain.mdx#avmgettxstatus):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -174,7 +174,7 @@ curl -X POST --data '{
 
 The response should look like this:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -188,7 +188,7 @@ You might also see that `status` is `Pending` if the network has not yet finaliz
 
 Now let’s check the balance of the `to` address:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -202,7 +202,7 @@ curl -X POST --data '{
 
 The response should be:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,

--- a/docs/build/tutorials/smart-digital-assets/creating-a-nft-part-1.md
+++ b/docs/build/tutorials/smart-digital-assets/creating-a-nft-part-1.md
@@ -23,7 +23,7 @@ Each NFT belongs to a **family**, which has a name and a symbol. Each family is 
 
 The signature for this method is:
 
-```cpp
+```
 avm.createNFTAsset({
     name: string,
     symbol: string,
@@ -62,7 +62,7 @@ avm.createNFTAsset({
 
 Later in this example, we’ll mint an NFT, so be sure to replace at least 1 address in the minter set with an address which your user controls.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -86,7 +86,7 @@ curl -X POST --data '{
 
 The response should look like this:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -122,7 +122,7 @@ NFT outputs don’t show up in calls to [`avm.getBalance`](../../avalanchego-api
 * `utxos` is an array of CB58 encoded strings.
 * `endIndex` This method supports pagination. `endIndex` denotes the last UTXO returned.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -135,7 +135,7 @@ curl -X POST --data '{
 
 The response contains a list of UTXOs:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -155,19 +155,19 @@ The response contains a list of UTXOs:
 
 [`avm.getUTXOs`](../../avalanchego-apis/x-chain.mdx#avmgetutxos) returns 2 UTXOs. Let’s take the first one and decode it to confirm that it’s an [NFT Mint Output.](../../references/avm-transaction-serialization.md#nft-mint-output) First, we convert the Base58Check encoded string which is returned from [`avm.getUTXOs`](../../avalanchego-apis/x-chain.mdx#avmgetutxos) in to hex. The following [CB58](http://support.avalabs.org/en/articles/4587395-what-is-cb58) string:
 
-```cpp
+```
 116VhGCxiSL4GrMPKHkk9Z92WCn2i4qk8qdN3gQkFz6FMEbHo82Lgg8nkMCPJcZgpVXZLQU6MfYuqRWfzHrojmcjKWbfwqzZoZZmvSjdD3KJFsW3PDs5oL3XpCHq4vkfFy3q1wxVY8qRc6VrTZaExfHKSQXX1KnC
 ```
 
 is expressed in hexadecimal as:
 
-```cpp
+```
 00 00 04 78 f2 39 8d d2 16 3c 34 13 2c e7 af a3 1f 0a c5 03 01 7f 86 3b f4 db 87 ea 55 53 c5 2d 7b 57 00 00 00 01 04 78 f2 39 8d d2 16 3c 34 13 2c e7 af a3 1f 0a c5 03 01 7f 86 3b f4 db 87 ea 55 53 c5 2d 7b 57 00 00 00 0a 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 01 3c b7 d3 84 2e 8c ee 6a 0e bd 09 f1 fe 88 4f 68 61 e1 b2 9c
 ```
 
 Now, we can decompose the hex into the UTXO’s individual components by referring to the [transaction serialization format](../../references/avm-transaction-serialization.md):
 
-```cpp
+```
 NFT Mint Output
 
 CodecID: 00 00
@@ -205,7 +205,7 @@ Now that we have an NFT family and a group for the single `MinterSet` we’re ab
 * `txID` is the transaction ID.
 * `changeAddr` in the result is the address where any change was sent.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -222,7 +222,7 @@ curl -X POST --data '{
 
 The response contains the transaction’s ID:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -235,7 +235,7 @@ The response contains the transaction’s ID:
 
 Similar to the previous step, we can now confirm that an NFT was minted by calling [`avm.getUTXOs`](../../avalanchego-apis/x-chain.mdx#avmgetutxos) and parsing the UTXO to confirm that we now have an [NFT Transfer Output](../../references/avm-transaction-serialization.md#nft-transfer-output).
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -248,7 +248,7 @@ curl -X POST --data '{
 
 This should give:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -270,19 +270,19 @@ As in the previous step, we can now decode the CB58 encoded UTXO to hexidecimal 
 
 First, we convert the Base58Check encoded string which is returned from [`avm.getUTXOs`](../../avalanchego-apis/x-chain.mdx#avmgetutxos) in to hex. The following CB58 string:
 
-```cpp
+```
 11Do4RK6FchGXeoycKujR7atm3tvBz3qc64uoipCc5J74Sj1U4orM6vbBGSES8hnjgjZava9oPgmnbHxh2mBKjeXdvAqTRtYMHEacrveSzKgk7F8h8xi8JB9CddoiX8nbjZMYt1keGo5Rvpjh8dGymDWwRbV1FdnG5uDiiyU8uidc3P24
 ```
 
 is expressed in hexadecimal as:
 
-```cpp
+```
 00 00 7d 07 0d 1e fe a6 4e 45 09 05 c6 11 ee b1 cf 61 9f 21 22 eb 17 db aa ea 9a fe 2d ff 17 be 27 6b 00 00 00 01 04 78 f2 39 8d d2 16 3c 34 13 2c e7 af a3 1f 0a c5 03 01 7f 86 3b f4 db 87 ea 55 53 c5 2d 7b 57 00 00 00 0b 00 00 00 00 00 00 00 08 41 56 41 20 4c 61 62 73 00 00 00 00 00 00 00 00 00 00 00 01 00 00 00 01 3c b7 d3 84 2e 8c ee 6a 0e bd 09 f1 fe 88 4f 68 61 e1 b2 9c
 ```
 
 Now, we can decompose the hex into the UTXO’s individual components:
 
-```cpp
+```
 NFT Mint Output
 
 CodecID: 00 00
@@ -322,7 +322,7 @@ Now, you can send the NFT to anyone. To do that, use AvalancheGo’s [`avm.sendN
 * `txID` is the transaction ID.
 * `changeAddr` in the result is the address where any change was sent.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -339,7 +339,7 @@ curl -X POST --data '{
 
 The response confirms that our NFT Transfer Operation was successful:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,

--- a/docs/build/tutorials/smart-digital-assets/creating-a-variable-cap-asset.md
+++ b/docs/build/tutorials/smart-digital-assets/creating-a-variable-cap-asset.md
@@ -21,7 +21,7 @@ Our asset will exist on the X-Chain, so to create our asset we’ll call [`avm.c
 
 The signature for this method is:
 
-```cpp
+```
 avm.createVariableCapAsset({
     name: string,
     symbol: string,
@@ -58,7 +58,7 @@ avm.createVariableCapAsset({
 
 Later in this example, we’ll mint more shares, so be sure to replace at least 2 addresses in the second minter set with addresses your user controls.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -92,7 +92,7 @@ curl -X POST --data '{
 
 The response should look like this:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -116,7 +116,7 @@ We’ll use [`avm.mint`](../../avalanchego-apis/x-chain.mdx#avmmint) to mint the
 * `to` is the address that will receive the newly minted shares. Replace `to` with an address your user controls so that later you’ll be able to send some of the newly minted shares.
 * `username` must be a user that holds keys giving it permission to mint more of this asset. That is, it controls at least _threshold_ keys for one of the minter sets we specified above.
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -133,7 +133,7 @@ curl -X POST --data '{
 
 The response contains the transaction’s ID:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -146,7 +146,7 @@ The response contains the transaction’s ID:
 
 We can check the status of the transaction we’ve just sent to the network using [`avm.getTxStatus`](../../avalanchego-apis/x-chain.mdx#avmgettxstatus):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
@@ -159,7 +159,7 @@ curl -X POST --data '{
 
 This should give:
 
-```cpp
+```json
 {
     "jsonrpc": "2.0",
     "result": {
@@ -175,7 +175,7 @@ This should give:
 
 All 10M shares are controlled by the `to` address we specified in `mint`. To verify this, we’ll use [`avm.getBalance`](../../avalanchego-apis/x-chain.mdx#avmgetbalance):
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -189,7 +189,7 @@ curl -X POST --data '{
 
 The response confirms that our asset creation was successful and that the expected address holds all 10,000,000 shares:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,
@@ -203,7 +203,7 @@ The response confirms that our asset creation was successful and that the expect
 
 Let’s send 100 shares to another address by using [`avm.send`](../../avalanchego-apis/x-chain.mdx#avmsend). To do so:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -220,7 +220,7 @@ curl -X POST --data '{
 
 Let’s check the balances of the `to` address:
 
-```cpp
+```sh
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     :1,
@@ -234,7 +234,7 @@ curl -X POST --data '{
 
 The response should be:
 
-```cpp
+```json
 {
     "jsonrpc":"2.0",
     "id"     :1,

--- a/docs/learn/platform-overview/transaction-fees.md
+++ b/docs/learn/platform-overview/transaction-fees.md
@@ -12,7 +12,7 @@ When you issue a transaction through Avalanche’s API, the transaction fee is a
 
 Different types of transactions require payment of a different transaction fee. This table shows the transaction fee schedule:
 
-```cpp
+```
 +----------+-------------------+------------------------+
 | Chain    : Transaction Type  | Transaction Fee (AVAX) |
 +----------+-------------------+------------------------+


### PR DESCRIPTION
the `cpp` is supposed to be used for C++ code snippets 