### PR TITLE
Fix: Add missing comma

### DIFF
--- a/docs/build/tutorials/platform/subnets/create-evm-blockchain.md
+++ b/docs/build/tutorials/platform/subnets/create-evm-blockchain.md
@@ -214,7 +214,7 @@ curl -X POST --data '{
           "minBlockGasCost": 0,
           "maxBlockGasCost": 1000000,
           "blockGasCostStep": 200000
-        }
+        },
         "allowFeeRecipients": false,
       },
       "alloc": {


### PR DESCRIPTION
Fixes broken JSON payload

The missing comma causes this:
![image](https://user-images.githubusercontent.com/42661870/157428761-feafbfa4-eec1-4cb8-a85d-9601795a96e0.png)
