### PR TITLE
Fix broken link

### DIFF
--- a/docs/build/tutorials/platform/subnets/create-custom-blockchain.md
+++ b/docs/build/tutorials/platform/subnets/create-custom-blockchain.md
@@ -194,7 +194,7 @@ More information can be found in the [Adding a Subnet Validator](../../nodes-and
 
 You can interact with this new instance of the VM. The API endpoint of the blockchain is `127.0.0.1:9650/ext/bc/sw813hGSWH8pdU9uzaYy9fCtYFfY7AjDd2c9rm64SbApnvjmk`. The last part in the endpoint is the blockchain ID, which is `sw813hGSWH8pdU9uzaYy9fCtYFfY7AjDd2c9rm64SbApnvjmk`. Every blockchain ID is different from each other, so this is not a static ID. Your blockchain ID and the endpoint can be different.
 
-You can also alias this chain ID with `timestampbc`, or whatever you like, for simpler API URLs. More information: [admin.aliasChain](https://docs.avax.network/build/../avalanchego-apis/admin#admin-aliaschain)
+You can also alias this chain ID with `timestampbc`, or whatever you like, for simpler API URLs. More information: [admin.aliasChain](https://docs.avax.network/build/avalanchego-apis/admin/#adminaliaschain)
 
 ### Verify Genesis Block
 


### PR DESCRIPTION
Link to admin.aliasChain in https://docs.avax.network/build/tutorials/platform/subnets/create-custom-blockchain/#interact-with-the-new-blockchain is broken

The current link takes you here
![image](https://user-images.githubusercontent.com/42661870/157841083-78604817-01db-4004-9b6b-543e304812ca.png)
