### PR TITLE
Add note on how VMID is calculated

### DIFF
--- a/docs/build/tutorials/platform/subnets/create-a-virtual-machine-vm.md
+++ b/docs/build/tutorials/platform/subnets/create-a-virtual-machine-vm.md
@@ -1450,6 +1450,8 @@ The path to the executable, as well as its name, can be provided to the build sc
 
 If no argument is given, the path defaults to a binary named with default VM ID: `$GOPATH/src/github.com/ava-labs/avalanchego/build/plugins/tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH`
 
+This name `tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH` is the CB58 encoded 32 byte identifier for the VM. For the timestampvm, this is the string "timestampvm" zero-extended in a 32 byte array and encoded in CB58.
+
 ### VM Aliases
 
 Each VM has a pre-defined, static ID. For instance, the default ID of the TimestampVM is: `tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH`.

--- a/docs/build/tutorials/platform/subnets/create-evm-blockchain.md
+++ b/docs/build/tutorials/platform/subnets/create-evm-blockchain.md
@@ -34,7 +34,7 @@ The path to the executable, can be provided to the build script via arguments. F
 ```
 
 If no argument is given, the path defaults to `$GOPATH/src/github.com/ava-labs/avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy`
-(The part `srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy` is the default ID of this VM.)
+(The part `srEXiWaHuhNyGwPUi444Tu47ZEDwxTWrbQiuD7FmgSAQ6X7Dy` is the default ID of this VM and corresponds to the string "subnetevm" zero-extended in a 32 byte array and encoded in CB58.)
 
 AvalancheGo searches for and registers plugins under `[buildDir]/plugins/`. You need to put built VM binary under this path. The `[buildDir]` defaults to the path of executed AvalancheGo binary. See [here](../../../references/avalanchego-config-flags.md#build-directory) for more information.
 


### PR DESCRIPTION
This PR adds brief documentation on how the VMID is calculated. We should add this to the FAQ as well, but after looking at the FAQ I think this should be part of a separate PR after we have separated out the subnet documentation from the subnet-evm documentation.