### PR TITLE
Set open file handles limit in systemd unit

### DIFF
--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -22,6 +22,7 @@ create_service_file () {
   echo "User=$(whoami)">>avalanchego.service
   echo "WorkingDirectory=$HOME">>avalanchego.service
   echo "ExecStart=$HOME/avalanche-node/avalanchego --config-file=$HOME/.avalanchego/configs/node.json">>avalanchego.service
+  echo "LimitNOFILE=32768">>avalanchego.service
   echo "Restart=always">>avalanchego.service
   echo "RestartSec=1">>avalanchego.service
   echo "[Install]">>avalanchego.service


### PR DESCRIPTION
This should prevent some startup failures seen by users, due to exceeding available file handles