### PR TITLE
Download fuji db for Avalanche Hackathon.

### DIFF
--- a/docs/build/tutorials/platform/download-fuji-db.md
+++ b/docs/build/tutorials/platform/download-fuji-db.md
@@ -2,7 +2,9 @@
 
 ## Introduction
 
-Currently fully syncing the Fuji network takes multiple days. A common request from developers is a quicker path to having a fully synced Fuji node. With that in mind we have released a Fuji DB which can be downloaded to a fresh AvalancheGo instance.
+Interest in Avalanche Subnets has been exploding. With the recent announcement of [Multiverse](https://medium.com/avalancheavax/avalanche-foundation-launches-multiverse-an-up-to-290m-incentive-program-to-accelerate-growth-of-c815ac5692c7), an up to $290M incentive program to accelerate growth of Subnets, we expect that interest to accelerate.
+
+A requirement of running a custom subnet is to first have a validator on the primary subnet.  Currently fully syncing the Fuji network takes multiple days. A common request from developers is a quicker path to having a fully synced Fuji node. With that in mind, and in time for the [Avalanche Summit Hackthons](https://www.avalanchesummit.com) uploaded a DB to S3 that you can use to start your own Fuji validator.
 
 ## Download AvalancheGo
 
@@ -10,7 +12,7 @@ First, you need an instance of AvalancheGo. For that you have multiple options i
 
 ### Build Locally
 
-Check out the [AvalancheGo repo](https://github.com/ava-labs/avalanchego) and follow the build steps.
+Check out the [AvalancheGo repo](https://github.com/ava-labs/avalanchego) and follow [the build steps](https://github.com/ava-labs/avalanchego#native-install).
 
 ### Run From Binary
 
@@ -18,27 +20,23 @@ Alternatively you can use a [pre-build binary](https://github.com/ava-labs/avala
 
 ## Install the Fuji DB
 
-To make it easier to launch your own subnet on Fuji, we uploaded a DB to S3 that you can use to run your own validator.
+Now that you have an instance of AvalancheGo you can download the Fuji DB from S3.
 
 ### Download the DB from S3
 
-First, download the DB:
+First, download the DB. Depending on your network speed this may take a while.
 
 ```zsh
 wget fuji-dbs.s3.amazonaws.com/03-25-2022-testnet-db.tar.gz 
 ```
 
-Depending on your network speed this may take a while.
-
 ### Unzip the tar
 
-Next, unzip the downloaded tarfile.
+Next, unzip the downloaded tarfile. This will extract a `fuji/` directory.
 
 ```zsh
 tar -xf 03-25-2022-testnet-db.tar.gz
 ```
-
-This will extract a `fuji/` directory.
 
 ### Move the DB
 
@@ -47,3 +45,7 @@ Lastly, move the `fuji/` directory to `~/.avalanchego/db/`
 ```zsh
 mv fuji/ ~/.avalanchego/db
 ```
+
+## Summary
+
+We want to make it as quick and seamless as possible for developers to go from idea to amazing subnet and application with as few steps as possible. Providing a DB for developers to quickly sync the Fuji network is just one more step to ensure a best-in-class UX for developers on the Avalanche network.

--- a/docs/build/tutorials/platform/download-fuji-db.md
+++ b/docs/build/tutorials/platform/download-fuji-db.md
@@ -4,7 +4,7 @@
 
 Interest in Avalanche Subnets has been exploding. With the recent announcement of [Multiverse](https://medium.com/avalancheavax/avalanche-foundation-launches-multiverse-an-up-to-290m-incentive-program-to-accelerate-growth-of-c815ac5692c7), an up to $290M incentive program to accelerate growth of Subnets, we expect that interest to accelerate.
 
-A requirement of running a custom subnet is to first have a validator on the primary subnet.  Currently fully syncing the Fuji network takes multiple days. A common request from developers is a quicker path to having a fully synced Fuji node. With that in mind, and in time for the [Avalanche Summit Hackthons](https://www.avalanchesummit.com) uploaded a DB to S3 that you can use to start your own Fuji validator.
+A requirement of running a custom subnet is to first have a validator on the primary subnet.  Currently fully syncing the Fuji network takes multiple days. A common request from developers is a quicker path to having a fully synced Fuji node. With that in mind, and in time for the [Avalanche Summit Hackthon](https://www.avalanchesummit.com), we've uploaded a DB to S3 that you can use to start your own Fuji validator.
 
 ## Download AvalancheGo
 
@@ -16,7 +16,7 @@ Check out the [AvalancheGo repo](https://github.com/ava-labs/avalanchego) and fo
 
 ### Run From Binary
 
-Alternatively you can use a [pre-build binary](https://github.com/ava-labs/avalanchego/releases).
+Alternatively you can use a [pre-built binary](https://github.com/ava-labs/avalanchego/releases).
 
 ## Install the Fuji DB
 

--- a/docs/build/tutorials/platform/download-fuji-db.md
+++ b/docs/build/tutorials/platform/download-fuji-db.md
@@ -1,0 +1,49 @@
+# Download the Fuji DB
+
+## Introduction
+
+Currently fully syncing the Fuji network takes multiple days. A common request from developers is a quicker path to having a fully synced Fuji node. With that in mind we have released a Fuji DB which can be downloaded to a fresh AvalancheGo instance.
+
+## Download AvalancheGo
+
+First, you need an instance of AvalancheGo. For that you have multiple options including cloning the repo and building it locally or just running from a pre-built binary.
+
+### Build Locally
+
+Check out the [AvalancheGo repo](https://github.com/ava-labs/avalanchego) and follow the build steps.
+
+### Run From Binary
+
+Alternatively you can use a [pre-build binary](https://github.com/ava-labs/avalanchego/releases).
+
+## Install the Fuji DB
+
+To make it easier to launch your own subnet on Fuji, we uploaded a DB to S3 that you can use to run your own validator.
+
+### Download the DB from S3
+
+First, download the DB:
+
+```zsh
+wget fuji-dbs.s3.amazonaws.com/03-25-2022-testnet-db.tar.gz 
+```
+
+Depending on your network speed this may take a while.
+
+### Unzip the tar
+
+Next, unzip the downloaded tarfile.
+
+```zsh
+tar -xf 03-25-2022-testnet-db.tar.gz
+```
+
+This will extract a `fuji/` directory.
+
+### Move the DB
+
+Lastly, move the `fuji/` directory to `~/.avalanchego/db/`
+
+```zsh
+mv fuji/ ~/.avalanchego/db
+```


### PR DESCRIPTION
 We've uploaded a DB to S3 that developers can use to quickly sycn and start their own Fuji validator. This documentation is steps showing how to download, unzip and `mv` the db into the correct path.