### PR TITLE
Fixed broken link to Figment DataHub

### DIFF
--- a/docs/build/tutorials/tutorials-contest/avalanche-erc721-tutorial/README.md
+++ b/docs/build/tutorials/tutorials-contest/avalanche-erc721-tutorial/README.md
@@ -89,7 +89,7 @@ This file is the entrypoint of our Truffle project. As you can see, we specify t
 MNEMONIC='paste your metamask mnemonic here which is twelve words long believe me'
 APIKEY=YOUR_DATAHUB_API_KEY_FOR_THE_FUJI_TESTNET
 ```
-Note: For the Fuji testnet I used [DataHub](https://datahub.figment.io/auth/login)'s testnet RPC. There is a free plan which you can use. For that you would need to register, grab your APIKEY and paste it into your **.env** file. 
+Note: For the Fuji testnet I used [DataHub](https://datahub.figment.io/signup)'s testnet RPC. There is a free plan which you can use. For that you would need to register, grab your APIKEY and paste it into your **.env** file. 
 Complete DataHub onboarding guide to DataHub 2.0 can be found [HERE](https://docs.figment.io/guides/getting-started-with-datahub)
 
 4. We would also need two more configuration files in order to build our initial TypeScript environment. Let us create a **tsconfig.json** under the root of our project with the following contents:

--- a/docs/build/tutorials/tutorials-contest/avalanche-erc721-tutorial/README.md
+++ b/docs/build/tutorials/tutorials-contest/avalanche-erc721-tutorial/README.md
@@ -89,7 +89,7 @@ This file is the entrypoint of our Truffle project. As you can see, we specify t
 MNEMONIC='paste your metamask mnemonic here which is twelve words long believe me'
 APIKEY=YOUR_DATAHUB_API_KEY_FOR_THE_FUJI_TESTNET
 ```
-Note: For the Fuji testnet I used [DataHub](https://datahub.figment.io/services/avalanche)'s testnet RPC. There is a free plan which you can use. For that you would need to register, grab your APIKEY and paste it into your **.env** file. 
+Note: For the Fuji testnet I used [DataHub](https://datahub.figment.io/auth/login)'s testnet RPC. There is a free plan which you can use. For that you would need to register, grab your APIKEY and paste it into your **.env** file. 
 
 4. We would also need two more configuration files in order to build our initial TypeScript environment. Let us create a **tsconfig.json** under the root of our project with the following contents:
 

--- a/docs/build/tutorials/tutorials-contest/avalanche-erc721-tutorial/README.md
+++ b/docs/build/tutorials/tutorials-contest/avalanche-erc721-tutorial/README.md
@@ -90,6 +90,7 @@ MNEMONIC='paste your metamask mnemonic here which is twelve words long believe m
 APIKEY=YOUR_DATAHUB_API_KEY_FOR_THE_FUJI_TESTNET
 ```
 Note: For the Fuji testnet I used [DataHub](https://datahub.figment.io/auth/login)'s testnet RPC. There is a free plan which you can use. For that you would need to register, grab your APIKEY and paste it into your **.env** file. 
+Complete DataHub onboarding guide to DataHub 2.0 can be found [HERE](https://docs.figment.io/guides/getting-started-with-datahub)
 
 4. We would also need two more configuration files in order to build our initial TypeScript environment. Let us create a **tsconfig.json** under the root of our project with the following contents:
 


### PR DESCRIPTION
A few months ago Figment released DataHub 2.0 and with the release of DataHub 2.0, some of the links/URLs to DataHub pages were changed. Recently while going through the Ava Docs I found one of those broken links and this PR is to fix the broken link.

FYI, all of the API endpoints remained the same, there are no changes in the API endpoints of both Mainnet & Testnet.

Complete DataHub onboarding guide to DataHub 2.0 can be found  **[HERE](https://docs.figment.io/guides/getting-started-with-datahub)**