### PR TITLE
tutorials: Promote AvalancheGo installer as first/default method

### DIFF
--- a/docs/build/tutorials/nodes-and-staking/README.md
+++ b/docs/build/tutorials/nodes-and-staking/README.md
@@ -6,11 +6,11 @@ sidebar_position: 1
 
 |  |  |
 | :--- | :--- |
-| [**Run an Avalanche Node**](run-avalanche-node.md) | How to run a node and interact with the network |
+| [**Run an Avalanche Node**](set-up-node-with-installer.md) | How to install and run AvalancheGo |
 | [**Node Backup and Restore**](node-backup-and-restore.md) | Back up important files to be able to restore your node |
 | [**Set up Node Monitoring**](setting-up-node-monitoring.md) | Set up infrastructure to monitor an instance of AvalancheGo |
 | [**Add a Validator**](add-a-validator.md) | Add a node to the [Primary Network](../../../learn/platform-overview/README.md) |
-| [**Set up Node on Linux using install script**](set-up-node-with-installer.md) | Create a node on Linux the easy way |
+| [**Run a node manually, or from source**](run-avalanche-node.md) | How to install without the installer script |
 | [**Stake AVAX, by Validating or Delegating, with the Avalanche Wallet**](staking-avax-by-validating-or-delegating-with-the-avalanche-wallet.md) | Stake AVAX from the Avalanche wallet |
 | [**Upgrade Your AvalancheGo Node**](upgrade-your-avalanchego-node.mdx) | Upgrade your Avalanche node |
 | [**Set Up an Avalanche Node with Amazon Web Services (AWS)**](setting-up-an-avalanche-node-with-amazon-web-services-aws.md) | Create a node that runs on AWS |

--- a/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
+++ b/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 2
+sidebar_position: 6
 description: The quickest way to learn about Avalanche is to run a node and interact with the network and geared toward people interested in how the Avalanche Platform works.
 ---
 
-# Run an Avalanche Node
+# Run an Avalanche Node manually
 
 The quickest way to learn about Avalanche is to run a node and interact with the network.
 

--- a/docs/build/tutorials/nodes-and-staking/set-up-node-with-installer.md
+++ b/docs/build/tutorials/nodes-and-staking/set-up-node-with-installer.md
@@ -1,9 +1,9 @@
 ---
-sidebar_position: 6
+sidebar_position: 2
 ---
 
 
-# Run an Avalanche Node using the Install Script
+# Run an Avalanche Node
 
 We have a shell (bash) script that installs AvalancheGo on your computer. This script sets up full, running node in a matter of minutes with minimal user input required.
 


### PR DESCRIPTION
I believe it's just an accident of history that the manual instructions were at the top of the list. The installer script is easier, and more reliable.