### PR TITLE
Installer: remove http-host directive from config file (#673)

### DIFF
--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -34,11 +34,10 @@ create_config_file () {
   rm -f node.json
   echo "{" >>node.json
   if [ "$ipChoice" = "1" ]; then
-    echo "  \"dynamic-public-ip\": \"opendns\",">>node.json
+    echo "  \"dynamic-public-ip\": \"opendns\"">>node.json
   else
-    echo "  \"public-ip\": \"$foundIP\",">>node.json
+    echo "  \"public-ip\": \"$foundIP\"">>node.json
   fi
-  echo "  \"http-host\": \"\"">>node.json
   echo "}" >>node.json
   mkdir -p $HOME/.avalanchego/configs
   cp -f node.json $HOME/.avalanchego/configs/node.json


### PR DESCRIPTION
See issue #673:  "http-host": "" by default is dangerous in avalanchego-installer.sh

See also [this Discord discussion on April 8](https://discord.com/channels/578992315641626624/620633143002660874/962019210790330448): this directive leads to validators leaving their node unprotected, unbeknownst to them.

Tested on an unsuspecting clean server. 