### PR TITLE
DFK node build from source

### DIFF
--- a/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
+++ b/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
@@ -70,6 +70,12 @@ Build AvalancheGo:
 
 The binary, named `avalanchego`, is in `avalanchego/build`. If you've followed the instructions so far, this will be within your `$GOPATH` at: `$GOPATH/src/github.com/ava-labs/avalanchego/build`.
 
+To begin running AvalancheGo, run the following (hit Ctrl+C to stop your node):
+
+```sh
+./build/avalanchego
+```
+
 #### **Binary**
 
 If you want to download a pre-built binary instead of building it yourself, go to our [releases page](https://github.com/ava-labs/avalanchego/releases), and select the release you want (probably the latest one.)

--- a/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
+++ b/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
@@ -146,4 +146,4 @@ To connect to the Fuji Testnet instead of the main net, use argument `--network-
 
 Now that you've launched your Avalanche node, what should you do next?
 
-Your Avalanche node will perform consensus on its own, but the rest of the network won't actually sample it during consensus since it is not yet a validator on the network. If you want to add your node as a validator, check out [Add a Validator](add-a-validator.md) to take it a step further.
+Your Avalanche node will perform consensus on its own, but it is not yet a validator on the network. This means that the rest of the network will not query your node when sampling the network during consensus. If you want to add your node as a validator, check out [Add a Validator](add-a-validator.md) to take it a step further.

--- a/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
+++ b/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
@@ -142,7 +142,7 @@ To be able to make API calls to your node from other machines, when starting up 
 
 To connect to the Fuji Testnet instead of the main net, use argument `--network-id=fuji`. You can get funds on the Testnet from the [faucet.](https://faucet.avax-test.network/)
 
-### What next?
+### What Next?
 
 Now that you've launched your Avalanche node, what should you do next?
 

--- a/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
+++ b/docs/build/tutorials/nodes-and-staking/run-avalanche-node.md
@@ -51,19 +51,16 @@ If you want to build the node from source, you're first going to need to install
 
 Run `go version`. **It should be 1.17.9 or above.** Run `echo $GOPATH`. **It should not be empty.**
 
-Download the AvalancheGo repository:
+Download the AvalancheGo repository into your `$GOPATH`:
 
 ```sh
+cd $GOPATH
+mkdir -p src/github.com/ava-labs
 git clone git@github.com:ava-labs/avalanchego.git
-```
-
-Note: This checkouts to master branch. For the latest stable version, checkout to the latest tag.
-
-Change to the `avalanchego` directory:
-
-```sh
 cd avalanchego
 ```
+
+Note: This checkouts to the master branch. For the latest stable version, checkout the latest tag.
 
 Build AvalancheGo:
 
@@ -71,7 +68,7 @@ Build AvalancheGo:
 ./scripts/build.sh
 ```
 
-The binary, named `avalanchego`, is in `avalanchego/build`.
+The binary, named `avalanchego`, is in `avalanchego/build`. If you've followed the instructions so far, this will be within your `$GOPATH` at: `$GOPATH/src/github.com/ava-labs/avalanchego/build`.
 
 #### **Binary**
 
@@ -139,224 +136,8 @@ To be able to make API calls to your node from other machines, when starting up 
 
 To connect to the Fuji Testnet instead of the main net, use argument `--network-id=fuji`. You can get funds on the Testnet from the [faucet.](https://faucet.avax-test.network/)
 
-### Create a Keystore User
+### What next?
 
-Avalanche nodes provide a built-in **Keystore.** The Keystore manages users and is a lot like a [wallet](http://support.avalabs.org/en/articles/4587108-what-is-a-blockchain-wallet). A user is a password-protected identity that a client can use when interacting with blockchains. **You should only create a keystore user on a node that you operate, as the node operator has access to your plaintext password.** To create a user, call [`keystore.createUser`](../../avalanchego-apis/keystore.md#keystorecreateuser):
+Now that you've launched your Avalanche node, what should you do next?
 
-```sh
-curl -X POST --data '{
-     "jsonrpc": "2.0",
-     "id": 1,
-     "method": "keystore.createUser",
-     "params": {
-         "username": "YOUR USERNAME HERE",
-         "password": "YOUR PASSWORD HERE"
-     }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/keystore
-```
-
-The response should be:
-
-```json
-{
-     "jsonrpc":"2.0",
-     "result":{"success":true},
-     "id":1
-}
-```
-
-Now, you have a user on this node. Keystore data exists at the node level. Users you create on one node’s Keystore do not exist on other nodes but you can import/export users to/from the Keystore. See the [Keystore API](../../avalanchego-apis/keystore.md) to see how.
-
-:::danger
-**You should only keep a small amount of your funds on your node.** Most of your funds should be secured by a mnemonic that is not saved to any computer.
-:::
-
-### Create an Address
-
-Avalanche is a platform of heterogeneous blockchains, one of which is the [X-Chain](../../../learn/platform-overview/README.md#exchange-chain-x-chain), which acts as a decentralized platform for creating and trading digital assets. We are now going to create an address to hold AVAX on our node.
-
-To create a new address on the X-Chain, call [`avm.createAddress`](../../avalanchego-apis/x-chain.mdx#avmcreateaddress), a method of the [X-Chain’s API](../../avalanchego-apis/x-chain.mdx):
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :2,
-    "method" :"avm.createAddress",
-    "params" :{
-        "username":"YOUR USERNAME HERE",
-        "password":"YOUR PASSWORD HERE"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
-If your node isn’t finished bootstrapping, this call will return status `503` with message `API call rejected because chain is not done bootstrapping`.
-
-Note that we make this request to `127.0.0.1:9650/ext/bc/X`. The `bc/X` portion signifies that the request is being sent to the blockchain whose ID (or alias) is `X` (i.e., the X-Chain).
-
-The response should look like this:
-
-```json
-{
-    "jsonrpc":"2.0",
-    "id":2,
-    "result" :{
-        "address":"X-avax1xeaj0h9uy7c5jn6fxjp0rg4g39jeh0hl27vf75"
-    }
-}
-```
-
-Your user now controls the address `X-avax1xeaj0h9uy7c5jn6fxjp0rg4g39jeh0hl27vf75` on the X-Chain. To tell apart addresses on different chains, the Avalanche convention is for an address to include the ID or alias of the chain it exists on. Hence, this address begins `X-`, denoting that it exists on the X-Chain.
-
-### Send Funds From Avalanche Wallet to Your Node
-
-:::caution
-_**Note: the instructions below move real funds.**_
-:::
-
-Let’s move funds from the Avalanche Wallet to your node.
-
-Go to [Avalanche Wallet](https://wallet.avax.network). Click `Access Wallet`, then `Mnemonic Key Phrase`. Enter your mnemonic phrase.
-
-Click the `Send` tab on the left. For amount, select, `.002` AVAX. Enter the address of your node, then click `Confirm`.
-
-![web wallet send tab](/img/web-wallet-send-tab(4)(4)(5)(5)(6)(7)(4)(1)(5).png)
-
-We can check an address’s balance of a given asset by calling `avm.getBalance`, another method of the X-Chain’s API. Let’s check that the transfer went through:
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :3,
-    "method" :"avm.getBalance",
-    "params" :{
-        "address":"X-avax1xeaj0h9uy7c5jn6fxjp0rg4g39jeh0hl27vf75",
-        "assetID"  :"AVAX"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
-Note that AVAX has the special ID `AVAX`. Usually an asset ID is an alphanumeric string.
-
-The response should indicate that we have `2,000,000 nAVAX` or `0.002 AVAX`.
-
-```json
-{
-    "jsonrpc":"2.0",
-    "id"     :3,
-    "result" :{
-        "balance":2000000,
-        "utxoIDs": [
-            {
-                "txID": "x6vR85YPNRf5phpLAEC7Sd6Tq2PXWRt3AAHAK4BpjxyjRyhtu",
-                "outputIndex": 0
-            }
-        ]
-    }
-}
-```
-
-### Send AVAX
-
-Now, let’s send some AVAX by making an API call to our node:
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :5,
-    "method" :"avm.send",
-    "params" :{
-        "assetID"    :"AVAX",
-        "amount"     :1000,
-        "to"         :"X-avax1w4nt49gyv4e99ldqevy50l2kz55y9efghep0cs",
-        "changeAddr" :"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
-        "username"   :"YOUR USERNAME HERE",
-        "password"   :"YOUR PASSWORD HERE"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
-`amount` specifies the number of nAVAX to send.
-
-If you want to specify a particular address where change should go, you can specify it in `changeAddr`. You can leave this field empty; if you do, any change will go to one of the addresses your user controls.
-
-In order to prevent spam, Avalanche requires the payment of a transaction fee. The transaction fee will be automatically deducted from an address controlled by your user when you issue a transaction. Keep that in mind when you’re checking balances below.
-
-:::info
-
-[Transaction Fees](../../../learn/platform-overview/transaction-fees.md)
-
-:::
-
-When you send this request, the node will authenticate you using your username and password. Then, it will look through all the [private keys](http://support.avalabs.org/en/articles/4587058-what-are-public-and-private-keys) controlled by your user until it finds enough AVAX to satisfy the request.
-
-The response contains the transaction’s ID. It will be different for every invocation of `send`.
-
-```json
-{
-    "jsonrpc":"2.0",
-    "id"     :5,
-    "result" :{
-        "txID":"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD",
-        "changeAddr" :"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"
-    }
-}
-```
-
-#### Checking the Transaction Status
-
-This transaction will only take a second or two to finalize. We can check its status with [`avm.getTxStatus`](../../avalanchego-apis/x-chain.mdx#avmgettxstatus):
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :6,
-    "method" :"avm.getTxStatus",
-    "params" :{
-        "txID":"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
-The response should indicate that the transaction was accepted:
-
-```json
-{
-    "jsonrpc":"2.0",
-    "id"     :6,
-    "result" :{
-        "status":"Accepted"
-    }
-}
-```
-
-You might also see that `status` is `Processing` if the network has not yet finalized the transaction.
-
-Once you see that the transaction is `Accepted`, check the balance of the `to` address to see that it has the AVAX we sent:
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :7,
-    "method" :"avm.getBalance",
-    "params" :{
-        "address":"X-avax1w4nt49gyv4e99ldqevy50l2kz55y9efghep0cs",
-        "assetID"  :"AVAX"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
-The response should be:
-
-```json
-{
-    "jsonrpc":"2.0",
-    "id"     :7,
-    "result" :{
-        "balance":1000
-    }
-}
-```
-
-In the same fashion, we could check `X-avax1xeaj0h9uy7c5jn6fxjp0rg4g39jeh0hl27vf75` to see that AVAX we sent was deducted from its balance, as well as the transaction fee.
-
-
+Your Avalanche node will perform consensus on its own, but the rest of the network won't actually sample it during consensus since it is not yet a validator on the network. If you want to add your node as a validator, check out [Add a Validator](add-a-validator.md) to take it a step further.

--- a/docs/build/tutorials/platform/subnets/setup-dfk-node.md
+++ b/docs/build/tutorials/platform/subnets/setup-dfk-node.md
@@ -27,7 +27,7 @@ There is a requirement to run a node on the DFK subnet -
 We'll assume that you have followed the instructions to build AvalancheGo from source in [this guide](../../nodes-and-staking/run-avalanche-node.md) and are still in the AvalancheGo directory.
 ## Build Binary
 
-First, we will assume that you're starting out in the AvalancheGo directory within your `$GOPATH`, and we will clone the DFK subnet-evm repository.
+First, we will assume that you're starting out in the AvalancheGo directory within your `$GOPATH`, and you will clone the DFK subnet-evm repository.
 
 ```bash
 cd $GOPATH/src/github.com
@@ -37,7 +37,7 @@ git clone https://github.com/DefiKingdoms/subnet-evm
 cd subnet-evm
 ```
 
-Now that we are in the DeFiKingdoms/subnet-evm repository, we will build the binary and place it directly into the AvalancheGo `build/plugins` directory by passing in the location on the path we want to place the plugin binary (which was created when building AvalancheGo).
+Now that you are in the DeFiKingdoms/subnet-evm repository, you will build the binary and place it directly into the AvalancheGo `build/plugins` directory. To do this, you will pass in the desired path to place the plugin binary. You will want to place this binary into the plugins directory of AvalancheGo, which was created when building AvalancheGo from source.
 
 ```bash
 ./scripts/build.sh $GOPATH/src/github.com/ava-labs/avalanchego/build/plugins/mDV3QWRXfwgKUWb9sggkv4vQxAQR4y2CyKrt5pLZ5SzQ7EHBv
@@ -47,13 +47,15 @@ The long string `mDV3QWRXfwgKUWb9sggkv4vQxAQR4y2CyKrt5pLZ5SzQ7EHBv` is the CB58 
 
 ## Whitelisting DFK Subnet and Restarting the Node
 
-AvalancheGo will only validate the primary network by default. In order to add the DFK Subnet, we will need to add the DFK Subnet ID to the set of whitelisted subnets in the node's config file or pass it through the command line options of the node. Once the node's config file has been updated, you will need to restart the Avalanche node (if running), or start the node to begin syncing both the Primary Network and the DFK Subnet with the new parameters as well as with the plugin binary in the correct place.
+AvalancheGo will only validate the primary network by default. In order to add the DFK Subnet, you will need to add the DFK Subnet ID to the set of whitelisted subnets in the node's config file or pass it through the command line options of the node. Once the node's config file has been updated, you will need to start the Avalanche node (restart if already running).
+
+Once you start the node, it will begin syncing the Primary Network. Once the node reaches the point in the Platform Chain where the DFK Subnet is created, it will begin syncing the DFK Subnet as well, and will start validating once it has fully bootstrapped.
 
 ### Updating Config File
 
 You can skip this section if you want to pass whitelisted subnets through command-line flags.
 
-You need to edit your existing config file for your node. In this tutorial we will create a config file at: `~/.avalanchego/config.json`. If you are not using any config file, then you can create a JSON file anywhere on your file system and specify the config file when running your AvalancheGo node at the command line.
+You need to edit your existing config file for your node. In this tutorial, you will create a config file at: `~/.avalanchego/config.json`. Note: you can create a config file anywhere on your file system, you will just need to specify its location via the flag `--config-file=<file path>` when you start your node.
 
 You will need to add the DFK Subnet ID to the whitelisted subnets section of the config file:
 
@@ -68,16 +70,20 @@ Whitelisted subnets is a comma separated list of subnet IDs, so if you are valid
 
 ### Running the Node
 
-First, make sure to shut down your node in case it is still running. Then, we will navigate back into the AvalancheGo directory and launch the node.
+First, make sure to shut down your node in case it is still running. Then, you will navigate back into the AvalancheGo directory:
+
+```bash
+cd $GOPATH/src/github.com/ava-labs/avalanchego
+```
 
 If you went through the steps to set up a config file, then you can launch your node by specifying the config file on the command line:
 
 ```bash
-./avalanchego/build/avalanchego --config-file ~/.avalanchego/config.json
+./build/avalanchego --config-file ~/.avalanchego/config.json
 ```
 
 If you want to pass the whitelisted subnets through the command line flag. You can append the other flags or even the `--config-file` flag as well, according to your need.
 
 ```bash
-./avalanchego/build/avalanchego --whitelisted-subnets Vn3aX6hNRstj5VHHm63TCgPNaeGnRSqCYXQqemSqDd2TQH4qJ
+./build/avalanchego --whitelisted-subnets Vn3aX6hNRstj5VHHm63TCgPNaeGnRSqCYXQqemSqDd2TQH4qJ
 ```

--- a/docs/build/tutorials/platform/subnets/setup-dfk-node.md
+++ b/docs/build/tutorials/platform/subnets/setup-dfk-node.md
@@ -2,10 +2,6 @@
 
 ## Introduction
 
-We recently deployed the DFK subnet on Avalanche mainnet and successfully launched the [DFK chain](https://subnets.avax.network/defi-kingdoms/dfk-chain/explorer) on that subnet. This subnet is maintained by the [DeFi Kingdom](https://defikingdoms.com/)'s team and is based on Avalanche's [subnet-evm](https://github.com/ava-labs/subnet-evm).
-
-A subnet, or subnetwork, is a dynamic set of validators working together to achieve consensus on the state of a set of blockchains. Each blockchain is validated by exactly one subnet. A subnet can validate many blockchains. A node may be a member of many subnets. You can learn more about subnets [here](../subnets/README.md).
-
 [DeFi Kingdom](https://defikingdoms.com/) recently launched the [DFK Subnet](https://subnets.avax.network/defi-kingdoms/dfk-chain/explorer).
 
 This tutorial will take you through the necessary steps to run your node on the DFK Subnet:

--- a/docs/build/tutorials/platform/subnets/setup-dfk-node.md
+++ b/docs/build/tutorials/platform/subnets/setup-dfk-node.md
@@ -6,46 +6,56 @@ We recently deployed the DFK subnet on Avalanche mainnet and successfully launch
 
 A subnet, or subnetwork, is a dynamic set of validators working together to achieve consensus on the state of a set of blockchains. Each blockchain is validated by exactly one subnet. A subnet can validate many blockchains. A node may be a member of many subnets. You can learn more about subnets [here](../subnets/README.md).
 
+[DeFi Kingdom](https://defikingdoms.com/) recently launched the [DFK Subnet](https://subnets.avax.network/defi-kingdoms/dfk-chain/explorer).
+
+This tutorial will take you through the necessary steps to run your node on the DFK Subnet:
+
+1) Build the AvalancheGo build directory
+2) Build the plugin binary for the DFK subnet-evm
+3) Whitelist the DFK Subnet
+4) Run your node and validate the DFK Subnet!
+
 ## Requirement
 
 There is a requirement to run a node on the DFK subnet - 
 
-* You must be running a node on the Avalanche Primary Network. You can use this [guide](../../nodes-and-staking/set-up-node-with-installer) to set up your node using the installer script.
-* You are using the same system where you have deployed your mainnet node.
+* You must be running a node on the Avalanche Primary Network. You can use this [guide](../../nodes-and-staking/run-avalanche-node.md) to set up your Avalanche node by building from source (recommended for this tutorial).
+* You should be using the same machine as where you build AvalancheGo from source.
 
 ## Setup
 
-Let's make a separate directory `dfk-subnet` for keeping and building our binaries. Move to the following directory and follow the rest of the tutorial.
-
+We'll assume that you have followed the instructions to build AvalancheGo from source in [this guide](../../nodes-and-staking/run-avalanche-node.md) and are still in the AvalancheGo directory.
 ## Build Binary
 
-Clone the Defi Kindom's subnet-evm repository which is originally forked from Avalanche's subnet-evm. And build it using the following command.
+First, we will assume that you're starting out in the AvalancheGo directory within your `$GOPATH`, and we will clone the DFK subnet-evm repository.
 
 ```bash
-git clone https://github.com/DefiKingdoms/subnet-evm \
-&& cd subnet-evm \
-&& ./scripts/build.sh build/mDV3QWRXfwgKUWb9sggkv4vQxAQR4y2CyKrt5pLZ5SzQ7EHBv
+cd $GOPATH/src/github.com
+mkdir DeFiKingdoms
+cd DeFiKingdoms
+git clone https://github.com/DefiKingdoms/subnet-evm
+cd subnet-evm
 ```
 
-The above command will clone the `subnet-evm` repository and build its binary inside the `subnet-evm/build` directory. The name of the binary will be the same as its vmID.
-
-## Move Binary to Plugins Directory
-
-Now we need to move the built binary to the `avalanchego/build/plugins` directory. Run the following command to move the binary to the `plugins` folder. Make sure to use the actual location of your `avalanchego` source and other relative paths. This command assumes we are in the `dfk-subnet` folder and the `avalanchego` source is in its sibling (.\./) folder.
+Now that we are in the DeFiKingdoms/subnet-evm repository, we will build the binary and place it directly into the AvalancheGo `build/plugins` directory by passing in the location on the path we want to place the plugin binary (which was created when building AvalancheGo).
 
 ```bash
-mv subnet-evm/build/mDV3QWRXfwgKUWb9sggkv4vQxAQR4y2CyKrt5pLZ5SzQ7EHBv ../avalanchego/build/plugins/
+./scripts/build.sh $GOPATH/src/github.com/ava-labs/avalanchego/build/plugins/mDV3QWRXfwgKUWb9sggkv4vQxAQR4y2CyKrt5pLZ5SzQ7EHBv
 ```
+
+The long string `mDV3QWRXfwgKUWb9sggkv4vQxAQR4y2CyKrt5pLZ5SzQ7EHBv` is the CB58 encoded VMID of the DFK subnet-evm. AvalancheGo will use the name of this file to determine what VMs are available to run from the `plugins` directory.
 
 ## Whitelisting DFK Subnet and Restarting the Node
 
-To start syncing the state with the chains on a subnet, we need to whitelist the subnet and restart the node. You can either add the whitelisted subnets in a config file or pass them through command-line options.
+AvalancheGo will only validate the primary network by default. In order to add the DFK Subnet, we will need to add the DFK Subnet ID to the set of whitelisted subnets in the node's config file or pass it through the command line options of the node. Once the node's config file has been updated, you will need to restart the Avalanche node (if running), or start the node to begin syncing both the Primary Network and the DFK Subnet with the new parameters as well as with the plugin binary in the correct place.
 
 ### Updating Config File
 
 You can skip this section if you want to pass whitelisted subnets through command-line flags.
 
-You need to edit your existing config file for your node. If you are running a node using [installer script](../../nodes-and-staking/set-up-node-with-installer), it can be found in `~/.avalanchego/configs/node.json`. If you are not using any config file, then you can make it anywhere on your system. Update this JSON file with the whitelisted subnet. 
+You need to edit your existing config file for your node. In this tutorial we will create a config file at: `~/.avalanchego/config.json`. If you are not using any config file, then you can create a JSON file anywhere on your file system and specify the config file when running your AvalancheGo node at the command line.
+
+You will need to add the DFK Subnet ID to the whitelisted subnets section of the config file:
 
 ```json
 {
@@ -54,18 +64,20 @@ You need to edit your existing config file for your node. If you are running a n
 }
 ```
 
-### Restarting the Node
+Whitelisted subnets is a comma separated list of subnet IDs, so if you are validating more than one subnet, you can simply add a comma to the end of the list and append the DFK Subnet ID `Vn3aX6hNRstj5VHHm63TCgPNaeGnRSqCYXQqemSqDd2TQH4qJ`.
+
+### Running the Node
+
+First, make sure to shut down your node in case it is still running. Then, we will navigate back into the AvalancheGo directory and launch the node.
+
+If you went through the steps to set up a config file, then you can launch your node by specifying the config file on the command line:
+
+```bash
+./avalanchego/build/avalanchego --config-file ~/.avalanchego/config.json
+```
 
 If you want to pass the whitelisted subnets through the command line flag. You can append the other flags or even the `--config-file` flag as well, according to your need.
 
 ```bash
-./avalanchego/build/avalanchego --whitelisted-subnets mDV3QWRXfwgKUWb9sggkv4vQxAQR4y2CyKrt5pLZ5SzQ7EHBv
+./avalanchego/build/avalanchego --whitelisted-subnets Vn3aX6hNRstj5VHHm63TCgPNaeGnRSqCYXQqemSqDd2TQH4qJ
 ```
-
-If you want to pass the whitelisted subnets through the config file.
-
-```bash
-./avalanchego/build/avalanchego --config-file ./config.json
-```
-
-Use the relative paths of binaries and config files as per your need.


### PR DESCRIPTION
This PR updates the DFK Node tutorial to build AvalancheGo directly from source to make it simpler to manage for this tutorial.