### PR TITLE
Update subnetevm.decodeBlock example script

### DIFF
--- a/docs/subnets/create-evm-blockchain.md
+++ b/docs/subnets/create-evm-blockchain.md
@@ -254,7 +254,6 @@ You can also issue a `subnetevm.decodeBlock` to make sure your encoded genesis b
 
 ```sh
 curl -X POST --data '{
-    {
     "jsonrpc": "2.0",
     "id"     : 1,
     "method" : "subnetevm.decodeGenesis",


### PR DESCRIPTION
There was an unnecessary '{' inside the subnetevm.decodeBlock example script causing command line to throw an error, I have removed it.