### PR TITLE
Bech32 encoding in AvalancheJS

### DIFF
--- a/docs/apis/avalanchejs/manage-x-chain-keys.md
+++ b/docs/apis/avalanchejs/manage-x-chain-keys.md
@@ -1,6 +1,6 @@
 # Manage X-Chain Keys
 
-AvalancheJS comes with its own AVM Keychain. This KeyChain is used in the functions of the API, enabling them to sign using keys it’s registered. The first step in this process is to create an instance of AvalancheJS connected to our Avalanche platform endpoint of choice.
+AvalancheJS comes with its own AVM Keychain. This KeyChain is used in the functions of the API, enabling them to sign using keys it&rsquo;s registered. The first step in this process is to create an instance of AvalancheJS connected to our Avalanche platform endpoint of choice.
 
 ```ts
 import {
@@ -52,7 +52,7 @@ let newAddress2 = myKeychain.importKey(mypk); //returns a Buffer for the address
 
 ## Working with Keychains {#working-with-keychains}
 
-The X-Chains’s KeyChain has standardized key management capabilities. The following functions are available on any KeyChain that implements this interface.
+The X-Chain&rsquo;s KeyChain has standardized key management capabilities. The following functions are available on any KeyChain that implements this interface.
 
 ```text
 let addresses = myKeychain.getAddresses(); //returns an array of Buffers for the addresses
@@ -63,7 +63,7 @@ let keypair = myKeychain.getKey(newAddress1); //returns the KeyPair class
 
 ## Working with Keypairs {#working-with-keypairs}
 
-The X-Chain’s KeyPair has standardized KeyPair functionality. The following operations are available on any KeyPair that implements this interface.
+The X-Chain&rsquo;s KeyPair has standardized KeyPair functionality. The following operations are available on any KeyPair that implements this interface.
 
 ```ts
 let address = keypair.getAddress(); //returns Buffer
@@ -89,12 +89,12 @@ let isValid = keypair.verify(message, signature); //returns a boolean
 
 ## Encode Bech32 Addresses {#encode-bech32-addresses}
 
-The X-Chain and the P-Chain use Bech32 to encode addresses. Note, the C-Chain also uses Bech32 to encode addresses for importing and exporting assets however the EVM, in general, uses the hex encoding ex: `0x46f3e64E4e3f5a46Eaf5c292301c6174B9B646Bf`.
+The X-Chain and the P-Chain use Bech32 to encode addresses. Note, the C-Chain also uses Bech32 to encode addresses for importing and exporting assets however the EVM, in general, uses hex encoding for addresses. Ex: `0x46f3e64E4e3f5a46Eaf5c292301c6174B9B646Bf`.
 
 Each Bech32 address is composed of the following components
 
 1. A Human-Readable Part (HRP).
-2. The number “1” is a separator (the last digit 1 seen is considered the separator).
+2. The number `1` is a separator (the last digit `1` seen is considered the separator).
 3. Base-32 encoded string for the data part of the address (the 20-byte address itself).
 4. A 6-character base-32 encoded error correction code using the BCH algorithm.
 
@@ -105,7 +105,7 @@ For example the following Bech32 address, `X-avax19rknw8l0grnfunjrzwxlxync6zrlu3
 3. Address: `9rknw8l0grnfunjrzwxlxync6zrlu33y`
 4. Checksum: `2jxhrg`
 
-Depending on the `networkID` which is passed in when instantiating `Avalanche` the encoded addresses will have a distinctive HRP per each network. AvalancheJS has address encoding for past networks.
+Depending on the `networkID` which is passed in when instantiating `Avalanche` the encoded addresses will have a distinctive HRP per each network. AvalancheJS also has address encoding for past networks `cascade`, `denali`, and `everest`.
 
 * 0 - X-`custom`19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya
 * 1 - X-`avax`19rknw8l0grnfunjrzwxlxync6zrlu33y2jxhrg
@@ -116,7 +116,7 @@ Depending on the `networkID` which is passed in when instantiating `Avalanche` t
 * 1337 - X-`custom`19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya
 * 12345 - X-`local`19rknw8l0grnfunjrzwxlxync6zrlu33ynpm3qq
 
-Here is the mapping of `networkID` to bech32 HRP.
+Here&rsquo;s the mapping of `networkID` to bech32 HRP.
 
 ```ts
 export const NetworkIDToHRP = {

--- a/docs/apis/avalanchejs/manage-x-chain-keys.md
+++ b/docs/apis/avalanchejs/manage-x-chain-keys.md
@@ -98,6 +98,13 @@ Each Bech32 address is composed of the following components
 3. Base-32 encoded string for the data part of the address (the 20-byte address itself).
 4. A 6-character base-32 encoded error correction code using the BCH algorithm.
 
+For example the following Bech32 address, `X-avax19rknw8l0grnfunjrzwxlxync6zrlu33y2jxhrg`, is composed like so:
+
+1. `avax`
+2. `1`
+3. `9rknw8l0grnfunjrzwxlxync6zrlu33y`
+4. `2jxhrg`
+
 Depending on the `networkID` which is passed in when instantiating `Avalanche` the encoded addresses will have a distinctive HRP per each network. AvalancheJS has address encoding for past networks.
 
 * 0 - X-`custom`19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya

--- a/docs/apis/avalanchejs/manage-x-chain-keys.md
+++ b/docs/apis/avalanchejs/manage-x-chain-keys.md
@@ -1,6 +1,6 @@
 # Manage X-Chain Keys
 
-AvalancheJS comes with its own AVM Keychain. This KeyChain is used in the functions of the API, enabling them to sign using keys it&rsquo;s registered. The first step in this process is to create an instance of AvalancheJS connected to our Avalanche platform endpoint of choice.
+AvalancheJS comes with its own AVM Keychain. This KeyChain is used in the functions of the API, enabling them to sign using keys it's registered. The first step in this process is to create an instance of AvalancheJS connected to our Avalanche platform endpoint of choice.
 
 ```ts
 import {
@@ -52,7 +52,7 @@ let newAddress2 = myKeychain.importKey(mypk); //returns a Buffer for the address
 
 ## Working with Keychains {#working-with-keychains}
 
-The X-Chain&rsquo;s KeyChain has standardized key management capabilities. The following functions are available on any KeyChain that implements this interface.
+The X-Chain's KeyChain has standardized key management capabilities. The following functions are available on any KeyChain that implements this interface.
 
 ```text
 let addresses = myKeychain.getAddresses(); //returns an array of Buffers for the addresses
@@ -63,7 +63,7 @@ let keypair = myKeychain.getKey(newAddress1); //returns the KeyPair class
 
 ## Working with Keypairs {#working-with-keypairs}
 
-The X-Chain&rsquo;s KeyPair has standardized KeyPair functionality. The following operations are available on any KeyPair that implements this interface.
+The X-Chain's KeyPair has standardized KeyPair functionality. The following operations are available on any KeyPair that implements this interface.
 
 ```ts
 let address = keypair.getAddress(); //returns Buffer
@@ -116,7 +116,7 @@ Depending on the `networkID` which is passed in when instantiating `Avalanche` t
 * 1337 - X-`custom`19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya
 * 12345 - X-`local`19rknw8l0grnfunjrzwxlxync6zrlu33ynpm3qq
 
-Here&rsquo;s the mapping of `networkID` to bech32 HRP.
+Here's the mapping of `networkID` to bech32 HRP.
 
 ```ts
 export const NetworkIDToHRP = {

--- a/docs/apis/avalanchejs/manage-x-chain-keys.md
+++ b/docs/apis/avalanchejs/manage-x-chain-keys.md
@@ -100,10 +100,10 @@ Each Bech32 address is composed of the following components
 
 For example the following Bech32 address, `X-avax19rknw8l0grnfunjrzwxlxync6zrlu33y2jxhrg`, is composed like so:
 
-1. `avax`
-2. `1`
-3. `9rknw8l0grnfunjrzwxlxync6zrlu33y`
-4. `2jxhrg`
+1. HRP: `avax`
+2. Separator: `1`
+3. Address: `9rknw8l0grnfunjrzwxlxync6zrlu33y`
+4. Checksum: `2jxhrg`
 
 Depending on the `networkID` which is passed in when instantiating `Avalanche` the encoded addresses will have a distinctive HRP per each network. AvalancheJS has address encoding for past networks.
 

--- a/docs/apis/avalanchejs/manage-x-chain-keys.md
+++ b/docs/apis/avalanchejs/manage-x-chain-keys.md
@@ -86,3 +86,78 @@ let signature = keypair.sign(message); //returns a Buffer with the signature
 let signerPubk = keypair.recover(message, signature);
 let isValid = keypair.verify(message, signature); //returns a boolean
 ```
+
+## Encode Bech32 Addresses {#encode-bech32-addresses}
+
+The X-Chain and the P-Chain use Bech32 to encode addresses. Note, the C-Chain also uses Bech32 to encode addresses for importing and exporting assets however the EVM, in general, uses the hex encoding ex: `0x46f3e64E4e3f5a46Eaf5c292301c6174B9B646Bf`.
+
+Each Bech32 address is composed of the following components
+
+1. A Human-Readable Part (HRP).
+2. The number “1” is a separator (the last digit 1 seen is considered the separator).
+3. Base-32 encoded string for the data part of the address (the 20-byte address itself).
+4. A 6-character base-32 encoded error correction code using the BCH algorithm.
+
+Depending on the `networkID` which is passed in when instantiating `Avalanche` the encoded addresses will have a distinctive HRP per each network. AvalancheJS has address encoding for past networks.
+
+* 0 - X-`custom`19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya
+* 1 - X-`avax`19rknw8l0grnfunjrzwxlxync6zrlu33y2jxhrg
+* 2 - X-`cascade`19rknw8l0grnfunjrzwxlxync6zrlu33ypmtvnh
+* 3 - X-`denali`19rknw8l0grnfunjrzwxlxync6zrlu33yhc357h
+* 4 - X-`everest`19rknw8l0grnfunjrzwxlxync6zrlu33yn44wty
+* 5 - X-`fuji`19rknw8l0grnfunjrzwxlxync6zrlu33yxqzg0h
+* 1337 - X-`custom`19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya
+* 12345 - X-`local`19rknw8l0grnfunjrzwxlxync6zrlu33ynpm3qq
+
+Here is the mapping of `networkID` to bech32 HRP.
+
+```ts
+export const NetworkIDToHRP = {
+  0: "custom",
+  1: "avax",
+  2: "cascade",
+  3: "denali",
+  4: "everest",
+  5: "fuji",
+  1337: "custom",
+  12345: "local"
+}
+```
+
+Change the HRP of the bech32 address by passing in a different networkID when instantiating `Avalanche`.
+
+```ts
+// mainnet
+const networkID = 1
+const avalanche = new Avalanche(undefined, undefined, undefined, networkID)
+
+// [ 'X-avax1j2j0vzttatv73gr7j4tnd7rp4el3ngcyjy0pre' ]
+// [ 'X-avax19rknw8l0grnfunjrzwxlxync6zrlu33y2jxhrg' ]
+```
+
+```ts
+// fuji
+const networkID = 5
+const avalanche = new Avalanche(undefined, undefined, undefined, networkID)
+
+// [ 'X-fuji1j2j0vzttatv73gr7j4tnd7rp4el3ngcy7kt70x' ]
+// [ 'X-fuji19rknw8l0grnfunjrzwxlxync6zrlu33yxqzg0h' ]
+```
+
+```ts
+// custom
+const networkID = 1337 // also networkID = 0
+const avalanche = new Avalanche(undefined, undefined, undefined, networkID)
+
+// [ 'X-custom1j2j0vzttatv73gr7j4tnd7rp4el3ngcyp7amyv' ]
+// [ 'X-custom19rknw8l0grnfunjrzwxlxync6zrlu33yeg5dya' ]
+```
+
+```ts
+// mainnet
+const networkID = 12345
+const avalanche = new Avalanche(undefined, undefined, undefined, networkID)
+
+// [ 'X-local1j2j0vzttatv73gr7j4tnd7rp4el3ngcythj8q3' ]
+// [ 'X-local19rknw8l0grnfunjrzwxlxync6zrlu33ynpm3qq' ]
+```


### PR DESCRIPTION
Add section describing how to encode addresses as Bech32 with correct HRP per `networkID`.