### PR TITLE
Update node name in guide to match command

### DIFF
--- a/docs/quickstart/network-runner.md
+++ b/docs/quickstart/network-runner.md
@@ -260,7 +260,7 @@ avalanche-network-runner control restart-node \
 
 #### add a node
 
-In this example we are adding a node named `node1`.
+In this example we are adding a node named `node99`.
 
 ```bash
 # e.g., ${HOME}/go/src/github.com/ava-labs/avalanchego/build/avalanchego


### PR DESCRIPTION
Just a minor edit, the commands start a node named `node99` but the guide says that it is adding a node named `node1`, so this will just edit the latter so it matches the commands.