### PR TITLE
corrected GCP validator terraform link

### DIFF
--- a/docs/nodes/build/set-up-an-avalanche-node-with-google-cloud-platform.md
+++ b/docs/nodes/build/set-up-an-avalanche-node-with-google-cloud-platform.md
@@ -109,7 +109,7 @@ I recommend to employ a full CI/CD pipeline using GCP Cloud Build which if utili
 
 ### Clone Github Repository
 
-I have provided a rudimentary terraform construct to provision a node on which to run Avalanche which can be found [here](/scripts/terraform-gcp/projects/my-avax-project/main.tf).
+I have provided a rudimentary terraform construct to provision a node on which to run Avalanche which can be found [here](https://github.com/ava-labs/avalanche-docs/tree/master/static/scripts/terraform-gcp/projects/my-avax-project).
 Documentation below assumes you are using this repository but if you have another terraform skelaton similar steps will apply.
 
 ### Terraform Configuration


### PR DESCRIPTION
The GCP validator setup instructions included a link intended to go to the related terraform project folder, however the link incorrectly went to just one of the terraform files without an obvious route to the intended location. 

Once the prior markdown was live, the link went to "https://docs.avax.network/assets/files/main-33a196cb120b7d974de0b4537d31130a.tf" which is one of the files in the project repo, but not obvious on where the github repo actually was.