### PR TITLE
Specify directory where upgrade.json needs to be placed

### DIFF
--- a/docs/subnets/customize-a-subnet.md
+++ b/docs/subnets/customize-a-subnet.md
@@ -453,7 +453,7 @@ Any mistakes in configuring network upgrades or coordinating them on validators 
 
 In addition to specifying the configuration for each of the above precompiles in the genesis chain config, they can be individually enabled or disabled at a given timestamp as a network upgrade. Disabling a precompile disables calling the precompile and destructs its storage so it can be enabled at a later timestamp with a new configuration if desired.
 
-These upgrades can be specified in a file named `upgrade.json` placed in the same directory as [`config.json`](#chain-configs) (`{chain-config-dir}/{blockchainID}/upgrade.json`) using the following format:
+These upgrades must be specified in a file named `upgrade.json` placed in the same directory where [`config.json`](#chain-configs) resides: `{chain-config-dir}/{blockchainID}/upgrade.json`, using the following format:
 
 ```json
 {

--- a/docs/subnets/customize-a-subnet.md
+++ b/docs/subnets/customize-a-subnet.md
@@ -453,7 +453,7 @@ Any mistakes in configuring network upgrades or coordinating them on validators 
 
 In addition to specifying the configuration for each of the above precompiles in the genesis chain config, they can be individually enabled or disabled at a given timestamp as a network upgrade. Disabling a precompile disables calling the precompile and destructs its storage so it can be enabled at a later timestamp with a new configuration if desired.
 
-These upgrades can be specified in a file named `upgrade.json` placed in the same directory as [`config.json`](#chain-configs) using the following format:
+These upgrades can be specified in a file named `upgrade.json` placed in the same directory as [`config.json`](#chain-configs) (`{chain-config-dir}/{blockchainID}/upgrade.json`) using the following format:
 
 ```json
 {


### PR DESCRIPTION
This PR makes the subnet-evm network upgrade docs specifically reference where the `upgrade.json` file needs to be placed.