### PR TITLE
fix: modify "pruning-enabled" field to bool type

### DIFF
--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -60,7 +60,7 @@ create_config_file () {
   rm -f config.json
   echo "{" >>config.json
   if [ "$archivalOpt" = "true" ]; then
-    echo "  \"pruning-enabled\": \"false\"">>config.json
+    echo "  \"pruning-enabled\": false">>config.json
   fi
   echo "}" >>config.json
   mkdir -p $HOME/.avalanchego/configs/chains/C


### PR DESCRIPTION
I use `./avalanchego-installer.sh --archival --fuji`

main.log prints out Fatal
```
[08-31|08:33:21.419] FATAL chains/manager.go:287 error creating required chain {"chainID": "yH8xxxxxxxxxx----NfcdoSxxxxx", "error": "error while creating new snowman vm failed to unmarshal config {\n  \"pruning-enabled\": \"false\"\n}\n: json: cannot unmarshal string into Go
struct field Config.pruning-enabled of type bool"}
```

so my colleague modify "pruning-enabled" field to bool type is working.
```
{
  "pruning-enabled": false
}
```