### PR TITLE
Update the path for the WAGMI genesis json file.

### DIFF
--- a/docs/subnets/wagmi.md
+++ b/docs/subnets/wagmi.md
@@ -15,7 +15,7 @@ The WAGMI ("We're All Going to Make It") Subnet Demo is a high throughput testbe
 - Min Fee: 1 GWei (4% of C-Chain)
 - Target Block Rate: 2s (Same as C-Chain)
 
-Genesis file of WAGMI can be found [here](https://github.com/ava-labs/subnet-evm/blob/master/networks/11111/genesis.json).
+Genesis file of WAGMI can be found [here](https://github.com/ava-labs/subnet-evm/blob/master/networks/testnet/11111/genesis.json).
 
 Everyone that has used the the C-Chain more than twice (~970k addresses) has been airdropped 10 WGM tokens. With the current fee parameterization, this should be enough for hundreds of txs.
 


### PR DESCRIPTION
[The current path](https://github.com/ava-labs/subnet-evm/blob/master/networks/11111/genesis.json) for the WAGMI genesis json file is broken. This PR updates the broke path with [the correct path](https://github.com/ava-labs/subnet-evm/blob/master/networks/testnet/11111/genesis.json).