### PR TITLE
Correct ANR Installation Command

### DIFF
--- a/docs/subnets/network-runner.md
+++ b/docs/subnets/network-runner.md
@@ -28,7 +28,7 @@ To build and install the binary locally (requires `golang` to be installed. Chec
 
 ```bash
 cd ${HOME}/go/src/github.com/ava-labs/avalanche-network-runner
-go install -v ./cmd/avalanche-network-runner
+go install -v ./cmd
 ```
 
 `avalanche-network-runner` will be installed into `$GOPATH/bin`, please make sure that `$GOPATH/bin` is in your `$PATH`, otherwise, you may not be able to run commands below.

--- a/docs/subnets/network-runner.md
+++ b/docs/subnets/network-runner.md
@@ -12,26 +12,14 @@ The ANR aims at being a tool for developers and system integrators alike, offeri
 
 ## Installation
 
-The Avalanche Network Runner repository is hosted at [https://github.com/ava-labs/avalanche-network-runner](https://github.com/ava-labs/avalanche-network-runner).
-
-That repository's README details the tool.
-
-Clone the repository with:
-
 ```bash
-git clone https://github.com/ava-labs/avalanche-network-runner.git
+curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s -- -b $GOPATH/bin
+
+cd $GOPATH/bin
+export PATH=$PWD:$PATH
 ```
 
-There are also binary releases ready to use at [releases](https://github.com/ava-labs/avalanche-network-runner/releases).
-
-To build and install the binary locally (requires `golang` to be installed. Check the [requirements](https://github.com/ava-labs/avalanchego#installation) for the minimum version):
-
-```bash
-cd ${HOME}/go/src/github.com/ava-labs/avalanche-network-runner
-go install -v ./cmd
-```
-
-`avalanche-network-runner` will be installed into `$GOPATH/bin`, please make sure that `$GOPATH/bin` is in your `$PATH`, otherwise, you may not be able to run commands below.
+`avalanche-network-runner` will be installed into `$GOPATH/bin`. 
 
 Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related to Avalanche Network Runner. We strongly recommend that you put the following in to your shell's configuration file.
 


### PR DESCRIPTION
Quick correction to installation instructions for ANR. 


 I've gotten some feedback that some of the installation instructions are wrong or unclear.
For example
`go install -v ./cmd/avalanche-network-runner`
should be
`go install -v ./cmd/`


Removed those instructions and added the standard curl command. 