### PR TITLE
Address style nit

### DIFF
--- a/.github/styles/Vocab/Products/accept.txt
+++ b/.github/styles/Vocab/Products/accept.txt
@@ -16,7 +16,6 @@ Avalanche-CLI
 AvalancheGo
 Avascan
 AVAX
-blackhole
 blockchain
 Blockchain
 blockchains

--- a/.github/styles/custom/RejectedForms.yml
+++ b/.github/styles/custom/RejectedForms.yml
@@ -8,3 +8,4 @@ swap:
   "(?i)abi": ABI
   "(?i)abis": ABIs
   "(?i)repos?": repository
+  "(?i)blackholes?": black hole

--- a/docs/subnets/customize-a-subnet.md
+++ b/docs/subnets/customize-a-subnet.md
@@ -683,7 +683,7 @@ In addition to the `AllowList` interface, the `RewardManager` adds the following
 - `disableRewards` - disables block rewards and starts burning fees.
 
 - `currentRewardAddress` - returns the current reward address. This is the address to which fees are
-  sent. It can include blackhole address (`0x010...0`) which means that fees are burned. It can also
+  sent. It can include black hole address (`0x010...0`) which means that fees are burned. It can also
   include a predefined hash (`0x0000000000000000000000000000000000000000`) denoting custom fee
   recipients are allowed. It's advised to use the `areFeeRecipientsAllowed` function to check if
   custom fee recipients are allowed first.


### PR DESCRIPTION
Standardize the spelling of `black hole` which I noticed on my big style pass. We used it a couple different ways.