### PR TITLE
Add Chainstack provider to the public-api-server page

### DIFF
--- a/docs/apis/avalanchego/public-api-server.md
+++ b/docs/apis/avalanchego/public-api-server.md
@@ -211,6 +211,12 @@ P-Chain, C-Chain, and Index API.
 
 [Chainstack](https://chainstack.com/) supports the C-Chain, X-Chain, P-Chain, and the Fuji Testnet.
 
+Features:
+
+- Globally distributed infrastructure for optimal performance.
+- Crypto payments natively.
+- 24/7 customer support.
+
 #### Mainnet
 
 ##### HTTP

--- a/docs/apis/avalanchego/public-api-server.md
+++ b/docs/apis/avalanchego/public-api-server.md
@@ -209,7 +209,7 @@ P-Chain, C-Chain, and Index API.
 
 ### Chainstack
 
-[Chainstack](https://chainstack.com/) supports the C-Chain, X-Chain, P-Chain, and the Fuji Testnet.
+[Chainstack](https://chainstack.com/build-better-with-avalanche/) supports the C-Chain, X-Chain, P-Chain, and the Fuji Testnet.
 
 Features:
 

--- a/docs/apis/avalanchego/public-api-server.md
+++ b/docs/apis/avalanchego/public-api-server.md
@@ -206,3 +206,37 @@ P-Chain, C-Chain, and Index API.
 #### Websockets
 
 - The URL is  `wss://sample-endpoint-name.network.quiknode.pro/token-goes-here/`
+
+### Chainstack
+
+[Chainstack](https://chainstack.com/) supports the C-Chain, X-Chain, P-Chain, and the Fuji Testnet.
+
+#### Mainnet
+
+##### HTTP
+
+- For C-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/rpc`
+- For X-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/bc/X/`
+- For P-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/P`
+
+##### Websockets
+
+Websockets are available for the C-chain and the X-chain.
+
+- For C-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`
+- For X-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/bc/X/events`
+
+#### Testnet (Fuji)
+
+##### HTTP
+
+- For C-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/rpc`
+- For X-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/bc/X/`
+- For P-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/P`
+
+##### Websockets
+
+Websockets are available for the C-chain and the X-chain.
+
+- For C-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`
+- For X-Chain API, the URL is `https://nd-123-145-789.p2pify.com/API_KEY/ext/bc/X/events`


### PR DESCRIPTION
Add details about the Chainstack provider public-API-server page. 

I followed the same pattern that the other providers listed on the page use. 
Thank you and let me know if you need any additional modifications. 