### PR TITLE
use install script for ANR

### DIFF
--- a/docs/quickstart/create-a-local-test-network.md
+++ b/docs/quickstart/create-a-local-test-network.md
@@ -17,22 +17,22 @@ The Avalanche Network Runner repository is hosted at [https://github.com/ava-lab
 
 That repository's README details the tool.
 
-Clone the repository with:
+To download a binary for the latest release, run:
 
-```bash
-git clone https://github.com/ava-labs/avalanche-network-runner.git
+```shell
+curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s
 ```
 
-There are also binary releases ready to use at [releases](https://github.com/ava-labs/avalanche-network-runner/releases). You can download and install it on to your computer.
+The script installs the binary inside the `~/bin` directory.
 
-To build from the source and install the binary locally (requires `golang` to be installed. Check the [requirements](https://github.com/ava-labs/avalanchego#installation) for the minimum version):
+Please make sure that `~/bin` is in your `$PATH`:
 
-```bash
-cd ${HOME}/go/src/github.com/ava-labs/avalanche-network-runner
-go install -v ./cmd/avalanche-network-runner
+```shell
+export PATH=~/bin:$PATH
 ```
 
-`avalanche-network-runner` will be installed into `$GOPATH/bin`, please make sure that `$GOPATH/bin` is in your `$PATH`, otherwise, you may not be able to run commands below.
+To add it to your path permanently, add an export command to your shell initialization script. If
+you run Ubuntu, use `.bashrc`. Mac uses `.zshrc`.
 
 Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related to Avalanche Network Runner. We strongly recommend that you put the following in to your shell's configuration file.
 

--- a/docs/quickstart/create-a-local-test-network.md
+++ b/docs/quickstart/create-a-local-test-network.md
@@ -34,7 +34,9 @@ export PATH=~/bin:$PATH
 To add it to your path permanently, add an export command to your shell initialization script. If
 you run Ubuntu, use `.bashrc`. Mac uses `.zshrc`.
 
-Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related to Avalanche Network Runner. We strongly recommend that you put the following in to your shell's configuration file.
+Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related to
+Avalanche Network Runner. We strongly recommend that you put the following in to your shell's configuration
+file.
 
 ```bash
 # replace execPath with the path to AvalancheGo on your machine
@@ -44,7 +46,8 @@ AVALANCHEGO_EXEC_PATH="${HOME}/go/src/github.com/ava-labs/avalanchego/build/aval
 
 Unless otherwise specified, file paths given below are relative to the root of this repository.
 
-When running with the binary `avalanche-network-runner`, it runs a server process as an RPC server which then waits for API calls and handles them.
+When running with the binary `avalanche-network-runner`, it runs a server process as an RPC server which
+then waits for API calls and handles them.
 Therefore we run one shell with the RPC server, and another one for issuing calls.
 
 ### Start the Server
@@ -56,15 +59,18 @@ avalanche-network-runner server \
 --grpc-gateway-port=":8081"
 ```
 
-Note that the above command will run until you stop it with `CTRL + C`. Further commands will have to be run in a separate terminal.
+Note that the above command will run until you stop it with `CTRL + C`. Further commands will have to
+be run in a separate terminal.
 
 The RPC server listens to two ports:
 
 - `port`: the main gRPC port (see [gRPC](https://grpc.io/)).
-- `grpc-gateway-port`: the gRPC gateway port (see [gRPC-gateway](https://grpc-ecosystem.github.io/grpc-gateway/)), which allows for HTTP requests.
+- `grpc-gateway-port`: the gRPC gateway port (see [gRPC-gateway](https://grpc-ecosystem.github.io/grpc-gateway/)),
+which allows for HTTP requests.
 
-When using the binary to issue calls, the main port will be hit. In this mode, the binary executes compiled code to issue calls.
-Alternatively, plain HTTP can be used to issue calls, without the need to use the binary. In this mode, the `grpc-gateway-port` should be queried.
+When using the binary to issue calls, the main port will be hit. In this mode, the binary executes compiled
+code to issue calls. Alternatively, plain HTTP can be used to issue calls, without the need to use the
+binary. In this mode, the `grpc-gateway-port` should be queried.
 
 Each of the examples below will show both modes, clarifying its usage.
 
@@ -115,7 +121,9 @@ avalanche-network-runner control health \
 --endpoint="0.0.0.0:8080"
 ```
 
-The response to this call is actually pretty large, as it contains the state of the whole cluster. At the very end of it there should be a text saying `healthy:true` (it would say `false` if it wasn't healthy).
+The response to this call is actually pretty large, as it contains the state of the whole cluster.
+At the very end of it there should be a text saying `healthy:true` (it would say `false` if it wasn't
+healthy).
 
 ```json
 {
@@ -216,15 +224,21 @@ Response
 }
 ```
 
-Now you have a 5-nodes network with HTTP ports (where API calls should be sent) `30301`, `31072`, `37730`, `40108` , and `64470`.
+Now you have a 5-nodes network with HTTP ports (where API calls should be sent) `30301`, `31072`, `37730`,
+`40108` , and `64470`.
 
-Please refer to the dedicated [Avalanche Network Runner documentation](../subnets/network-runner.md) for more information.
+Please refer to the dedicated [Avalanche Network Runner documentation](../subnets/network-runner.md)
+for more information.
 
 ## Manually
 
-The below commands assume you have [AvalancheGo](../nodes/build/run-avalanche-node-manually.md#download-avalanchego) installed at `$GOPATH/src/github.com/ava-labs/avalanchego`. Each of the five nodes created is a validator. The staking keys for these nodes are in `$GOPATH/src/github.com/ava-labs/avalanchego/staking/local/staker1.crt`, etc.
+The below commands assume you have [AvalancheGo](../nodes/build/run-avalanche-node-manually.md#download-avalanchego)
+installed at `$GOPATH/src/github.com/ava-labs/avalanchego`. Each of the five nodes created is a validator.
+The staking keys for these nodes are in `$GOPATH/src/github.com/ava-labs/avalanchego/staking/local/staker1.crt`,
+etc.
 
-The 5 nodes will have HTTP ports (where API calls should be sent) `9650`, `9652`, `9654`, `9656` , and `9658`.
+The 5 nodes will have HTTP ports (where API calls should be sent) `9650`, `9652`, `9654`, `9656` , and
+`9658`.
 
 To start the network:
 

--- a/docs/quickstart/create-a-local-test-network.md
+++ b/docs/quickstart/create-a-local-test-network.md
@@ -24,7 +24,7 @@ curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/m
 ```
 
 The script installs the binary inside the `~/bin` directory. If the directory doesn't exist,
-it will be be created.
+it will be created.
 
 Please make sure that `~/bin` is in your `$PATH`:
 
@@ -33,7 +33,7 @@ export PATH=~/bin:$PATH
 ```
 
 To add it to your path permanently, add an export command to your shell initialization script. If
-you run bash, use `.bashrc`. If you run zsh, use `.zshrc`.
+you run `bash`, use `.bashrc`. If you run `zsh`, use `.zshrc`.
 
 Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related to
 Avalanche Network Runner. We strongly recommend that you put the following in to your shell's configuration

--- a/docs/quickstart/create-a-local-test-network.md
+++ b/docs/quickstart/create-a-local-test-network.md
@@ -23,7 +23,8 @@ To download a binary for the latest release, run:
 curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s
 ```
 
-The script installs the binary inside the `~/bin` directory.
+The script installs the binary inside the `~/bin` directory. If the directory doesn't exist,
+it will be be created.
 
 Please make sure that `~/bin` is in your `$PATH`:
 
@@ -32,7 +33,7 @@ export PATH=~/bin:$PATH
 ```
 
 To add it to your path permanently, add an export command to your shell initialization script. If
-you run Ubuntu, use `.bashrc`. Mac uses `.zshrc`.
+you run bash, use `.bashrc`. If you run zsh, use `.zshrc`.
 
 Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related to
 Avalanche Network Runner. We strongly recommend that you put the following in to your shell's configuration

--- a/docs/subnets/build-first-subnet.md
+++ b/docs/subnets/build-first-subnet.md
@@ -16,7 +16,7 @@ curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts
 ```
 
 The binary installs inside the `~/bin` directory. If the directory doesn't exist,
-it will be be created.
+it will be created.
 
 You can run all of the commands in this tutorial by calling `~/bin/avalanche`.
 

--- a/docs/subnets/build-first-subnet.md
+++ b/docs/subnets/build-first-subnet.md
@@ -15,7 +15,8 @@ The fastest way to install the latest Avalanche-CLI binary is by running the ins
 curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts/install.sh | sh -s
 ```
 
-The binary installs inside the `~/bin` directory.
+The binary installs inside the `~/bin` directory. If the directory doesn't exist,
+it will be be created.
 
 You can run all of the commands in this tutorial by calling `~/bin/avalanche`.
 

--- a/docs/subnets/create-a-evm-blockchain-on-subnet-with-avalanchejs.md
+++ b/docs/subnets/create-a-evm-blockchain-on-subnet-with-avalanchejs.md
@@ -93,23 +93,14 @@ For the development purpose, we can use [**Avalanche Network Runner
 (ANR)**](../subnets/network-runner.md). It helps us in simulating the actual network. For this
 tutorial, we will be installing ANR binary and will interact with the network through RPCs.
 
-### Clone Avalanche Network Runner
-
-Now move to `subnet-evm-demo`, and clone the repository.
-
-```bash
-git clone https://github.com/ava-labs/avalanche-network-runner
-cd avalanche-network-runner
-```
-
 ### Install ANR Binary
 
-The following command will install the ANR binary inside `$GOPATH/bin`. Please make sure that you
-have the `$GOPATH/bin` path set in the `$PATH` environment variable, otherwise, you will not be able
+The following command will install the ANR binary inside `~/bin`. Please make sure that you
+have the `~/bin` path set in the `$PATH` environment variable, otherwise, you will not be able
 to run the binary unless you specify its location in each command.
 
-```bash
-go install -v ./cmd/avalanche-network-runner
+```shell
+curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s
 ```
 
 ### Start RPC Server

--- a/docs/subnets/hello-world-precompile-tutorial.md
+++ b/docs/subnets/hello-world-precompile-tutorial.md
@@ -178,7 +178,7 @@ mkdir -p src/github.com/ava-labs
 cd src/github.com/ava-labs
 git clone git@github.com:ava-labs/subnet-evm.git
 git clone git@github.com:ava-labs/avalanchego.git
-go install github.com/ava-labs/avalanche-network-runner@latest
+curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s
 npm install -g solc
 npm install -g yarn
 ```

--- a/docs/subnets/install-avalanche-cli.md
+++ b/docs/subnets/install-avalanche-cli.md
@@ -12,7 +12,8 @@ To download a binary for the latest release, run:
 curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts/install.sh | sh -s
 ```
 
-The script installs the binary inside the `~/bin` directory.
+The script installs the binary inside the `~/bin` directory. If the directory doesn't exist,
+it will be be created.
 
 ## Adding Avalanche-CLI to Your PATH
 
@@ -24,7 +25,7 @@ export PATH=~/bin:$PATH
 ```
 
 To add it to your path permanently, add an export command to your shell initialization script. If
-you run Ubuntu, use `.bashrc`. Mac uses `.zshrc`.
+you run bash, use `.bashrc`. If you run zsh, use `.zshrc`.
 
 For example:
 

--- a/docs/subnets/install-avalanche-cli.md
+++ b/docs/subnets/install-avalanche-cli.md
@@ -13,7 +13,7 @@ curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-cli/main/scripts
 ```
 
 The script installs the binary inside the `~/bin` directory. If the directory doesn't exist,
-it will be be created.
+it will be created.
 
 ## Adding Avalanche-CLI to Your PATH
 
@@ -25,7 +25,7 @@ export PATH=~/bin:$PATH
 ```
 
 To add it to your path permanently, add an export command to your shell initialization script. If
-you run bash, use `.bashrc`. If you run zsh, use `.zshrc`.
+you run `bash`, use `.bashrc`. If you run `zsh`, use `.zshrc`.
 
 For example:
 

--- a/docs/subnets/network-runner.md
+++ b/docs/subnets/network-runner.md
@@ -25,15 +25,21 @@ allowing to locally test code before deploying to Mainnet or even public testnet
 <!-- markdownlint-disable MD013 -->
 
 ```bash
-curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh | sh -s -- -b $GOPATH/bin
-
-cd $GOPATH/bin
-export PATH=$PWD:$PATH
+curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/main/scripts/install.sh
 ```
 
 <!-- markdownlint-enable MD013 -->
 
-`avalanche-network-runner` will be installed into `$GOPATH/bin`.
+The script installs the binary inside the `~/bin` directory.
+
+Please make sure that `~/bin` is in your `$PATH`:
+
+```shell
+export PATH=~/bin:$PATH
+```
+
+To add it to your path permanently, add an export command to your shell initialization script. If
+you run Ubuntu, use `.bashrc`. Mac uses `.zshrc`.
 
 Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related
 to Avalanche Network Runner. We strongly recommend that you put the following in to your shell's

--- a/docs/subnets/network-runner.md
+++ b/docs/subnets/network-runner.md
@@ -30,7 +30,8 @@ curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/m
 
 <!-- markdownlint-enable MD013 -->
 
-The script installs the binary inside the `~/bin` directory.
+The script installs the binary inside the `~/bin` directory. If the directory doesn't exist,
+it will be be created.
 
 Please make sure that `~/bin` is in your `$PATH`:
 
@@ -39,7 +40,7 @@ export PATH=~/bin:$PATH
 ```
 
 To add it to your path permanently, add an export command to your shell initialization script. If
-you run Ubuntu, use `.bashrc`. Mac uses `.zshrc`.
+you run bash, use `.bashrc`. If you run zsh, use `.zshrc`.
 
 Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related
 to Avalanche Network Runner. We strongly recommend that you put the following in to your shell's

--- a/docs/subnets/network-runner.md
+++ b/docs/subnets/network-runner.md
@@ -31,7 +31,7 @@ curl -sSfL https://raw.githubusercontent.com/ava-labs/avalanche-network-runner/m
 <!-- markdownlint-enable MD013 -->
 
 The script installs the binary inside the `~/bin` directory. If the directory doesn't exist,
-it will be be created.
+it will be created.
 
 Please make sure that `~/bin` is in your `$PATH`:
 
@@ -40,7 +40,7 @@ export PATH=~/bin:$PATH
 ```
 
 To add it to your path permanently, add an export command to your shell initialization script. If
-you run bash, use `.bashrc`. If you run zsh, use `.zshrc`.
+you run `bash`, use `.bashrc`. If you run `zsh`, use `.zshrc`.
 
 Furthermore, `AVALANCHEGO_EXEC_PATH` should be set properly in all shells you run commands related
 to Avalanche Network Runner. We strongly recommend that you put the following in to your shell's


### PR DESCRIPTION
Avoid usage of `go install` for ANR, as the resulting binary does not provide version information.