### PR TITLE
Alphabetize API docs

### DIFF
--- a/docs/apis/avalanchego/apis/admin.md
+++ b/docs/apis/avalanchego/apis/admin.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 7
+sidebar_position: 6
 ---
 
 # Admin API

--- a/docs/apis/avalanchego/apis/auth.md
+++ b/docs/apis/avalanchego/apis/auth.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 8
+sidebar_position: 7
 ---
 
 # Auth API

--- a/docs/apis/avalanchego/apis/c-chain.md
+++ b/docs/apis/avalanchego/apis/c-chain.md
@@ -275,63 +275,6 @@ To interact with other instances of the EVM AVAX endpoints:
 /ext/bc/blockchainID/avax
 ```
 
-### `avax.getAtomicTx`
-
-Gets a transaction by its ID. Optional encoding parameter to specify the format for the returned
-transaction. Can only be `hex` when a value is provided.
-
-**Signature:**
-
-```go
-avax.getAtomicTx({
-    txID: string,
-    encoding: string, //optional
-}) -> {
-    tx: string,
-    encoding: string,
-    blockHeight: string
-}
-```
-
-**Request:**
-
-- `txID` is the transaction ID. It should be in cb58 format.
-- `encoding` is the encoding format to use. Can only be `hex` when a value is provided.
-
-**Response:**
-
-- `tx` is the transaction encoded to `encoding`.
-- `encoding` is the `encoding`.
-- `blockHeight` is the height of the block which the transaction was included in.
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :1,
-    "method" :"avax.getAtomicTx",
-    "params" :{
-        "txID":"2GD5SRYJQr2kw5jE73trBFiAgVQyrCaeg223TaTyJFYXf2kPty",
-        "encoding": "hex"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "tx": "0x000000000000000030399d0775f450604bd2fbc49ce0c5c1c6dfeb2dc2acb8c92c26eeae6e6df4502b19d891ad56056d9c01f18f43f58b5c784ad07a4a49cf3d1f11623804b5cba2c6bf000000018212d6807a0ec9c1b26321418fe7a548180b5be728ce53fe7e98ab5755ed316100000001dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db00000005000003a352a382400000000100000000000000018db97c7cece249c2b98bdc0226cc4c2a57bf52fc000003a3529edd17dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db000000010000000900000001ead19377f015422fbb8731204fcf6d6879dd05146c2d5b5594e2fea2cb420b2f40bd457b71e279e547790b28fe5482f278c76cf39b2dce5c2e6c53352fe6827d002cc7d20d",
-    "encoding": "hex",
-    "blockHeight": "1"
-  },
-  "id": 1
-}
-```
-
 ### `avax.export`
 
 :::warning
@@ -517,7 +460,111 @@ curl -X POST --data '{
         "privateKeyHex": "0xec381fb8d32168be4cf7f8d4ce9d8ca892d77ba574264f3665ad5edb89710157"
     },
     "id": 1
-}}
+}
+```
+
+### `avax.getAtomicTx`
+
+Gets a transaction by its ID. Optional encoding parameter to specify the format for the returned
+transaction. Can only be `hex` when a value is provided.
+
+**Signature:**
+
+```go
+avax.getAtomicTx({
+    txID: string,
+    encoding: string, //optional
+}) -> {
+    tx: string,
+    encoding: string,
+    blockHeight: string
+}
+```
+
+**Request:**
+
+- `txID` is the transaction ID. It should be in cb58 format.
+- `encoding` is the encoding format to use. Can only be `hex` when a value is provided.
+
+**Response:**
+
+- `tx` is the transaction encoded to `encoding`.
+- `encoding` is the `encoding`.
+- `blockHeight` is the height of the block which the transaction was included in.
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"avax.getAtomicTx",
+    "params" :{
+        "txID":"2GD5SRYJQr2kw5jE73trBFiAgVQyrCaeg223TaTyJFYXf2kPty",
+        "encoding": "hex"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "tx": "0x000000000000000030399d0775f450604bd2fbc49ce0c5c1c6dfeb2dc2acb8c92c26eeae6e6df4502b19d891ad56056d9c01f18f43f58b5c784ad07a4a49cf3d1f11623804b5cba2c6bf000000018212d6807a0ec9c1b26321418fe7a548180b5be728ce53fe7e98ab5755ed316100000001dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db00000005000003a352a382400000000100000000000000018db97c7cece249c2b98bdc0226cc4c2a57bf52fc000003a3529edd17dbcf890f77f49b96857648b72b77f9f82937f28a68704af05da0dc12ba53f2db000000010000000900000001ead19377f015422fbb8731204fcf6d6879dd05146c2d5b5594e2fea2cb420b2f40bd457b71e279e547790b28fe5482f278c76cf39b2dce5c2e6c53352fe6827d002cc7d20d",
+    "encoding": "hex",
+    "blockHeight": "1"
+  },
+  "id": 1
+}
+```
+
+### `avax.getAtomicTxStatus`
+
+Get the status of an atomic transaction sent to the network.
+
+**Signature:**
+
+```sh
+avax.getAtomicTxStatus({txID: string}) -> {
+  status: string,
+  blockHeight: string // returned when status is Accepted
+}
+```
+
+`status` is one of:
+
+- `Accepted`: The transaction is (or will be) accepted by every node. Check the `blockHeight`
+  property
+- `Processing`: The transaction is being voted on by this node
+- `Dropped`: The transaction was dropped by this node because it thought the transaction invalid
+- `Unknown`: The transaction hasn’t been seen by this node
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"avax.getAtomicTxStatus",
+    "params" :{
+        "txID":"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "status": "Accepted",
+    "blockHeight": "1"
+  }
+}
 ```
 
 ### `avax.getUTXOs`
@@ -832,58 +879,10 @@ curl -X POST --data '{
 }
 ```
 
-### `avax.getAtomicTxStatus`
-
-Get the status of an atomic transaction sent to the network.
-
-**Signature:**
-
-```sh
-avax.getAtomicTxStatus({txID: string}) -> {
-  status: string,
-  blockHeight: string // returned when status is Accepted
-}
-```
-
-`status` is one of:
-
-- `Accepted`: The transaction is (or will be) accepted by every node. Check the `blockHeight`
-  property
-- `Processing`: The transaction is being voted on by this node
-- `Dropped`: The transaction was dropped by this node because it thought the transaction invalid
-- `Unknown`: The transaction hasn’t been seen by this node
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :1,
-    "method" :"avax.getAtomicTxStatus",
-    "params" :{
-        "txID":"2QouvFWUbjuySRxeX5xMbNCuAaKWfbk5FeEa2JmoF85RKLk2dD"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/avax
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "status": "Accepted",
-    "blockHeight": "1"
-  }
-}
-```
-
 ## Admin API
 
 This API can be used for debugging. Note that the Admin API is disabled by default. To run a node
-with the Admin API enabled, use [C-Chain config flag`--coreth-admin-api-enabled:true`](../../../nodes/maintain/chain-config-flags.md#coreth-admin-api-enabled-boolean)
-.
+with the Admin API enabled, use [C-Chain config flag`--coreth-admin-api-enabled:true`](../../../nodes/maintain/chain-config-flags.md#coreth-admin-api-enabled-boolean).
 
 ### Endpoint
 

--- a/docs/apis/avalanchego/apis/health.md
+++ b/docs/apis/avalanchego/apis/health.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 9
+sidebar_position: 8
 description: This API can be used for measuring node health. Use Avalanche docs as a reference when testing node health. Helpful examples provided.
 ---
 

--- a/docs/apis/avalanchego/apis/index-api.md
+++ b/docs/apis/avalanchego/apis/index-api.md
@@ -209,7 +209,7 @@ curl --location --request POST 'localhost:9650/ext/index/X/tx' \
 
 Returns the transactions at index [`startIndex`], [`startIndex+1`], ... , [`startIndex+n-1`]
 
-- If [`n`] == 0, returns an empty response (i.e. null).
+- If [`n`] == 0, returns an empty response (for example: null).
 - If [`startIndex`] > the last accepted index, returns an error (unless the above apply.)
 - If [`n`] > [`MaxFetchedByRange`], returns an error.
 - If we run out of transactions, returns the ones fetched before running out.

--- a/docs/apis/avalanchego/apis/index-api.md
+++ b/docs/apis/avalanchego/apis/index-api.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 10
+sidebar_position: 9
 ---
 
 # Index API

--- a/docs/apis/avalanchego/apis/info.md
+++ b/docs/apis/avalanchego/apis/info.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 11
+sidebar_position: 10
 ---
 
 # Info API

--- a/docs/apis/avalanchego/apis/info.md
+++ b/docs/apis/avalanchego/apis/info.md
@@ -23,6 +23,43 @@ This API uses the `json 2.0` RPC format. For more information on making JSON RPC
 
 ## Methods
 
+### `info.isBootstrapped`
+
+Check whether a given chain is done bootstrapping
+
+**Signature:**
+
+```sh
+info.isBootstrapped({chain: string}) -> {isBootstrapped: bool}
+```
+
+`chain` is the ID or alias of a chain.
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"info.isBootstrapped",
+    "params": {
+        "chain":"X"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/info
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "isBootstrapped": true
+  },
+  "id": 1
+}
+```
+
 ### `info.getBlockchainID`
 
 Given a blockchain’s alias, get its ID. (See [`admin.aliasChain`](admin.md#adminaliaschain).)
@@ -254,6 +291,69 @@ curl -X POST --data '{
 }
 ```
 
+### `info.getTxFee`
+
+Get the fees of the network.
+
+**Signature:**
+
+```sh
+info.getTxFee() ->
+{
+    txFee: uint64,
+    createAssetTxFee: uint64,
+    createSubnetTxFee: uint64,
+    transformSubnetTxFee: uint64,
+    createBlockchainTxFee: uint64,
+    addPrimaryNetworkValidatorFee: uint64,
+    addPrimaryNetworkDelegatorFee: uint64,
+    addSubnetValidatorFee: uint64,
+    addSubnetDelegatorFee: uint64
+}
+```
+
+- `txFee` is the default fee for making transactions.
+- `createAssetTxFee` is the fee for creating a new asset.
+- `createSubnetTxFee` is the fee for creating a new Subnet.
+- `transformSubnetTxFee` is the fee for converting a PoA Subnet into a PoS Subnet.
+- `createBlockchainTxFee` is the fee for creating a new blockchain.
+- `addPrimaryNetworkValidatorFee` is the fee for adding a new primary network validator.
+- `addPrimaryNetworkDelegatorFee` is the fee for adding a new primary network delegator.
+- `addSubnetValidatorFee` is the fee for adding a new Subnet validator.
+- `addSubnetDelegatorFee` is the fee for adding a new Subnet delegator.
+
+All fees are denominated in nAVAX.
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     :1,
+    "method" :"info.getTxFee"
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/info
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "txFee": "1000000",
+    "createAssetTxFee": "10000000",
+    "createSubnetTxFee": "1000000000",
+    "transformSubnetTxFee": "10000000000",
+    "createBlockchainTxFee": "1000000000",
+    "addPrimaryNetworkValidatorFee": "0",
+    "addPrimaryNetworkDelegatorFee": "0",
+    "addSubnetValidatorFee": "1000000",
+    "addSubnetDelegatorFee": "1000000"
+  }
+}
+```
+
 ### `info.getVMs`
 
 Get the virtual machines installed on this node.
@@ -291,43 +391,6 @@ curl -X POST --data '{
       "rXJsCSEYXg2TehWxCEEGj6JU2PWKTkd6cBdNLjoe2SpsKD9cy": ["propertyfx"],
       "spdxUxVJQbX85MGxMHbKw1sHxMnSqJ3QBzDyDYEP3h6TLuxqQ": ["secp256k1fx"]
     }
-  },
-  "id": 1
-}
-```
-
-### `info.isBootstrapped`
-
-Check whether a given chain is done bootstrapping
-
-**Signature:**
-
-```sh
-info.isBootstrapped({chain: string}) -> {isBootstrapped: bool}
-```
-
-`chain` is the ID or alias of a chain.
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :1,
-    "method" :"info.isBootstrapped",
-    "params": {
-        "chain":"X"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/info
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "isBootstrapped": true
   },
   "id": 1
 }
@@ -438,69 +501,6 @@ curl -X POST --data '{
         "benched": []
       }
     ]
-  }
-}
-```
-
-### `info.getTxFee`
-
-Get the fees of the network.
-
-**Signature:**
-
-```sh
-info.getTxFee() ->
-{
-    txFee: uint64,
-    createAssetTxFee: uint64,
-    createSubnetTxFee: uint64,
-    transformSubnetTxFee: uint64,
-    createBlockchainTxFee: uint64,
-    addPrimaryNetworkValidatorFee: uint64,
-    addPrimaryNetworkDelegatorFee: uint64,
-    addSubnetValidatorFee: uint64,
-    addSubnetDelegatorFee: uint64
-}
-```
-
-- `txFee` is the default fee for making transactions.
-- `createAssetTxFee` is the fee for creating a new asset.
-- `createSubnetTxFee` is the fee for creating a new Subnet.
-- `transformSubnetTxFee` is the fee for converting a PoA Subnet into a PoS Subnet.
-- `createBlockchainTxFee` is the fee for creating a new blockchain.
-- `addPrimaryNetworkValidatorFee` is the fee for adding a new primary network validator.
-- `addPrimaryNetworkDelegatorFee` is the fee for adding a new primary network delegator.
-- `addSubnetValidatorFee` is the fee for adding a new Subnet validator.
-- `addSubnetDelegatorFee` is the fee for adding a new Subnet delegator.
-
-All fees are denominated in nAVAX.
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     :1,
-    "method" :"info.getTxFee"
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/info
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "txFee": "1000000",
-    "createAssetTxFee": "10000000",
-    "createSubnetTxFee": "1000000000",
-    "transformSubnetTxFee": "10000000000",
-    "createBlockchainTxFee": "1000000000",
-    "addPrimaryNetworkValidatorFee": "0",
-    "addPrimaryNetworkDelegatorFee": "0",
-    "addSubnetValidatorFee": "1000000",
-    "addSubnetDelegatorFee": "1000000"
   }
 }
 ```

--- a/docs/apis/avalanchego/apis/ipc.md
+++ b/docs/apis/avalanchego/apis/ipc.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 12
+sidebar_position: 11
 description: The IPC API allows users to create UNIX domain sockets for blockchains to publish to. Find out more information here.
 ---
 

--- a/docs/apis/avalanchego/apis/keystore.md
+++ b/docs/apis/avalanchego/apis/keystore.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 13
+sidebar_position: 12
 ---
 
 # Keystore API

--- a/docs/apis/avalanchego/apis/metrics.md
+++ b/docs/apis/avalanchego/apis/metrics.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 14
+sidebar_position: 13
 ---
 
 # Metrics API

--- a/docs/apis/avalanchego/apis/p-chain.md
+++ b/docs/apis/avalanchego/apis/p-chain.md
@@ -119,6 +119,95 @@ curl -X POST --data '{
 }
 ```
 
+### `platform.addSubnetValidator`
+
+:::warning
+
+Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
+
+:::
+
+Add a validator to a Subnet other than the Primary Network. The Validator must validate the Primary
+Network for the entire duration they validate this Subnet.
+
+**Signature:**
+
+```sh
+platform.addSubnetValidator(
+    {
+        nodeID: string,
+        subnetID: string,
+        startTime: int,
+        endTime: int,
+        weight: int,
+        from: []string, // optional
+        changeAddr: string, // optional
+        username: string,
+        password: string
+    }
+) ->
+{
+    txID: string,
+    changeAddr: string,
+}
+```
+
+- `nodeID` is the node ID of the validator being added to the Subnet. This validator must validate
+  the Primary Network for the entire duration that it validates this Subnet.
+- `subnetID` is the ID of the Subnet we’re adding a validator to.
+- `startTime` is the Unix time when the validator starts validating the Subnet. It must be at or
+  after the time that the validator starts validating the Primary Network
+- `endTime` is the Unix time when the validator stops validating the Subnet. It must be at or before
+  the time that the validator stops validating the Primary Network.
+- `weight` is the validator’s weight used for sampling. If the validator’s weight is 1 and the
+  cumulative weight of all validators in the Subnet is 100, then this validator will be included in
+  about 1 in every 100 samples during consensus. The cumulative weight of all validators in the
+  Subnet must be at least `snow-sample-size`. For example, if there is only one validator in the
+  Subnet, its weight must be at least `snow-sample-size` (default 20). Recall that a validator's
+  weight can't be changed while it is validating, so take care to use an appropriate value.
+- `from` are the fund addresses that the user wants to use to pay for this operation. If omitted,
+  use any of user's addresses as needed.
+- `changeAddr` is the address any change/left-over of the fund (specified by the `from` addresses)
+  will be sent to. If omitted, change/left-over is sent to one of the addresses controlled by the
+  user.
+- `username` is the user that pays the transaction fee.
+- `password` is `username`‘s password.
+- `txID` is the transaction ID.
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc": "2.0",
+    "method": "platform.addSubnetValidator",
+    "params": {
+        "nodeID":"NodeID-7xhw2mdxuds44j42tcb6u5579esbst3lg",
+        "subnetID":"zbfoww1ffkpvrfywpj1cvqrfnyesepdfc61hmu2n9jnghduel",
+        "startTime":1583524047,
+        "endTime":1604102399,
+        "weight":1,
+        "from": ["P-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5"],
+        "changeAddr": "P-avax103y30cxeulkjfe3kwfnpt432ylmnxux8r73r8u",
+        "username":"myUsername",
+        "password":"myPassword"
+    },
+    "id": 1
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "txID": "2exafyvRNSE5ehwjhafBVt6CTntot7DFjsZNcZ54GSxBbVLcCm",
+    "changeAddr": "P-avax103y30cxeulkjfe3kwfnpt432ylmnxux8r73r8u"
+  }
+}
+```
+
 ### `platform.addValidator`
 
 :::warning
@@ -231,95 +320,6 @@ curl -X POST --data '{
     "changeAddr": "P-avax103y30cxeulkjfe3kwfnpt432ylmnxux8r73r8u"
   },
   "id": 1
-}
-```
-
-### `platform.addSubnetValidator`
-
-:::warning
-
-Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
-
-:::
-
-Add a validator to a Subnet other than the Primary Network. The Validator must validate the Primary
-Network for the entire duration they validate this Subnet.
-
-**Signature:**
-
-```sh
-platform.addSubnetValidator(
-    {
-        nodeID: string,
-        subnetID: string,
-        startTime: int,
-        endTime: int,
-        weight: int,
-        from: []string, // optional
-        changeAddr: string, // optional
-        username: string,
-        password: string
-    }
-) ->
-{
-    txID: string,
-    changeAddr: string,
-}
-```
-
-- `nodeID` is the node ID of the validator being added to the Subnet. This validator must validate
-  the Primary Network for the entire duration that it validates this Subnet.
-- `subnetID` is the ID of the Subnet we’re adding a validator to.
-- `startTime` is the Unix time when the validator starts validating the Subnet. It must be at or
-  after the time that the validator starts validating the Primary Network
-- `endTime` is the Unix time when the validator stops validating the Subnet. It must be at or before
-  the time that the validator stops validating the Primary Network.
-- `weight` is the validator’s weight used for sampling. If the validator’s weight is 1 and the
-  cumulative weight of all validators in the Subnet is 100, then this validator will be included in
-  about 1 in every 100 samples during consensus. The cumulative weight of all validators in the
-  Subnet must be at least `snow-sample-size`. For example, if there is only one validator in the
-  Subnet, its weight must be at least `snow-sample-size` (default 20). Recall that a validator's
-  weight can't be changed while it is validating, so take care to use an appropriate value.
-- `from` are the fund addresses that the user wants to use to pay for this operation. If omitted,
-  use any of user's addresses as needed.
-- `changeAddr` is the address any change/left-over of the fund (specified by the `from` addresses)
-  will be sent to. If omitted, change/left-over is sent to one of the addresses controlled by the
-  user.
-- `username` is the user that pays the transaction fee.
-- `password` is `username`‘s password.
-- `txID` is the transaction ID.
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc": "2.0",
-    "method": "platform.addSubnetValidator",
-    "params": {
-        "nodeID":"NodeID-7xhw2mdxuds44j42tcb6u5579esbst3lg",
-        "subnetID":"zbfoww1ffkpvrfywpj1cvqrfnyesepdfc61hmu2n9jnghduel",
-        "startTime":1583524047,
-        "endTime":1604102399,
-        "weight":1,
-        "from": ["P-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5"],
-        "changeAddr": "P-avax103y30cxeulkjfe3kwfnpt432ylmnxux8r73r8u",
-        "username":"myUsername",
-        "password":"myPassword"
-    },
-    "id": 1
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "txID": "2exafyvRNSE5ehwjhafBVt6CTntot7DFjsZNcZ54GSxBbVLcCm",
-    "changeAddr": "P-avax103y30cxeulkjfe3kwfnpt432ylmnxux8r73r8u"
-  }
 }
 ```
 
@@ -1480,6 +1480,63 @@ curl -X POST --data '{
 }
 ```
 
+### `platform.getStake`
+
+Get the amount of nAVAX staked by a set of addresses. The amount returned does not include staking
+rewards.
+
+**Signature:**
+
+```sh
+platform.getStake({
+    addresses: []string
+}) ->
+{
+    stakeds: string -> int,
+    stakedOutputs:  []string,
+    encoding: string
+}
+```
+
+- `addresses` are the addresses to get information about.
+- `stakeds` is a map from assetID to the amount staked by addresses provided.
+- `stakedOutputs` are the string representation of staked outputs.
+- `encoding` specifies the format for the returned outputs.
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc": "2.0",
+    "method": "platform.getStake",
+    "params": {
+        "addresses": [
+            "P-avax1pmgmagjcljjzuz2ve339dx82khm7q8getlegte"
+        ]
+    },
+    "id": 1
+}
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "stakeds": {
+      "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z": "25000000000"
+    },
+    "stakedOutputs": [
+      "0x000021e67317cbc4be2aeb00677ad6462778a8f52274b9d605df2591b23027a87dff00000007000000064198bf46000000000000000000000001000000010ed1bea258fca42e094ccc625698eab5f7e01d190f0f332d"
+    ],
+    "encoding": "hex"
+  },
+  "id": 1
+}
+```
+
 ### `platform.getStakingAssetID`
 
 Retrieve an assetID for a Subnet’s staking asset.
@@ -1578,63 +1635,6 @@ curl -X POST --data '{
         "threshold": "2"
       }
     ]
-  },
-  "id": 1
-}
-```
-
-### `platform.getStake`
-
-Get the amount of nAVAX staked by a set of addresses. The amount returned does not include staking
-rewards.
-
-**Signature:**
-
-```sh
-platform.getStake({
-    addresses: []string
-}) ->
-{
-    stakeds: string -> int,
-    stakedOutputs:  []string,
-    encoding: string
-}
-```
-
-- `addresses` are the addresses to get information about.
-- `stakeds` is a map from assetID to the amount staked by addresses provided.
-- `stakedOutputs` are the string representation of staked outputs.
-- `encoding` specifies the format for the returned outputs.
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc": "2.0",
-    "method": "platform.getStake",
-    "params": {
-        "addresses": [
-            "P-avax1pmgmagjcljjzuz2ve339dx82khm7q8getlegte"
-        ]
-    },
-    "id": 1
-}
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/P
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "stakeds": {
-      "FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z": "25000000000"
-    },
-    "stakedOutputs": [
-      "0x000021e67317cbc4be2aeb00677ad6462778a8f52274b9d605df2591b23027a87dff00000007000000064198bf46000000000000000000000001000000010ed1bea258fca42e094ccc625698eab5f7e01d190f0f332d"
-    ],
-    "encoding": "hex"
   },
   "id": 1
 }

--- a/docs/apis/avalanchego/apis/subnet-evm.md
+++ b/docs/apis/avalanchego/apis/subnet-evm.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 15
+sidebar_position: 14
 ---
 
 # Subnet-EVM API

--- a/docs/apis/avalanchego/apis/x-chain.md
+++ b/docs/apis/avalanchego/apis/x-chain.md
@@ -1173,10 +1173,6 @@ This gives response:
 }
 ```
 
-<!--
-TODO: Add avm.getVertex
--->
-
 ### `avm.import`
 
 :::warning

--- a/docs/apis/avalanchego/apis/x-chain.md
+++ b/docs/apis/avalanchego/apis/x-chain.md
@@ -225,6 +225,10 @@ curl -X POST --data '{
 }
 ```
 
+<!-- 
+TODO: Add avm.createAsset  
+-->
+
 ### `avm.createFixedCapAsset`
 
 :::warning
@@ -313,42 +317,47 @@ curl -X POST --data '{
 }
 ```
 
-### `avm.mint`
+### `avm.createNFTAsset`
 
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
 
-Mint units of a variable-cap asset created with
-[`avm.createVariableCapAsset`](x-chain.md#avmcreatevariablecapasset).
+Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint
+units of this asset using `avm.mintNFT`.
 
 **Signature:**
 
 ```sh
-avm.mint({
-    amount: int,
-    assetID: string,
-    to: string,
+avm.createNFTAsset({
+    name: string,
+    symbol: string,
+    minterSets: []{
+        minters: []string,
+        threshold: int
+    },
     from: []string, //optional
     changeAddr: string, //optional
     username: string,
     password: string
 }) ->
-{
-    txID: string,
+ {
+    assetID: string,
     changeAddr: string,
 }
 ```
 
-- `amount` units of `assetID` will be created and controlled by address `to`.
+- `name` is a human-readable name for the asset. Not necessarily unique.
+- `symbol` is a shorthand symbol for the asset. Between 0 and 4 characters. Not necessarily unique.
+  May be omitted.
+- `minterSets` is a list where each element specifies that `threshold` of the addresses in `minters`
+  may together mint more of the asset by signing a minting transaction.
 - `from` are the addresses that you want to use for this operation. If omitted, uses any of your
   addresses as needed.
 - `changeAddr` is the address any change will be sent to. If omitted, change is sent to one of the
   addresses controlled by the user.
-- `username` is the user that pays the transaction fee. `username` must hold keys giving it
-  permission to mint more of this asset. That is, it must control at least _threshold_ keys for one
-  of the minter sets.
-- `txID` is this transaction’s ID.
+- `username` pays the transaction fee.
+- `assetID` is the ID of the new asset.
 - `changeAddr` in the result is the address where any change was sent.
 
 **Example Call:**
@@ -357,13 +366,20 @@ avm.mint({
 curl -X POST --data '{
     "jsonrpc":"2.0",
     "id"     : 1,
-    "method" :"avm.mint",
+    "method" :"avm.createNFTAsset",
     "params" :{
-        "amount":10000000,
-        "assetID":"i1EqsthjiFTxunrj8WD2xFSrQ5p2siEKQacmCCB5qBFVqfSL2",
-        "to":"X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5",
-        "from":["X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5"],
-        "changeAddr":"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
+        "name":"Coincert",
+        "symbol":"TIXX",
+        "minterSets":[
+            {
+                "minters":[
+                    "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"
+                ],
+                "threshold": 1
+            }
+        ],
+        "from": ["X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"],
+        "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
         "username":"myUsername",
         "password":"myPassword"
     }
@@ -375,11 +391,11 @@ curl -X POST --data '{
 ```json
 {
   "jsonrpc": "2.0",
-  "id": 1,
   "result": {
-    "txID": "2oGdPdfw2qcNUHeqjw8sU2hPVrFyNUTgn6A8HenDra7oLCDtja",
+    "assetID": "2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP",
     "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"
-  }
+  },
+  "id": 1
 }
 ```
 
@@ -478,163 +494,6 @@ curl -X POST --data '{
 }
 ```
 
-### `avm.createNFTAsset`
-
-:::warning
-Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
-:::
-
-Create a new non-fungible asset. No units of the asset exist at initialization. Minters can mint
-units of this asset using `avm.mintNFT`.
-
-**Signature:**
-
-```sh
-avm.createNFTAsset({
-    name: string,
-    symbol: string,
-    minterSets: []{
-        minters: []string,
-        threshold: int
-    },
-    from: []string, //optional
-    changeAddr: string, //optional
-    username: string,
-    password: string
-}) ->
- {
-    assetID: string,
-    changeAddr: string,
-}
-```
-
-- `name` is a human-readable name for the asset. Not necessarily unique.
-- `symbol` is a shorthand symbol for the asset. Between 0 and 4 characters. Not necessarily unique.
-  May be omitted.
-- `minterSets` is a list where each element specifies that `threshold` of the addresses in `minters`
-  may together mint more of the asset by signing a minting transaction.
-- `from` are the addresses that you want to use for this operation. If omitted, uses any of your
-  addresses as needed.
-- `changeAddr` is the address any change will be sent to. If omitted, change is sent to one of the
-  addresses controlled by the user.
-- `username` pays the transaction fee.
-- `assetID` is the ID of the new asset.
-- `changeAddr` in the result is the address where any change was sent.
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     : 1,
-    "method" :"avm.createNFTAsset",
-    "params" :{
-        "name":"Coincert",
-        "symbol":"TIXX",
-        "minterSets":[
-            {
-                "minters":[
-                    "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"
-                ],
-                "threshold": 1
-            }
-        ],
-        "from": ["X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"],
-        "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
-        "username":"myUsername",
-        "password":"myPassword"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "assetID": "2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP",
-    "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"
-  },
-  "id": 1
-}
-```
-
-### `avm.mintNFT`
-
-:::warning
-Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
-:::
-
-Mint non-fungible tokens which were created with
-[`avm.createNFTAsset`](x-chain.md#avmcreatenftasset).
-
-**Signature:**
-
-```sh
-avm.mintNFT({
-    assetID: string,
-    payload: string,
-    to: string,
-    encoding: string, //optional
-    from: []string, //optional
-    changeAddr: string, //optional
-    username: string,
-    password: string
-}) ->
-{
-    txID: string,
-    changeAddr: string,
-}
-```
-
-- `assetID` is the assetID of the newly created NFT asset.
-- `payload` is an arbitrary payload of up to 1024 bytes. Its encoding format is specified by the
-  `encoding` argument.
-- `from` are the addresses that you want to use for this operation. If omitted, uses any of your
-  addresses as needed.
-- `changeAddr` is the address any change will be sent to. If omitted, change is sent to one of the
-  addresses controlled by the user.
-- `username` is the user that pays the transaction fee. `username` must hold keys giving it
-  permission to mint more of this asset. That is, it must control at least _threshold_ keys for one
-  of the minter sets.
-- `txID` is this transaction’s ID.
-- `changeAddr` in the result is the address where any change was sent.
-- `encoding` is the encoding format to use for the payload argument. Can only be `hex` when a value
-  is provided.
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc":"2.0",
-    "id"     : 1,
-    "method" :"avm.mintNFT",
-    "params" :{
-        "assetID":"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP",
-        "payload":"0x415641204c61627338259aed",
-        "to":"X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5",
-        "from":["X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5"],
-        "changeAddr":"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
-        "username":"myUsername",
-        "password":"myPassword"
-    }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": {
-    "txID": "2oGdPdfw2qcNUHeqjw8sU2hPVrFyNUTgn6A8HenDra7oLCDtja",
-    "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"
-  }
-}
-```
-
 ### `avm.export`
 
 :::
@@ -708,6 +567,10 @@ curl -X POST --data '{
 }
 ```
 
+<!-- 
+TODO: Add avm.exportAVAX
+-->
+
 ### `avm.exportKey`
 
 :::warning
@@ -754,6 +617,72 @@ curl -X POST --data '{
   "result": {
     "privateKey": "PrivateKey-2w4XiXxPfQK4TypYqnohRL8DRNTz9cGiGmwQ1zmgEqD9c9KWLq"
   }
+}
+```
+
+### `avm.getAddressTxs`
+
+Returns all transactions that change the balance of the given address. A transaction is said to
+change an address's balance if either is true:
+
+- A UTXO that the transaction consumes was at least partially owned by the address.
+- A UTXO that the transaction produces is at least partially owned by the address.
+
+:::tip
+Note: Indexing (`index-transactions`) must be enabled in the X-chain config.
+:::
+
+**Signature:**
+
+```sh
+avm.getAddressTxs({
+    address: string,
+    cursor: uint64,     // optional, leave empty to get the first page
+    assetID: string,
+    pageSize: uint64    // optional, defaults to 1024
+}) -> {
+    txIDs: []string,
+    cursor: uint64,
+}
+```
+
+**Request Parameters:**
+
+- `address`: The address for which we're fetching related transactions
+- `assetID`: Only return transactions that changed the balance of this asset. Must be an ID or an
+  alias for an asset.
+- `pageSize`: Number of items to return per page. Optional. Defaults to 1024.
+
+**Response Parameter:**
+
+- `txIDs`: List of transaction IDs that affected the balance of this address.
+- `cursor`: Page number or offset. Use this in request to get the next page.
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+  "jsonrpc":"2.0",
+  "id"     : 1,
+  "method" :"avm.getAddressTxs",
+  "params" :{
+      "address":"X-local1kpprmfpzzm5lxyene32f6lr7j0aj7gxsu6hp9y",
+      "assetID":"AVAX",
+      "pageSize":20
+  }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {
+    "txIDs": ["SsJF7KKwxiUJkczygwmgLqo3XVRotmpKP8rMp74cpLuNLfwf6"],
+    "cursor": "1"
+  },
+  "id": 1
 }
 ```
 
@@ -905,71 +834,6 @@ curl -X POST --data '{
 }
 ```
 
-### `avm.getAddressTxs`
-
-Returns all transactions that change the balance of the given address. A transaction is said to
-change an address's balance if either is true:
-
-- A UTXO that the transaction consumes was at least partially owned by the address.
-- A UTXO that the transaction produces is at least partially owned by the address.
-
-:::tip
-Note: Indexing (`index-transactions`) must be enabled in the X-chain config.
-:::
-
-**Signature:**
-
-```sh
-avm.getAddressTxs({
-    address: string,
-    cursor: uint64,     // optional, leave empty to get the first page
-    assetID: string,
-    pageSize: uint64    // optional, defaults to 1024
-}) -> {
-    txIDs: []string,
-    cursor: uint64,
-}
-```
-
-**Request Parameters:**
-
-- `address`: The address for which we're fetching related transactions
-- `assetID`: Only return transactions that changed the balance of this asset. Must be an ID or an
-  alias for an asset.
-- `pageSize`: Number of items to return per page. Optional. Defaults to 1024.
-
-**Response Parameter:**
-
-- `txIDs`: List of transaction IDs that affected the balance of this address.
-- `cursor`: Page number or offset. Use this in request to get the next page.
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-  "jsonrpc":"2.0",
-  "id"     : 1,
-  "method" :"avm.getAddressTxs",
-  "params" :{
-      "address":"X-local1kpprmfpzzm5lxyene32f6lr7j0aj7gxsu6hp9y",
-      "assetID":"AVAX",
-      "pageSize":20
-  }
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "result": {
-    "txIDs": ["SsJF7KKwxiUJkczygwmgLqo3XVRotmpKP8rMp74cpLuNLfwf6"],
-    "cursor": "1"
-  },
-  "id": 1
-}
-```
 
 ### `avm.getTx`
 
@@ -1309,6 +1173,10 @@ This gives response:
 }
 ```
 
+<!--
+TODO: Add avm.getVertex
+-->
+
 ### `avm.import`
 
 :::warning
@@ -1365,6 +1233,9 @@ curl -X POST --data '{
 }
 ```
 
+<!--
+TODO: Add avm.importAVAX
+-->
 ### `avm.importKey`
 
 :::warning
@@ -1495,6 +1366,152 @@ curl -X POST --data '{
     "addresses": ["X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5"]
   },
   "id": 1
+}
+```
+
+### `avm.mint`
+
+:::warning
+Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
+:::
+
+Mint units of a variable-cap asset created with
+[`avm.createVariableCapAsset`](x-chain.md#avmcreatevariablecapasset).
+
+**Signature:**
+
+```sh
+avm.mint({
+    amount: int,
+    assetID: string,
+    to: string,
+    from: []string, //optional
+    changeAddr: string, //optional
+    username: string,
+    password: string
+}) ->
+{
+    txID: string,
+    changeAddr: string,
+}
+```
+
+- `amount` units of `assetID` will be created and controlled by address `to`.
+- `from` are the addresses that you want to use for this operation. If omitted, uses any of your
+  addresses as needed.
+- `changeAddr` is the address any change will be sent to. If omitted, change is sent to one of the
+  addresses controlled by the user.
+- `username` is the user that pays the transaction fee. `username` must hold keys giving it
+  permission to mint more of this asset. That is, it must control at least _threshold_ keys for one
+  of the minter sets.
+- `txID` is this transaction’s ID.
+- `changeAddr` in the result is the address where any change was sent.
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     : 1,
+    "method" :"avm.mint",
+    "params" :{
+        "amount":10000000,
+        "assetID":"i1EqsthjiFTxunrj8WD2xFSrQ5p2siEKQacmCCB5qBFVqfSL2",
+        "to":"X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5",
+        "from":["X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5"],
+        "changeAddr":"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
+        "username":"myUsername",
+        "password":"myPassword"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "txID": "2oGdPdfw2qcNUHeqjw8sU2hPVrFyNUTgn6A8HenDra7oLCDtja",
+    "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"
+  }
+}
+```
+
+
+### `avm.mintNFT`
+
+:::warning
+Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
+:::
+
+Mint non-fungible tokens which were created with
+[`avm.createNFTAsset`](x-chain.md#avmcreatenftasset).
+
+**Signature:**
+
+```sh
+avm.mintNFT({
+    assetID: string,
+    payload: string,
+    to: string,
+    encoding: string, //optional
+    from: []string, //optional
+    changeAddr: string, //optional
+    username: string,
+    password: string
+}) ->
+{
+    txID: string,
+    changeAddr: string,
+}
+```
+
+- `assetID` is the assetID of the newly created NFT asset.
+- `payload` is an arbitrary payload of up to 1024 bytes. Its encoding format is specified by the
+  `encoding` argument.
+- `from` are the addresses that you want to use for this operation. If omitted, uses any of your
+  addresses as needed.
+- `changeAddr` is the address any change will be sent to. If omitted, change is sent to one of the
+  addresses controlled by the user.
+- `username` is the user that pays the transaction fee. `username` must hold keys giving it
+  permission to mint more of this asset. That is, it must control at least _threshold_ keys for one
+  of the minter sets.
+- `txID` is this transaction’s ID.
+- `changeAddr` in the result is the address where any change was sent.
+- `encoding` is the encoding format to use for the payload argument. Can only be `hex` when a value
+  is provided.
+
+**Example Call:**
+
+```sh
+curl -X POST --data '{
+    "jsonrpc":"2.0",
+    "id"     : 1,
+    "method" :"avm.mintNFT",
+    "params" :{
+        "assetID":"2KGdt2HpFKpTH5CtGZjYt5XPWs6Pv9DLoRBhiFfntbezdRvZWP",
+        "payload":"0x415641204c61627338259aed",
+        "to":"X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5",
+        "from":["X-avax18jma8ppw3nhx5r4ap8clazz0dps7rv5ukulre5"],
+        "changeAddr":"X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8",
+        "username":"myUsername",
+        "password":"myPassword"
+    }
+}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/X
+```
+
+**Example Response:**
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": {
+    "txID": "2oGdPdfw2qcNUHeqjw8sU2hPVrFyNUTgn6A8HenDra7oLCDtja",
+    "changeAddr": "X-avax1turszjwn05lflpewurw96rfrd3h6x8flgs5uf8"
+  }
 }
 ```
 


### PR DESCRIPTION
I alphabetized the following API docs to make them easier to visually browse. No content changed. This was strictly alphabetizing the endpoints.

- X-Chain
- Index
- Info
- Platform
- C-Chain

Also decrement the `sidebar_position` by 1 for each of these files

- Admin
- Auth
- Health
- Index
- info
- IPC
- Keystore
- Metrics
- Subnet-EVM