### PR TITLE
Update PrecompileGen tutorial to use create precompile script

### DIFF
--- a/docs/subnets/hello-world-precompile-tutorial.md
+++ b/docs/subnets/hello-world-precompile-tutorial.md
@@ -274,7 +274,7 @@ Let's go back to the root of the Subnet-EVM repository and run the PrecompileGen
 ```bash
 cd $GOPATH/src/github.com/ava-labs/subnet-evm
 
-go run ./cmd/precompilegen/main.go --abi ./contract-examples/contracts/IHelloWorld.abi --type HelloWorld --pkg precompile --out ./precompile/hello_world.go
+./scripts/create_precompile.sh --abi ./contract-examples/contracts/IHelloWorld.abi --type HelloWorld --pkg precompile --out ./precompile/hello_world.go
 ```
 
 <!-- markdownlint-enable MD013 -->

--- a/docs/subnets/hello-world-precompile-tutorial.md
+++ b/docs/subnets/hello-world-precompile-tutorial.md
@@ -274,7 +274,7 @@ Let's go back to the root of the Subnet-EVM repository and run the PrecompileGen
 ```bash
 cd $GOPATH/src/github.com/ava-labs/subnet-evm
 
-./scripts/create_precompile.sh --abi ./contract-examples/contracts/IHelloWorld.abi --type HelloWorld --pkg precompile --out ./precompile/hello_world.go
+./scripts/generate_precompile.sh --abi ./contract-examples/contracts/IHelloWorld.abi --type HelloWorld --pkg precompile --out ./precompile/hello_world.go
 ```
 
 <!-- markdownlint-enable MD013 -->


### PR DESCRIPTION
This PR updates the PrecompileGen tutorial to use the new script `./scripts/create_precompile.sh` instead of directly running it with the `go run ...` command.

This change was made to address https://github.com/ava-labs/subnet-evm/issues/483.

Since we use the blst library in AvalancheGo, we need to set a CGO flag when compiling/running subnet-evm on some OSs. I have not been able to reproduce this bug, so we should hold off on merging this PR until the reporter confirms that this resolves the issue and the corresponding subnet-evm PR gets merged.