### PR TITLE
http flags update

### DIFF
--- a/docs/apis/avalanchego/avalanchego-release-notes.md
+++ b/docs/apis/avalanchego/avalanchego-release-notes.md
@@ -85,7 +85,7 @@ It is optional, but encouraged. The supported plugin version is `24`.
 
 - Added support to specify `HTTP` server timeouts
   - `--http-read-timeout`
-  - `--http-read-header-timeout`  
+  - `--http-read-header-timeout`
   - `--http-write-timeout`
   - `--http-idle-timeout`
 

--- a/docs/apis/avalanchego/avalanchego-release-notes.md
+++ b/docs/apis/avalanchego/avalanchego-release-notes.md
@@ -84,10 +84,10 @@ It is optional, but encouraged. The supported plugin version is `24`.
 **Configs**
 
 - Added support to specify `HTTP` server timeouts
-  - `--http-read-timeout`
-  - `--http-read-header-timeout`
-  - `--http-write-timeout`
-  - `--http-idle-timeout`
+  - `--http-read-timeout` - Maximum duration for reading the entire request, including the body. A zero or negative value means there will be no timeout.
+  - `--http-read-header-timeout` - Maximum duration to read request headers. The connection’s read deadline is reset after reading the headers. If %s is zero, the value of %s is used. If both are zero, there is no timeout.
+  - `--http-write-timeout` - Maximum duration before timing out writes of the response. It is reset whenever a new request’s header is read. A zero or negative value means there will be no timeout.
+  - `--http-idle-timeout` - Maximum duration to wait for the next request when keep-alives are enabled. If %s is zero, the value of %s is used. If both are zero, there is no timeout.
 
 **APIs**
 

--- a/docs/apis/avalanchego/avalanchego-release-notes.md
+++ b/docs/apis/avalanchego/avalanchego-release-notes.md
@@ -84,10 +84,10 @@ It is optional, but encouraged. The supported plugin version is `24`.
 **Configs**
 
 - Added support to specify `HTTP` server timeouts
-  - `--http-read-timeout` - Maximum duration for reading the entire request, including the body. A zero or negative value means there will be no timeout.
-  - `--http-read-header-timeout` - Maximum duration to read request headers. The connection’s read deadline is reset after reading the headers. If %s is zero, the value of %s is used. If both are zero, there is no timeout.
-  - `--http-write-timeout` - Maximum duration before timing out writes of the response. It is reset whenever a new request’s header is read. A zero or negative value means there will be no timeout.
-  - `--http-idle-timeout` - Maximum duration to wait for the next request when keep-alives are enabled. If %s is zero, the value of %s is used. If both are zero, there is no timeout.
+  - `--http-read-timeout`
+  - `--http-read-header-timeout`  
+  - `--http-write-timeout`
+  - `--http-idle-timeout`
 
 **APIs**
 

--- a/docs/nodes/maintain/avalanchego-config-flags.md
+++ b/docs/nodes/maintain/avalanchego-config-flags.md
@@ -459,6 +459,28 @@ content of the TLS private key used by the node for the HTTPS server. Note that
 full private key content, with the leading and trailing header, must be base64
 encoded. This must be specified when `--http-tls-enabled=true`.
 
+#### `--http-read-timeout` (string)
+
+Maximum duration for reading the entire request, including the body. A zero or
+negative value means there will be no timeout.
+
+#### `--http-read-header-timeout` (string)
+
+Maximum duration to read request headers. The connection’s read deadline is
+reset after reading the headers. If %s is zero, the value of %s is used. If both
+are zero, there is no timeout.
+
+#### `--http-write-timeout` (string)
+
+Maximum duration before timing out writes of the response. It is reset whenever
+a new request’s header is read. A zero or negative value means there will be no
+timeout.
+
+#### `--http-idle-timeout` (string)
+
+Maximum duration to wait for the next request when keep-alives are enabled. If
+%s is zero, the value of %s is used. If both are zero, there is no timeout.
+
 ## IPCs
 
 #### `--ipcs-chain-ids` (string)


### PR DESCRIPTION
The flag definitions came directly from AvalancheGo

- [--http-read-timeout](https://github.com/ava-labs/avalanchego/blob/master/config/flags.go#L206)
- [--http-read-header-timeout](https://github.com/ava-labs/avalanchego/blob/master/config/flags.go#L207)
- [--http-write-timeout](https://github.com/ava-labs/avalanchego/blob/master/config/flags.go#L208)
- [--http-idle-timeout](https://github.com/ava-labs/avalanchego/blob/master/config/flags.go#L209)
