### PR TITLE
Add warning message about deprecated APIs

### DIFF
--- a/docs/apis/avalanchego/apis/ipc.md
+++ b/docs/apis/avalanchego/apis/ipc.md
@@ -53,7 +53,7 @@ This API uses the `json 2.0` RPC format.
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -99,7 +99,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 

--- a/docs/apis/avalanchego/apis/ipc.md
+++ b/docs/apis/avalanchego/apis/ipc.md
@@ -53,7 +53,7 @@ This API uses the `json 2.0` RPC format.
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -99,7 +99,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 

--- a/docs/apis/avalanchego/apis/ipc.md
+++ b/docs/apis/avalanchego/apis/ipc.md
@@ -50,6 +50,13 @@ This API uses the `json 2.0` RPC format.
 
 ### `ipcs.publishBlockchain`
 
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 Register a blockchain so it publishes accepted vertices to a Unix domain socket.
 
 **Signature:**
@@ -89,6 +96,12 @@ curl -X POST --data '{
 ```
 
 ### `ipcs.unpublishBlockchain`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Deregister a blockchain so that it no longer publishes to a Unix domain socket.
 

--- a/docs/apis/avalanchego/apis/keystore.md
+++ b/docs/apis/avalanchego/apis/keystore.md
@@ -47,7 +47,7 @@ This API uses the `json 2.0` API format. For more information on making JSON RPC
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -96,7 +96,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -136,7 +136,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -192,7 +192,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -244,7 +244,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 

--- a/docs/apis/avalanchego/apis/keystore.md
+++ b/docs/apis/avalanchego/apis/keystore.md
@@ -45,6 +45,12 @@ This API uses the `json 2.0` API format. For more information on making JSON RPC
 
 ### keystore.createUser
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 Create a new user with the specified username and password.
 
 **Signature:**
@@ -88,6 +94,12 @@ curl -X POST --data '{
 
 ### keystore.deleteUser
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 Delete a user.
 
 **Signature:**
@@ -121,6 +133,12 @@ curl -X POST --data '{
 ```
 
 ### keystore.exportUser
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Export a user. The user can be imported to another node with
 [`keystore.importUser`](keystore.md#keystoreimportuser). The user’s password remains encrypted.
@@ -172,6 +190,12 @@ curl -X POST --data '{
 
 ### keystore.importUser
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 Import a user. `password` must match the user’s password. `username` doesn’t have to match the
 username `user` had when it was exported.
 
@@ -217,6 +241,12 @@ curl -X POST --data '{
 ```
 
 ### keystore.listUsers
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 List the users in this keystore.
 

--- a/docs/apis/avalanchego/apis/keystore.md
+++ b/docs/apis/avalanchego/apis/keystore.md
@@ -47,7 +47,7 @@ This API uses the `json 2.0` API format. For more information on making JSON RPC
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -96,7 +96,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -136,7 +136,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -192,7 +192,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -244,7 +244,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 

--- a/docs/apis/avalanchego/apis/p-chain.md
+++ b/docs/apis/avalanchego/apis/p-chain.md
@@ -25,7 +25,7 @@ This API uses the `json 2.0` RPC format.
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -129,7 +129,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -224,7 +224,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -345,7 +345,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -396,7 +396,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -491,7 +491,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -570,7 +570,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -642,7 +642,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -700,7 +700,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -915,7 +915,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1302,7 +1302,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1509,7 +1509,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1569,7 +1569,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1674,7 +1674,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -2198,7 +2198,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -2277,7 +2277,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -2377,7 +2377,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 

--- a/docs/apis/avalanchego/apis/p-chain.md
+++ b/docs/apis/avalanchego/apis/p-chain.md
@@ -25,7 +25,7 @@ This API uses the `json 2.0` RPC format.
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -129,7 +129,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -224,7 +224,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -345,7 +345,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -396,7 +396,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -491,7 +491,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -570,7 +570,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -642,7 +642,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -700,7 +700,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -915,7 +915,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1302,7 +1302,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1509,7 +1509,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1569,7 +1569,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1674,7 +1674,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -2198,7 +2198,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -2277,7 +2277,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -2377,7 +2377,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 

--- a/docs/apis/avalanchego/apis/p-chain.md
+++ b/docs/apis/avalanchego/apis/p-chain.md
@@ -23,6 +23,12 @@ This API uses the `json 2.0` RPC format.
 
 ### `platform.addDelegator`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -121,6 +127,12 @@ curl -X POST --data '{
 
 ### `platform.addSubnetValidator`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -209,6 +221,12 @@ curl -X POST --data '{
 ```
 
 ### `platform.addValidator`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 
@@ -325,6 +343,12 @@ curl -X POST --data '{
 
 ### `platform.createAddress`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -369,6 +393,12 @@ curl -X POST --data '{
 ```
 
 ### `platform.createBlockchain`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 
@@ -459,6 +489,12 @@ curl -X POST --data '{
 
 ### `platform.createSubnet`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -532,6 +568,12 @@ curl -X POST --data '{
 
 ### `platform.exportAVAX`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 Send AVAX from an address on the P-Chain to an address on the X-Chain or C-Chain. After issuing this
 transaction, you must call the X-Chain's [`avm.import`](x-chain.md#avmimport) or C-Chain's
 [`avax.import`](c-chain.md#avaximport) with assetID `AVAX` to complete the transfer.
@@ -598,6 +640,12 @@ curl -X POST --data '{
 
 ### `platform.exportKey`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -649,6 +697,12 @@ curl -X POST --data '{
 ```
 
 ### `platform.getBalance`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Get the balance of AVAX controlled by a given address.
 
@@ -858,6 +912,12 @@ curl -X POST --data '{
 ```
 
 ### `platform.getBlockchains`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Get all the blockchains that exist (excluding the P-Chain).
 
@@ -1240,6 +1300,12 @@ curl -X POST --data '{
 
 ### `platform.getMaxStakeAmount`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 Returns the maximum amount of nAVAX staking to the named node during a particular time period.
 
 **Signature:**
@@ -1441,6 +1507,12 @@ curl -X POST --data '{
 
 ### `platform.getRewardUTXOs`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 Returns the UTXOs that were rewarded after the provided transaction's staking or delegation period
 ended.
 
@@ -1494,6 +1566,12 @@ curl -X POST --data '{
 ```
 
 ### `platform.getStake`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Get the amount of nAVAX staked by a set of addresses. The amount returned does not include staking
 rewards.
@@ -1593,6 +1671,12 @@ curl -X POST --data '{
 ```
 
 ### `platform.getSubnets`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Get info about the Subnets.
 
@@ -2112,6 +2196,12 @@ curl -X POST --data '{
 
 ### `platform.importAVAX`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -2184,6 +2274,12 @@ curl -X POST --data '{
 ```
 
 ### `platform.importKey`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 
@@ -2278,6 +2374,12 @@ curl -X POST --data '{
 ```
 
 ### `platform.listAddresses`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 

--- a/docs/apis/avalanchego/apis/x-chain.md
+++ b/docs/apis/avalanchego/apis/x-chain.md
@@ -186,7 +186,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -239,7 +239,7 @@ TODO: Add avm.createAsset
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -333,7 +333,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -421,7 +421,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -522,7 +522,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -605,7 +605,7 @@ TODO: Add avm.exportAVAX
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -660,7 +660,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -732,7 +732,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -838,7 +838,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1231,7 +1231,7 @@ This gives response:
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1296,7 +1296,7 @@ TODO: Add avm.importAVAX
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1392,7 +1392,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1441,7 +1441,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1518,7 +1518,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1599,7 +1599,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1672,7 +1672,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1755,7 +1755,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of **v1.9.12**.
+Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1832,7 +1832,7 @@ This call is made to the wallet API endpoint:
 
 :::caution
 
-Endpoint deprecated as of **v1.9.12**.
+Endpoint deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1888,7 +1888,7 @@ This call is made to the wallet API endpoint:
 
 :::caution
 
-Endpoint deprecated as of **v1.9.12**.
+Endpoint deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1966,7 +1966,7 @@ This call is made to the wallet API endpoint:
 
 :::caution
 
-Endpoint deprecated as of **v1.9.12**.
+Endpoint deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -2048,7 +2048,7 @@ This call is made to the events API endpoint:
 
 :::caution
 
-Endpoint deprecated as of **v1.9.12**.
+Endpoint deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 

--- a/docs/apis/avalanchego/apis/x-chain.md
+++ b/docs/apis/avalanchego/apis/x-chain.md
@@ -184,6 +184,12 @@ curl -X POST --data '{
 
 ### `avm.createAddress`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
@@ -230,6 +236,12 @@ TODO: Add avm.createAsset
 -->
 
 ### `avm.createFixedCapAsset`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -319,6 +331,12 @@ curl -X POST --data '{
 
 ### `avm.createNFTAsset`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
@@ -400,6 +418,12 @@ curl -X POST --data '{
 ```
 
 ### `avm.createVariableCapAsset`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -496,6 +520,12 @@ curl -X POST --data '{
 
 ### `avm.export`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
@@ -573,6 +603,12 @@ TODO: Add avm.exportAVAX
 
 ### `avm.exportKey`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
@@ -621,6 +657,12 @@ curl -X POST --data '{
 ```
 
 ### `avm.getAddressTxs`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Returns all transactions that change the balance of the given address. A transaction is said to
 change an address's balance if either is true:
@@ -687,6 +729,12 @@ curl -X POST --data '{
 ```
 
 ### `avm.getAllBalances`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Get the balances of all assets controlled by a given address.
 
@@ -787,6 +835,12 @@ curl -X POST --data '{
 ```
 
 ### `avm.getBalance`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 Get the balance of an asset controlled by a given address.
 
@@ -1175,6 +1229,12 @@ This gives response:
 
 ### `avm.import`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
@@ -1233,6 +1293,12 @@ curl -X POST --data '{
 TODO: Add avm.importAVAX
 -->
 ### `avm.importKey`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -1324,6 +1390,12 @@ curl -X POST --data '{
 
 ### `avm.listAddresses`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
@@ -1366,6 +1438,12 @@ curl -X POST --data '{
 ```
 
 ### `avm.mint`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -1437,6 +1515,12 @@ curl -X POST --data '{
 
 
 ### `avm.mintNFT`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -1513,6 +1597,12 @@ curl -X POST --data '{
 
 ### `avm.send`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
@@ -1579,6 +1669,12 @@ curl -X POST --data '{
 ```
 
 ### `avm.sendMultiple`
+
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
 
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
@@ -1657,6 +1753,12 @@ curl -X POST --data '{
 
 ### `avm.sendNFT`
 
+:::caution
+
+Deprecated as of **v1.9.12**.
+
+:::
+
 :::warning
 Not recommended for use on Mainnet. See warning notice in [Keystore API](./keystore.md).
 :::
@@ -1728,6 +1830,12 @@ This call is made to the wallet API endpoint:
 
 `/ext/bc/X/wallet`
 
+:::caution
+
+Endpoint deprecated as of **v1.9.12**.
+
+:::
+
 **Signature:**
 
 ```sh
@@ -1777,6 +1885,12 @@ can use the modified UTXO set.
 This call is made to the wallet API endpoint:
 
 `/ext/bc/X/wallet`
+
+:::caution
+
+Endpoint deprecated as of **v1.9.12**.
+
+:::
 
 **Signature:**
 
@@ -1849,6 +1963,12 @@ addresses and assume the TX will be accepted so that future calls can use the mo
 This call is made to the wallet API endpoint:
 
 `/ext/bc/X/wallet`
+
+:::caution
+
+Endpoint deprecated as of **v1.9.12**.
+
+:::
 
 **Signature:**
 
@@ -1925,6 +2045,13 @@ Listen for transactions on a specified address.
 This call is made to the events API endpoint:
 
 `/ext/bc/X/events`
+
+:::caution
+
+Endpoint deprecated as of **v1.9.12**.
+
+:::
+
 
 #### **Golang Example**
 

--- a/docs/apis/avalanchego/apis/x-chain.md
+++ b/docs/apis/avalanchego/apis/x-chain.md
@@ -186,7 +186,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -239,7 +239,7 @@ TODO: Add avm.createAsset
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -333,7 +333,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -421,7 +421,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -522,7 +522,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -605,7 +605,7 @@ TODO: Add avm.exportAVAX
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -660,7 +660,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -732,7 +732,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -838,7 +838,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1231,7 +1231,7 @@ This gives response:
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1296,7 +1296,7 @@ TODO: Add avm.importAVAX
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1392,7 +1392,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1441,7 +1441,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1518,7 +1518,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1599,7 +1599,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1672,7 +1672,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1755,7 +1755,7 @@ curl -X POST --data '{
 
 :::caution
 
-Deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1832,7 +1832,7 @@ This call is made to the wallet API endpoint:
 
 :::caution
 
-Endpoint deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Endpoint deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1888,7 +1888,7 @@ This call is made to the wallet API endpoint:
 
 :::caution
 
-Endpoint deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Endpoint deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -1966,7 +1966,7 @@ This call is made to the wallet API endpoint:
 
 :::caution
 
-Endpoint deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Endpoint deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 
@@ -2048,7 +2048,7 @@ This call is made to the events API endpoint:
 
 :::caution
 
-Endpoint deprecated as of [**v1.9.12**](/docs/apis/avalanchego/avalanchego-release-notes.md#v1912-view-on-github).
+Endpoint deprecated as of [**v1.9.12**](../avalanchego-release-notes.md#v1912-view-on-github).
 
 :::
 


### PR DESCRIPTION
Adding a warning message to all deprecated APIs as per [V1.9.12  release notes](https://docs.avax.network/apis/avalanchego/avalanchego-release-notes#v1912-view-on-github).