### PR TITLE
Add community made node setup guide to nodes overview page

### DIFF
--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -19,6 +19,7 @@ node, and then validate the Avalanche network using an AvalancheGo node.
 | [**Run an Avalanche Node with Google Cloud Platform**](./build/set-up-an-avalanche-node-with-google-cloud-platform.md)                      | Create a node that runs on Google GCP       |
 | [**Run an Avalanche Node with Alibaba Cloud**](./build/set-up-node-on-alibaba-cloud.md)     | Create a node that runs on Alibaba Cloud       |
 | [**Run an Avalanche Node with Tencent Cloud**](./build/set-up-node-on-tencent-cloud.md)     | Create a node that runs on Tencent Cloud       |
+| [**Run an Avalanche Node with Community Guide**](https://github.com/MoonBoi9001/Avalanche-node-quickstart-quide)     | Comprehensive Community Made Setup Guide       |
 | [**Frequently Asked Questions**](./build/FAQ.md)     | Learn about common errors when building your node.       |
 
 ## Maintain

--- a/docs/nodes/README.md
+++ b/docs/nodes/README.md
@@ -19,7 +19,7 @@ node, and then validate the Avalanche network using an AvalancheGo node.
 | [**Run an Avalanche Node with Google Cloud Platform**](./build/set-up-an-avalanche-node-with-google-cloud-platform.md)                      | Create a node that runs on Google GCP       |
 | [**Run an Avalanche Node with Alibaba Cloud**](./build/set-up-node-on-alibaba-cloud.md)     | Create a node that runs on Alibaba Cloud       |
 | [**Run an Avalanche Node with Tencent Cloud**](./build/set-up-node-on-tencent-cloud.md)     | Create a node that runs on Tencent Cloud       |
-| [**Run an Avalanche Node with Community Guide**](https://github.com/MoonBoi9001/Avalanche-node-quickstart-quide)     | Comprehensive Community Made Setup Guide       |
+| [**Setup an Avalanche Node Using Community Guide**](https://github.com/MoonBoi9001/Avalanche-node-quickstart-quide)     | Comprehensive community made setup guide       |
 | [**Frequently Asked Questions**](./build/FAQ.md)     | Learn about common errors when building your node.       |
 
 ## Maintain


### PR DESCRIPTION
I am submitting this pull request to propose the integration of my comprehensive node setup guide into the official Avalanche documentation. As a new user, I found the existing guides difficult to follow, and I believe my guide addresses the gaps and provides a more user-friendly experience for those setting up their nodes.

Throughout my own setup process, I relied heavily on the support of Ava-Labs team members on Discord. While their assistance was invaluable, I recognize that their time could be better spent on other tasks if the documentation were more thorough and user-friendly. My guide aims to alleviate this issue by providing a more comprehensive and accessible resource for new users.

In this pull request, I have added a link to my guide within the existing documentation, so users can choose to reference it if they find it helpful. I invite the Avalanche team to review my guide and provide any constructive feedback or suggestions for improvement. My ultimate goal is to contribute to the growth of Avalanche, potentially reaching over 1,000,000 validators, by making the node setup process more accessible to users of varying technical abilities.

I believe that by integrating this community-made guide, we can bridge the gap in the current documentation, enhance the user experience, and ultimately foster the growth and success of the Avalanche ecosystem.