### PR TITLE
docs: added warning that doc is in review and linked to github

### DIFF
--- a/docs/subnets/deploy-a-gnosis-safe-on-your-evm.md
+++ b/docs/subnets/deploy-a-gnosis-safe-on-your-evm.md
@@ -1,5 +1,12 @@
 # Deploy a Gnosis Safe on Your Subnet-EVM
 
+:::warning
+
+**This document is under maintenance.** For a step-by-step tutorial on how to deploy a Gnosis Safe, 
+please visit our **[GitHub](https://github.com/ava-labs/gnosis-subnet).**
+
+:::
+
 ## Introduction
 
 This article shows how to deploy and interact with a [Gnosis Safe](https://gnosis-safe.io/)


### PR DESCRIPTION
We got a report form one of subnet projects that our [Gnosis Safe tutorial](https://docs.avax.network/subnets/deploy-a-gnosis-safe-on-your-evm) is no longer correct.

This PR includes a warning and a link at the top of this tutorial page while we update the docs.