### PR TITLE
Adding an info box regarding SSH git clone 

### DIFF
--- a/docs/nodes/build/run-avalanche-node-manually.md
+++ b/docs/nodes/build/run-avalanche-node-manually.md
@@ -113,9 +113,11 @@ cd avalanchego
 ```
 
 :::info
-The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
-how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
-Without a public SSH key, the cloning process will not go through. 
+The repository cloning method used is SSH, which requires additional steps. 
+You can find more about SSH and how to use it 
+[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process 
+will not go through. 
 As an alternative, you can use the HTTPS method:
 
 `git clone https://github.com/ava-labs/avalanchego.git`

--- a/docs/nodes/build/run-avalanche-node-manually.md
+++ b/docs/nodes/build/run-avalanche-node-manually.md
@@ -112,6 +112,15 @@ git clone git@github.com:ava-labs/avalanchego.git
 cd avalanchego
 ```
 
+:::info
+The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
+how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process will not go through. 
+As an alternative, you can use the HTTPS method:
+
+`git clone https://github.com/ava-labs/avalanchego.git`
+:::
+
 Note: This checkouts to the master branch. For the latest stable version, checkout the latest tag.
 
 Build AvalancheGo:

--- a/docs/subnets/create-custom-subnet.md
+++ b/docs/subnets/create-custom-subnet.md
@@ -16,10 +16,13 @@ First off, clone the Subnet-EVM repository into a directory of your choosing.
 ```shell
 git clone git@github.com:ava-labs/subnet-evm.git
 ```
+
 :::info
-The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
-how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
-Without a public SSH key, the cloning process will not go through. 
+The repository cloning method used is SSH, which requires additional steps. 
+You can find more about SSH and how to use it 
+[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process 
+will not go through. 
 As an alternative, you can use the HTTPS method:
 
 `git clone https://github.com/ava-labs/subnet-evm.git`

--- a/docs/subnets/create-custom-subnet.md
+++ b/docs/subnets/create-custom-subnet.md
@@ -16,6 +16,14 @@ First off, clone the Subnet-EVM repository into a directory of your choosing.
 ```shell
 git clone git@github.com:ava-labs/subnet-evm.git
 ```
+:::info
+The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
+how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process will not go through. 
+As an alternative, you can use the HTTPS method:
+
+`git clone https://github.com/ava-labs/subnet-evm.git`
+:::
 
 ### Modify Subnet-EVM
 

--- a/docs/subnets/hello-world-precompile-tutorial.md
+++ b/docs/subnets/hello-world-precompile-tutorial.md
@@ -201,9 +201,11 @@ npm install -g yarn
 ```
 
 :::info
-The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
-how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
-Without a public SSH key, the cloning process will not go through. 
+The repository cloning method used is SSH, which requires additional steps. 
+You can find more about SSH and how to use it 
+[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process 
+will not go through. 
 As an alternative, you can use the HTTPS method:
 
 `git clone https://github.com/ava-labs/subnet-evm.git`

--- a/docs/subnets/hello-world-precompile-tutorial.md
+++ b/docs/subnets/hello-world-precompile-tutorial.md
@@ -200,6 +200,17 @@ npm install -g solc
 npm install -g yarn
 ```
 
+:::info
+The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
+how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process will not go through. 
+As an alternative, you can use the HTTPS method:
+
+`git clone https://github.com/ava-labs/subnet-evm.git`
+
+`git clone https://github.com/ava-labs/avalanchego.git`
+:::
+
 ### Complete Code
 
 You can inspect the [Hello World Pull Request](https://github.com/ava-labs/subnet-evm/pull/565/)

--- a/docs/subnets/setup-dfk-node.md
+++ b/docs/subnets/setup-dfk-node.md
@@ -35,6 +35,15 @@ git clone git@github.com:ava-labs/subnet-evm.git
 cd subnet-evm
 ```
 
+:::info
+The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
+how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process will not go through. 
+As an alternative, you can use the HTTPS method:
+
+`git clone https://github.com/ava-labs/subnet-evm.git`
+:::
+
 Now that you are in the `ava-labs/subnet-evm` repository, you will build the binary and place it
 directly into the `plugins` directory. To do this, you will pass in the desired
 path to place the plugin binary. You will want to place this binary into the plugins directory of
@@ -125,3 +134,14 @@ cd subnet-evm
 cd $GOPATH/src/github.com/ava-labs/avalanchego
 ./build/avalanchego --track-subnets Vn3aX6hNRstj5VHHm63TCgPNaeGnRSqCYXQqemSqDd2TQH4qJ
 ```
+
+:::info
+The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
+how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process will not go through. 
+As an alternative, you can use the HTTPS method:
+
+`git clone https://github.com/ava-labs/avalanchego.git`
+
+`git clone https://github.com/ava-labs/subnet-evm.git`
+:::

--- a/docs/subnets/setup-dfk-node.md
+++ b/docs/subnets/setup-dfk-node.md
@@ -36,9 +36,11 @@ cd subnet-evm
 ```
 
 :::info
-The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
-how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
-Without a public SSH key, the cloning process will not go through. 
+The repository cloning method used is SSH, which requires additional steps. 
+You can find more about SSH and how to use it 
+[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process 
+will not go through. 
 As an alternative, you can use the HTTPS method:
 
 `git clone https://github.com/ava-labs/subnet-evm.git`
@@ -136,9 +138,11 @@ cd $GOPATH/src/github.com/ava-labs/avalanchego
 ```
 
 :::info
-The repository cloning method used is SSH, which requires additional steps. You can find more about SSH and 
-how to use it [here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
-Without a public SSH key, the cloning process will not go through. 
+The repository cloning method used is SSH, which requires additional steps. 
+You can find more about SSH and how to use it 
+[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+Without a public SSH key, the cloning process 
+will not go through. 
 As an alternative, you can use the HTTPS method:
 
 `git clone https://github.com/ava-labs/avalanchego.git`


### PR DESCRIPTION
We use SSH git cloning, and not all users are aware of this stuff. Recently I've seen a user having trouble cloning the repo because of this.

I suggest adding this warning message that let's users know about SSH and the HTTPS alternative.