### PR TITLE
Removing Mixed Query Flags

### DIFF
--- a/docs/nodes/maintain/avalanchego-config-flags.md
+++ b/docs/nodes/maintain/avalanchego-config-flags.md
@@ -1030,18 +1030,6 @@ Maximum amount of time an item should be processing and still be healthy.
 Reports unhealthy if there is an item processing for longer than this duration.
 The value must be greater than `0`. Defaults to `2m`.
 
-##### `--snow-mixed-query-num-push-vdr` (uint)
-
-If this node is a validator, when a container is inserted into consensus, send a
-Push Query to this many validators and a Pull Query to the others. Must be <= k.
-Defaults to `10`.
-
-##### `--snow-mixed-query-num-push-non-vdr` (uint)
-
-If this node is not a validator, when a container is inserted into consensus,
-send a Push Query to %s validators and a Pull Query to the others. Must be <= k.
-Defaults to `0`.
-
 ### ProposerVM Parameters
 
 #### `--proposervm-use-current-height` (bool)

--- a/docs/nodes/maintain/subnet-configs.md
+++ b/docs/nodes/maintain/subnet-configs.md
@@ -89,8 +89,6 @@ Parameters](./avalanchego-config-flags.md#snow-parameters).
 | --snow-optimal-processing           | `optimalProcessing`      |
 | --snow-max-processing               | maxOutstandingItems      |
 | --snow-max-time-processing          | maxItemProcessingTime    |
-| --snow-mixed-query-num-push-vdr     | mixedQueryNumPushVdr     |
-| --snow-mixed-query-num-push-non-vdr | mixedQueryNumPushNondVdr |
 | --snow-avalanche-batch-size         | `batchSize`              |
 | --snow-avalanche-num-parents        | `parentSize`             |
 


### PR DESCRIPTION
As part of https://github.com/ava-labs/avalanchego/pull/1428 we are removing mixed queries, so the corresponding configs can be removed.