### PR TITLE
Sidebars and css implementation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -32,9 +32,10 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          sidebarPath: require.resolve("./sidebars.js"),
+          // sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
           editUrl: "https://github.com/ava-labs/avalanche-docs/edit/master/",
+          sidebarPath: "./sidebars.json",
           remarkPlugins: [math],
           rehypePlugins: [katex],
         },

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -32,7 +32,6 @@ const config = {
       /** @type {import('@docusaurus/preset-classic').Options} */
       ({
         docs: {
-          // sidebarPath: require.resolve("./sidebars.js"),
           routeBasePath: "/",
           editUrl: "https://github.com/ava-labs/avalanche-docs/edit/master/",
           sidebarPath: "./sidebars.json",

--- a/sidebars.json
+++ b/sidebars.json
@@ -1,0 +1,298 @@
+{
+  "learn": [
+    "learn/avalanche/intro",
+    {
+      "type": "html",
+      "value": "<hr/>"
+    },
+    {
+      "type": "html",
+      "value": "<span class='menu__link'><b><small> The Avalanche Protocol </small></b></span>"
+    },
+    "learn/avalanche/avalanche-platform",
+    "learn/avalanche/avalanche-consensus",
+    "learn/avalanche/avax",
+    "learn/avalanche/subnets-overview",
+    "learn/avalanche/virtual-machines",
+    {
+      "type": "html",
+      "value": "<hr/>"
+    },
+    "learn/projects",
+    {
+      "type": "link",
+      "label": "Whitepapers",
+      "href": "https://www.avalabs.org/whitepapers"
+    },
+    {
+      "type": "link",
+      "label": "Audits",
+      "href": "https://github.com/ava-labs/audits"
+    },
+    "disclaimer"
+  ],
+  "quickStart": [
+    "quickstart/README",
+    "quickstart/fuji-workflow",
+    "quickstart/cross-chain-transfers",
+    "quickstart/multisig-utxos-with-avalanchejs",
+    "quickstart/transaction-fees",
+    "quickstart/adjusting-gas-price-during-high-network-activity",
+    "quickstart/sending-transactions-with-dynamic-fees-using-javascript",
+    "quickstart/tools-list",
+    "quickstart/integrate-exchange-with-avalanche",
+    "quickstart/blockchain-flow"
+  ],
+  "dapps": [
+    "dapps/launch-your-ethereum-dapp",
+    {
+      "type": "category",
+      "label": "Developer Toolchains",
+      "collapsed": true,
+      "items": [
+        "dapps/developer-toolchains/README",
+        "dapps/developer-toolchains/using-foundry-with-the-avalanche-c-chain",
+        "dapps/developer-toolchains/using-hardhat-with-the-avalanche-c-chain",
+        "dapps/developer-toolchains/using-truffle-with-the-avalanche-c-chain",
+        "dapps/developer-toolchains/verify-smart-contract-using-hardhat-and-snowtrace",
+        "dapps/developer-toolchains/verify-smart-contracts-with-truffle-verify"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Non Fungible Tokens (NFTs)",
+      "collapsed": true,
+      "items": [
+        "dapps/nfts/README",
+        "dapps/nfts/intro-to-erc721s",
+        "dapps/nfts/preparing-nft-files"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Smart Contract",
+      "collapsed": true,
+      "items": [
+        "dapps/smart-contracts/README",
+        "dapps/smart-contracts/create-erc-20-token-on-avalanche-c-chain",
+        "dapps/smart-contracts/deploy-a-smart-contract-on-avalanche-using-remix-and-metamask",
+        "dapps/smart-contracts/verify-smart-contracts",
+        "dapps/smart-contracts/add-avalanche-programmatically"
+      ]
+    }
+  ],
+  "subnets": [
+    {
+      "type": "category",
+      "label": "Are Subnets Right For You?",
+      "collapsed": true,
+      "items": [
+        "subnets/when-to-use-subnet-vs-c-chain",
+        "subnets/subnet-development-lifecycle"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Build Your First Subnet",
+      "collapsed": true,
+      "items": [
+        "subnets/install-avalanche-cli",
+        "subnets/build-first-subnet",
+        "subnets/create-a-fuji-subnet",
+        "subnets/create-a-mainnet-subnet",
+        "subnets/deploy-a-smart-contract-on-your-evm",
+        "subnets/create-custom-subnet",
+        "subnets/create-a-evm-blockchain-on-subnet-with-avalanchejs"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "How to Use Avalanche-CLI",
+      "collapsed": true,
+      "items": [
+        "subnets/create-evm-subnet-config",
+        "subnets/create-a-local-subnet",
+        "subnets/multisig-deploy",
+        "subnets/how-to-pause-and-resume-subnets",
+        "subnets/how-to-list-and-describe",
+        "subnets/how-to-delete-subnet",
+        "subnets/how-to-upgrade-subnet-vm",
+        "subnets/how-to-upgrade-precompile",
+        "subnets/how-to-run-cli-with-docker",
+        "subnets/how-to-import-subnet",
+        "subnets/troubleshoot-deployments"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Customize",
+      "collapsed": true,
+      "items": [
+        "subnets/customize-a-subnet",
+        "subnets/hello-world-precompile-tutorial",
+        "subnets/introduction-to-vm",
+        "subnets/create-a-vm-timestampvm",
+        "subnets/create-a-vm-blobvm",
+        "subnets/create-a-simple-rust-vm",
+        "subnets/create-a-simple-vm-from-scratch",
+        "subnets/cross-subnet-communication"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Deploy",
+      "collapsed": true,
+      "items": ["subnets/deploying-subnets-on-prod", "subnets/setup-dfk-node"]
+    },
+    {
+      "type": "category",
+      "label": "Upgrade",
+      "collapsed": true,
+      "items": ["subnets/subnet-upgrade", "subnets/case-study-wagmi-upgrade"]
+    },
+    {
+      "type": "category",
+      "label": "Tools",
+      "collapsed": true,
+      "items": [
+        "subnets/avalanche-subnet-faucet",
+        "subnets/deploying-cross-chain-evm-bridge",
+        "subnets/network-runner",
+        "subnets/deploy-a-gnosis-safe-on-your-evm"
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Examples",
+      "collapsed": true,
+      "items": ["subnets/wagmi"]
+    },
+    {
+      "type": "category",
+      "label": "Technical Reference",
+      "collapsed": true,
+      "items": [
+        "subnets/reference-cli-commands",
+        "subnets/reference-elastic-subnets-parameters"
+      ]
+    },
+    {
+      "type": "link",
+      "label": "Subnet FAQ",
+      "href": "https://support.avax.network/en/articles/6158840-subnet-faq"
+    }
+  ],
+  "apis": [
+    "apis/README",
+    {
+      "type": "category",
+      "label": "AvalancheGo",
+      "collapsed": true,
+      "items": [
+        "apis/avalanchego/README",
+        {
+          "type": "category",
+          "label": "APIs",
+          "collapsed": true,
+          "items": [
+            {
+              "type": "autogenerated",
+              "dirName": "apis/avalanchego/apis"
+            }
+          ]
+        },
+        "apis/avalanchego/public-api-server",
+        "apis/avalanchego/postman-avalanche-collection",
+        "apis/avalanchego/x-chain-migration",
+        "apis/avalanchego/cb58-deprecation",
+        {
+          "type": "link",
+          "label": "Release Notes",
+          "href": "https://github.com/ava-labs/avalanchego/releases"
+        }
+      ]
+    },
+    {
+      "type": "category",
+      "label": "AvalancheJS",
+      "collapsed": true,
+      "items": [
+        "apis/avalanchejs/README",
+        "apis/avalanchejs/api",
+        "apis/avalanchejs/create-an-asset-on-the-x-chain",
+        "apis/avalanchejs/manage-x-chain-keys",
+        "apis/avalanchejs/send-an-asset-on-the-x-chain",
+        "apis/avalanchejs/generate-a-txid-using-avalanchejs"
+      ]
+    },
+    "apis/metrics",
+    "apis/glacier"
+  ],
+  "nodes": [
+    "nodes/README",
+    {
+      "type": "category",
+      "label": "Build",
+      "collapsed": true,
+      "items": [
+        {
+          "type": "autogenerated",
+          "dirName": "nodes/build"
+        }
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Maintain",
+      "collapsed": true,
+      "items": [
+        {
+          "type": "autogenerated",
+          "dirName": "nodes/maintain"
+        }
+      ]
+    },
+    {
+      "type": "category",
+      "label": "Validate",
+      "collapsed": true,
+      "items": [
+        {
+          "type": "autogenerated",
+          "dirName": "nodes/validate"
+        }
+      ]
+    }
+  ],
+
+  "specs": [
+    "specs/avm-transaction-serialization",
+    "specs/coreth-atomic-transaction-serialization",
+    "specs/cryptographic-primitives",
+    "specs/network-protocol",
+    "specs/serialization-primitives",
+    "specs/platform-transaction-serialization",
+    "specs/abigen",
+    "specs/banff-changes"
+  ],
+
+  "community": [
+    "community/README",
+    "community/bug-bounty",
+    {
+      "type": "link",
+      "label": "Product Support",
+      "href": "https://support.avax.network/en/"
+    },
+    {
+      "type": "category",
+      "label": "Tutorials Contest",
+      "collapsed": true,
+      "items": [
+        "community/tutorials-contest/README",
+        "community/tutorials-contest/2022",
+        "community/tutorials-contest/2021"
+      ]
+    }
+  ]
+}

--- a/sidebars.json
+++ b/sidebars.json
@@ -1,6 +1,5 @@
 {
   "learn": [
-    "learn/avalanche/intro",
     {
       "type": "html",
       "value": "<hr/>"
@@ -9,6 +8,7 @@
       "type": "html",
       "value": "<span class='menu__link'><b><small> The Avalanche Protocol </small></b></span>"
     },
+    "learn/avalanche/intro",
     "learn/avalanche/avalanche-platform",
     "learn/avalanche/avalanche-consensus",
     "learn/avalanche/avax",

--- a/sidebars.json
+++ b/sidebars.json
@@ -2,10 +2,6 @@
   "learn": [
     {
       "type": "html",
-      "value": "<hr/>"
-    },
-    {
-      "type": "html",
       "value": "<span class='menu__link'><b><small> The Avalanche Protocol </small></b></span>"
     },
     "learn/avalanche/intro",

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -194,3 +194,24 @@ html[data-theme='dark'] .header-github-link:before {
 html[data-theme='dark'] .header-discord-link:before {
   filter: invert(100%);
 }
+
+hr {
+  height: 1px;
+  border-radius: 0;
+  margin: 3.5em 0;
+}
+
+li hr {
+  height: 4px;
+  margin: 0.2em auto;
+  width: 90%;
+  border-width: 0;
+}
+
+[data-theme='light'] li hr {
+  background-color: #f8f8f8;
+}
+
+[data-theme='dark'] li hr {
+  background-color: #333;
+}


### PR DESCRIPTION
# Why this should be merged

Currently our sidebars are autogenerated according to the path each MD is stored in the `docs` folder. While this is simple, it does not allow us to customize the sidebar and it constricts the structure of our sidebar to only 1-2 dimensions max. This migration to using the `sidebars.json` manually gives us more control of the style and flow of our sidebars. 

In the future, we plan to have multiple styled sections in the sidebars similar to our competitors to ease our user flow and add better aesthetics to the dev docs.

# How this works 

The docusaurus config file references the `sidebars.json` to build the sidebars for each tab. You can now inject html elements into the sidebar. If a path is not explicitly referenced in this .json, it will not show in our website. This is actually useful because we now have control over which pages we hide/show, and don't have to full remove .md from our repository if it is WIP or considered obsolete.  