### PR TITLE
Add Explanatory Fuji

### DIFF
--- a/docs/learn/avalanche/avalanche-platform.md
+++ b/docs/learn/avalanche/avalanche-platform.md
@@ -15,6 +15,10 @@ The Primary Network is a special [Subnet](subnets-overview.md) that runs three b
 - The Platform Chain [(P-Chain)](avalanche-platform.md#p-chain)
 - The Exchange Chain [(X-Chain)](avalanche-platform.md#x-chain)
 
+:::note
+Avalanche Mainnet is comprised of the Primary Network and all deployed Subnets.
+:::
+
 A node can become a validator for the Primary Network by staking at least **2,000 AVAX**.
 
 ![Primary network](/img/primary-network.png)

--- a/docs/learn/avalanche/fuji.md
+++ b/docs/learn/avalanche/fuji.md
@@ -10,14 +10,22 @@ with a platform to simulate the conditions found in the Mainnet environment. It 
 to deploy demo Smart Contracts, allowing them to test and refine their applications before deploying
 them on the [Primary Network](/learn/avalanche/avalanche-platform.md).
 
+## Why Use Fuji Over Mainnet?
+
 Users interested in experimenting with Avalanche can receive free testnet AVAX, allowing them to
 explore the platform without any risk. These testnet tokens have no value in the real world and are
 only meant for experimentation purposes within the Fuji test network. To receive testnet tokens, 
 users can request funds from the
 [Avalanche Faucet](/subnets/avalanche-subnet-faucet.md#using-the-faucet). 
- 
-While Fuji Network is a valuable resource, developers also
+
+## Additional Considerations
+
+- The Public API endpoint for Fuji is not the same as Mainnet. More info is avaliable in the
+[Public API Server](/apis/avalanchego/public-api-server) 
+documentation.
+- Fuji Testnet has its own dedicated block explorer on [Snowtrace](https://testnet.snowtrace.io/). 
+- While Fuji Network is a valuable resource, developers also
 have the option to explore
 [Avalanche Network Runner](https://docs.avax.network/quickstart/tools-list#avalanche-network-runner-anr)
 as an alternative means of locally testing their projects, ensuring comprehensive evaluation and 
-fine-tuning before interacting with the wider network.
+fine-tuning before interacting with the wider network. 

--- a/docs/learn/avalanche/fuji.md
+++ b/docs/learn/avalanche/fuji.md
@@ -5,25 +5,31 @@ sidebar_label: Fuji Testnet
 
 # Fuji Testnet
 
-The Fuji Testnet serves as the official testnet within the Avalanche ecosystem, providing users
-with a platform to simulate the conditions found in the Mainnet environment. It enables developers
-to deploy demo Smart Contracts, allowing them to test and refine their applications before deploying
-them on the [Primary Network](/learn/avalanche/avalanche-platform.md).
+The Fuji Testnet serves as the official testnet for the Avalanche ecosystem. 
+
+Fuji's infrastructure imitates Avalanche Mainnet. It's comprised of a
+[Primary Network](/learn/avalanche/avalanche-platform.md) formed by instances of X, P, and C-Chain,
+as well as many test Subnets. 
 
 ## Why Use Fuji Over Mainnet?
 
+Fuji provides users with a platform to simulate the conditions found in the Mainnet environment. It
+enables developers to deploy demo Smart Contracts, allowing them to test and refine their applications
+before deploying them on the [Primary Network](/learn/avalanche/avalanche-platform.md). 
+
 Users interested in experimenting with Avalanche can receive free testnet AVAX, allowing them to
 explore the platform without any risk. These testnet tokens have no value in the real world and are
-only meant for experimentation purposes within the Fuji test network. To receive testnet tokens, 
-users can request funds from the
+only meant for experimentation purposes within the Fuji test network. 
+
+To receive testnet tokens, users can request funds from the
 [Avalanche Faucet](/subnets/avalanche-subnet-faucet.md#using-the-faucet). 
 
 ## Additional Considerations
 
+- Fuji Testnet has its own dedicated block explorer on [Snowtrace](https://testnet.snowtrace.io/). 
 - The Public API endpoint for Fuji is not the same as Mainnet. More info is avaliable in the
 [Public API Server](/apis/avalanchego/public-api-server) 
 documentation.
-- Fuji Testnet has its own dedicated block explorer on [Snowtrace](https://testnet.snowtrace.io/). 
 - While Fuji Network is a valuable resource, developers also
 have the option to explore
 [Avalanche Network Runner](https://docs.avax.network/quickstart/tools-list#avalanche-network-runner-anr)

--- a/docs/learn/avalanche/fuji.md
+++ b/docs/learn/avalanche/fuji.md
@@ -1,0 +1,23 @@
+---
+description: Fuji testnet is the official Avalanche testnet. 
+sidebar_label: Fuji Testnet
+---
+
+# Fuji Testnet
+
+The Fuji Testnet serves as the official testnet within the Avalanche ecosystem, providing users
+with a platform to simulate the conditions found in the Mainnet environment. It enables developers
+to deploy demo Smart Contracts, allowing them to test and refine their applications before deploying
+them on the [Primary Network](/learn/avalanche/avalanche-platform.md).
+
+Users interested in experimenting with Avalanche can receive free testnet AVAX, allowing them to
+explore the platform without any risk. These testnet tokens have no value in the real world and are
+only meant for experimentation purposes within the Fuji test network. To receive testnet tokens, 
+users can request funds from the
+[Avalanche Faucet](/subnets/avalanche-subnet-faucet.md#using-the-faucet). 
+ 
+While Fuji Network is a valuable resource, developers also
+have the option to explore
+[Avalanche Network Runner](https://docs.avax.network/quickstart/tools-list#avalanche-network-runner-anr)
+as an alternative means of locally testing their projects, ensuring comprehensive evaluation and 
+fine-tuning before interacting with the wider network.

--- a/sidebars.json
+++ b/sidebars.json
@@ -5,7 +5,12 @@
       "value": "<span class='menu__link'><b><small> The Avalanche Protocol </small></b></span>"
     },
     "learn/avalanche/intro",
-    "learn/avalanche/avalanche-platform",
+    {
+      "type": "category",
+      "label": "Networks",
+      "collapsed": false,
+      "items": ["learn/avalanche/avalanche-platform", "learn/avalanche/fuji"]
+    },
     "learn/avalanche/avalanche-consensus",
     "learn/avalanche/avax",
     "learn/avalanche/subnets-overview",


### PR DESCRIPTION
## Why this should be merged

Our docs lack a high-level overview of Fuji. 

## How this works

This doc defines Fuji as our official testnet, briefly defines what a faucet is, and explains the value the testnet provides a user/developer. Fuji and The Primary Network were added to a "Networks" subsection which is expanded by default. 

## Workflow checks

- [x] ran `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [x] ran `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [x] completed the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass
- [x] all files which were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [x] `sidebars.json` also reflects any changes mentioned in the previous bullet
