### PR TITLE
Update Subnet Explorer Link in Fuji Subnet Tutorial

### DIFF
--- a/docs/subnets/create-a-fuji-subnet.md
+++ b/docs/subnets/create-a-fuji-subnet.md
@@ -536,7 +536,8 @@ Endpoint for blockchain "2XDnKyAEr1RhhWpTpMXqrjeejN23vETmDykVzkb4PrU1fQjewh" wit
 
 Well done. You have just created your own Subnet with your own Subnet-EVM running on `Fuji`.
 
-To get your new Subnet information, visit [Avascan Testnet](https://testnet.avascan.info/). The
+To get your new Subnet information, visit the
+[Avalanche Subnet Explorer](https://subnets.avax.network/). The
 search best works by blockchain ID, so in this example, enter `2XDnKyAEr1RhhWpTpMXqrjeejN23vETmDykVzkb4PrU1fQjewh`
 into the search box and you should see your shiny new blockchain information.
 


### PR DESCRIPTION
## Why this should be merged

Now that our explorer cover the P-Chain as well, can should replace AvaScan with link to our explorer.

## Workflow checks

- [x] ran `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [x] ran `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [x] completed the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass
- [x] if a doc was removed/deleted, the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [x] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [x] `_redirects` were manually verified with the cloudflare preview link
- [x] `sidebars.json` reflects all changes made to file path
