### PR TITLE
Fix typo in the precompile documentation

### DIFF
--- a/docs/subnets/hello-world-precompile-tutorial.md
+++ b/docs/subnets/hello-world-precompile-tutorial.md
@@ -808,7 +808,7 @@ func StoreGreeting(stateDB contract.StateDB, input string) {
 }
 ```
 
-The below code snippet can be copied and pasted to overwrite the default `sayGreeting()` code.
+The below code snippet can be copied and pasted to overwrite the default `setGreeting()` code.
 
 <!-- markdownlint-disable MD013 -->
 


### PR DESCRIPTION
The correct name of the function being called is `setGreeting` and not `sayGreeting`

The snippet of code embedded below the typo defines a function called `setGreeting`. This is correct. There is no `sayGreeting` function any where in the code.

<img width="1018" alt="Screenshot 2023-06-13 at 5 41 11 PM" src="https://github.com/ava-labs/avalanche-docs/assets/260614/97cd14d2-269d-41b1-ab84-6773297ae382">
