### PR TITLE
fix(introduction-to-vm): typo & url

### DIFF
--- a/docs/subnets/introduction-to-vm.md
+++ b/docs/subnets/introduction-to-vm.md
@@ -30,7 +30,7 @@ of the blockchain.
 ## Blockchain
 
 A blockchain relies on two major components: The **Consensus Engine** and the **VM**. The VM defines
-application specific behavior and how blocks are and built and parsed to create the blockchain. VMs
+application specific behavior and how blocks are built and parsed to create the blockchain. VMs
 all run on top of the Avalanche Consensus Engine, which allows nodes in the network to agree on the
 state of the blockchain. Here's a quick example of how VMs interact with consensus:
 
@@ -39,9 +39,9 @@ state of the blockchain. Here's a quick example of how VMs interact with consens
 3. The consensus engine will request the block from the VM
 4. The consensus engine will verify the returned block using the VM's implementation of `Verify()`
 5. The consensus engine will get the network to reach consensus on whether to accept or reject the newly
-verified block
+   verified block
    - Every virtuous (well-behaved) node on the network will have the same preference for a particular
-   block
+     block
 6. Depending upon the consensus results, the engine will either accept or reject the block
    - What happens when a block is accepted or rejected is specific to the implementation of the VM
 
@@ -73,11 +73,11 @@ Users can interact with a blockchain and its VM through handlers exposed by the 
 VMs expose two types of handlers to serve responses for incoming requests:
 
 - **Blockchain Handlers** - Referred to as handlers, these expose APIs to interact with a blockchain
-instantiated by a VM. The API endpoint will be different for each chain. The endpoint for a handler
-is `/ext/bc/[chainID]`.
+  instantiated by a VM. The API endpoint will be different for each chain. The endpoint for a handler
+  is `/ext/bc/[chainID]`.
 - **VM Handlers** - Referred to as static handlers, these expose APIs to interact with the VM
-directly. One example API would be to parse genesis data to instantiate a new blockchain. The endpoint
-for a static handler is `/ext/vm/[vmID]`.
+  directly. One example API would be to parse genesis data to instantiate a new blockchain. The endpoint
+  for a static handler is `/ext/vm/[vmID]`.
 
 For any readers familiar with object-oriented programming, static and non-static handlers on a VM are
 analogous to static and non-static methods on a class. Blockchain handlers can be thought of as methods
@@ -87,7 +87,7 @@ on an object, whereas VM handlers can be thought of as static methods on a class
 
 The `vm.Factory` interface is implemented to create new VM instances from which a blockchain can be
 initialized. The factory's `New` method shown below provides `AvalancheGo` with an instance of the
-VM. It's defined in the 
+VM. It's defined in the
 [`factory.go`](https://github.com/ava-labs/timestampvm/blob/main/timestampvm/factory.go) file
 of the `timestampvm` repository.
 

--- a/docs/subnets/introduction-to-vm.md
+++ b/docs/subnets/introduction-to-vm.md
@@ -9,7 +9,7 @@ This is part of a series of tutorials for building a Virtual Machine (VM):
 - [How to Build a Complex Golang VM](./create-a-vm-blobvm.md)
 - [How to Build a Simple Rust VM](./create-a-simple-rust-vm.md)
 
-A [Virtual Machine (VM)](/learn/avalanche/subnets-overview.md#virtual-machines) is a blueprint for a
+A [Virtual Machine (VM)](/learn/avalanche/virtual-machines) is a blueprint for a
 blockchain. Blockchains
 are instantiated from a VM, similar to how objects are instantiated from a class definition. VMs can
 define anything you want, but will generally define transactions that are executed and how blocks are


### PR DESCRIPTION
1. "how blocks are `and` built and parsed to create the blockchain." ❌
"how blocks are built and parsed to create the blockchain." ✅

https://docs.avax.network/subnets/introduction-to-vm#blockchain
<img width="843" alt="Screenshot 2023-06-18 at 5 32 27 PM" src="https://github.com/ava-labs/avalanche-docs/assets/38423994/9835342d-a10f-4023-a2fe-a3fd8c918d81">

2. This should open https://docs.avax.network/learn/avalanche/virtual-machines, not https://docs.avax.network/learn/avalanche/subnets-overview#virtual-machines

<img width="191" alt="Screenshot 2023-06-18 at 6 17 27 PM" src="https://github.com/ava-labs/avalanche-docs/assets/38423994/d87eefa9-810c-4c5b-90d5-3f53cf5e8f9c">
