### PR TITLE
Update links to WAGMI genesis.json

### DIFF
--- a/docs/subnets/case-study-wagmi-upgrade.md
+++ b/docs/subnets/case-study-wagmi-upgrade.md
@@ -33,7 +33,7 @@ into an official Coreth release.
 - Target Block Rate: 2s (Same as C-Chain)
 
 You can check out the [Genesis file of WAGMI
-Subnet](https://github.com/ava-labs/subnet-evm/blob/master/networks/testnet/11111/genesis.json) to
+Subnet](https://github.com/ava-labs/public-chain-assets/blob/1951594346dcc91682bdd8929bcf8c1bf6a04c33/chains/11111/genesis.json) to
 see the initial configuration.
 
 ### Network Upgrades: Enable/Disable Precompiles

--- a/docs/subnets/create-a-evm-blockchain-on-subnet-with-avalanchejs.md
+++ b/docs/subnets/create-a-evm-blockchain-on-subnet-with-avalanchejs.md
@@ -285,7 +285,7 @@ module.exports = {
 
 Each blockchain has some genesis state when it’s created. Each VM defines the format and semantics
 of its genesis data. We will be using the default genesis data provided by `subnet-evm`. You can
-also find it inside the `networks/11111/` folder of the `subnet-evm` repository or simply copy and paste
+also find it inside the `chains/11111/` folder of the [public-chain-assets](https://github.com/ava-labs/public-chain-assets) repository or simply copy and paste
 the following data inside the `genesis.json` file of the project folder. (Note that fields
 `airdropHash` and `airdropAmount` have been removed.)
 

--- a/docs/subnets/customize-a-subnet.md
+++ b/docs/subnets/customize-a-subnet.md
@@ -200,7 +200,7 @@ Otherwise it will error.
 ### Genesis Examples
 
 Another example of a genesis file can be found in the
-[networks folder](https://github.com/ava-labs/subnet-evm/blob/master/networks/testnet/11111/genesis.json).
+[networks folder](https://github.com/ava-labs/public-chain-assets/blob/1951594346dcc91682bdd8929bcf8c1bf6a04c33/chains/11111/genesis.json)
 Note: please remove `airdropHash` and `airdropAmount` fields if you want to start with it.
 
 Here are a few examples on how a genesis file is used:


### PR DESCRIPTION

# Docs PR Template

Apparently the genesis.json were moved from Subnet EVM to their own repository. Updated the documents accordingly

## How this works

Updated a few links and some references to the genesis.json for WAGNI

## How these changes were tested 

A local version of the docs were built

## Workflow checks

- [x] ran `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- []x ran `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [x] completed the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass
- [x] if a doc was removed/deleted, the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [x] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [x] `_redirects` were manually verified with the cloudflare preview link
- [x] `sidebars.json` reflects all changes made to file path
