### PR TITLE
add missing link to 'create vm from scratch tutorial' from other vm tutorials

### DIFF
--- a/docs/subnets/create-a-simple-rust-vm.md
+++ b/docs/subnets/create-a-simple-rust-vm.md
@@ -6,6 +6,7 @@ This is part of a series of tutorials for building a Virtual Machine (VM):
 - [How to Build a Simple Golang VM](./create-a-vm-timestampvm.md)
 - [How to Build a Complex Golang VM](./create-a-vm-blobvm.md)
 - How to Build a Simple Rust VM (this article)
+- [How to Build a Simple VM From Scratch](./create-a-simple-vm-from-scratch.md)
 
 ## Introduction
 

--- a/docs/subnets/create-a-vm-blobvm.md
+++ b/docs/subnets/create-a-vm-blobvm.md
@@ -6,6 +6,7 @@ This is part of a series of tutorials for building a Virtual Machine (VM):
 - [How to Build a Simple Golang VM](./create-a-vm-timestampvm.md)
 - How to Build a Complex Golang VM (this article)
 - [How to Build a Simple Rust VM](./create-a-simple-rust-vm.md)
+- [How to Build a Simple VM From Scratch](./create-a-simple-vm-from-scratch.md)
 
 
 ## Introduction

--- a/docs/subnets/create-a-vm-timestampvm.md
+++ b/docs/subnets/create-a-vm-timestampvm.md
@@ -6,6 +6,7 @@ This is part of a series of tutorials for building a Virtual Machine (VM):
 - How to Build a Simple Golang VM (this article)
 - [How to Build a Complex Golang VM](./create-a-vm-blobvm.md)
 - [How to Build a Simple Rust VM](./create-a-simple-rust-vm.md)
+- [How to Build a Simple VM From Scratch](./create-a-simple-vm-from-scratch.md)
 
 ## Introduction
 

--- a/docs/subnets/introduction-to-vm.md
+++ b/docs/subnets/introduction-to-vm.md
@@ -8,6 +8,7 @@ This is part of a series of tutorials for building a Virtual Machine (VM):
 - [How to Build a Simple Golang VM](./create-a-vm-timestampvm.md)
 - [How to Build a Complex Golang VM](./create-a-vm-blobvm.md)
 - [How to Build a Simple Rust VM](./create-a-simple-rust-vm.md)
+- [How to Build a Simple VM From Scratch](./create-a-simple-vm-from-scratch.md)
 
 A [Virtual Machine (VM)](/learn/avalanche/virtual-machines) is a blueprint for a
 blockchain. Blockchains


### PR DESCRIPTION
# Docs PR Template

## Why this should be merged

The sidebar links to an additional doc that isn't referenced in the related documentation. It's easy to spot on desktop but harder to notice on mobile.

## How this works

[this document](https://docs.avax.network/subnets/create-a-simple-vm-from-scratch) references a larger list of tutorials than the [other documents](https://docs.avax.network/subnets/introduction-to-vm)

## How these changes were tested 



## Workflow checks

- [] ran `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [] ran `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [] completed the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass
- [] if a doc was removed/deleted, the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path
