### PR TITLE
Update delegator rewards info

### DIFF
--- a/docs/nodes/validate/how-to-stake.md
+++ b/docs/nodes/validate/how-to-stake.md
@@ -253,7 +253,8 @@ When you issue the transaction to delegate tokens, the staked tokens and
 transaction fee are deducted from the addresses you control. When you are done
 delegating, the staked tokens are returned to your address. If you earned a
 reward, it is sent to the address you specified when you delegated tokens. 
-Rewards are sent to delegators right after the delegation ends with the return of staked tokens, and before the validation period of the node 
+Rewards are sent to delegators right after the delegation ends with the 
+return of staked tokens, and before the validation period of the node 
 they're delegating to is complete.
 
 ## FAQ

--- a/docs/nodes/validate/how-to-stake.md
+++ b/docs/nodes/validate/how-to-stake.md
@@ -253,7 +253,7 @@ When you issue the transaction to delegate tokens, the staked tokens and
 transaction fee are deducted from the addresses you control. When you are done
 delegating, the staked tokens are returned to your address. If you earned a
 reward, it is sent to the address you specified when you delegated tokens. 
-Rewards are sent to delegators before the validation period of the node 
+Rewards are sent to delegators right after the delegation ends with the return of staked tokens, and before the validation period of the node 
 they're delegating to is complete.
 
 ## FAQ

--- a/docs/nodes/validate/how-to-stake.md
+++ b/docs/nodes/validate/how-to-stake.md
@@ -252,7 +252,9 @@ validator’s delegation fee rate.
 When you issue the transaction to delegate tokens, the staked tokens and
 transaction fee are deducted from the addresses you control. When you are done
 delegating, the staked tokens are returned to your address. If you earned a
-reward, it is sent to the address you specified when you delegated tokens.
+reward, it is sent to the address you specified when you delegated tokens. 
+Rewards are sent to delegators before the validation period of the node 
+they're delegating to is complete.
 
 ## FAQ
 


### PR DESCRIPTION
## Why this should be merged

Adds context to the delegation rewards section to clarify that delegators will be sent rewards before the validation period of the node they're delegating to is complete.