### PR TITLE
Add note on VM binary naming

### DIFF
--- a/docs/build/vm/create/golang-vm-simple.md
+++ b/docs/build/vm/create/golang-vm-simple.md
@@ -1233,6 +1233,12 @@ Each VM has a predefined, static ID. For instance, the default ID of the Timesta
 It's possible to give an alias for these IDs. For example, we can alias `TimestampVM` by creating a
 JSON file at `~/.avalanchego/configs/vms/aliases.json` with:
 
+:::warning
+The name of the VM binary is also its static ID and should not be changed manually.
+Changing the name of the VM binary will result in AvalancheGo failing to start the VM.
+To reference a VM by another name, define a VM alias as described below.
+:::
+
 ```json
 {
   "tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH": [


### PR DESCRIPTION
## Why this should be merged

from https://github.com/ava-labs/avalanche-docs/pull/1469

This PR adds a small note detailing the fact that the VM binary name should not be manually altered.

Signed-off-by: Dan Sover [dan.sover@avalabs.org](mailto:dan.sover@avalabs.org)

## How this works

changed `golang-vm-simple.md`

## Workflow checks

- [x] ran `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [x] ran `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
