### PR TITLE
feat: correct timestampvm ID string source

### DIFF
--- a/docs/build/vm/create/golang-vm-simple.md
+++ b/docs/build/vm/create/golang-vm-simple.md
@@ -1,6 +1,6 @@
 ---
 tags: [Build, Virtual Machines]
-description: Learn how to build a simple virtual machine on Avalanche using Golang. 
+description: Learn how to build a simple virtual machine on Avalanche using Golang.
 sidebar_label: Simple Golang VM
 pagination_label: Build a Simple Golang VM
 sidebar_position: 1
@@ -604,7 +604,7 @@ func (vm *VM) initGenesis(genesisData []byte) error {
 
 #### CreateHandlers
 
-Registered handlers defined in `Service`. See [below](/build/vm/create/golang-vm-simple.md#api) for 
+Registered handlers defined in `Service`. See [below](/build/vm/create/golang-vm-simple.md#api) for
 more on APIs.
 
 ```go title="/timestampvm/vm.go"
@@ -1222,8 +1222,8 @@ If no argument is given, the path defaults to a binary named with default VM ID:
 `$GOPATH/src/github.com/ava-labs/avalanchego/build/plugins/tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH`
 
 This name `tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH` is the CB58 encoded 32 byte identifier
-for the VM. For the timestampvm, this is the string "timestampvm" zero-extended in a 32 byte array
-and encoded in CB58. 
+for the VM. For the timestampvm, this is the string "timestamp" zero-extended in a 32 byte array
+and encoded in CB58.
 
 ### VM Aliases
 


### PR DESCRIPTION
# Docs PR Template

## Why this should be merged

The doc currently states:
> This name `tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH` is the CB58 encoded 32 byte identifier
for the VM. For the timestampvm, this is the string "timestampvm" zero-extended in a 32 byte array and encoded in CB58.

Yet if we use `timestampvm` as the source string, we end up with `tGas3T58KzdjcJ2iKSyiYsWiqYctRXaPTqBCA11BqEkNg8kPc`. This can be confusing for people when they generate their own VM ID.

## How this works

The VM ID was generated only from the string `timestamp` and not `timestampvm`.

## How these changes were tested 

We can verify this when converting the IDs back to bytes:
- `tGas3T58KzdjLHhBDMnH2TvrddhqTji5iZAMZ3RXs2NLpSnhH` = `[116, 105, 109, 101, 115, 116, 97, 109, 112, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]` = `timestamp`
- `tGas3T58KzdjcJ2iKSyiYsWiqYctRXaPTqBCA11BqEkNg8kPc` = `[116, 105, 109, 101, 115, 116, 97, 109, 112, 118, 109, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]` = `timestampvm`

## Workflow checks

- [x] ran `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [x] ran `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [x] completed the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass
- [x] if a doc was removed/deleted, the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [x] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [x] `_redirects` were manually verified with the cloudflare preview link
- [x] `sidebars.json` reflects all changes made to file path
