### PR TITLE
add node cmds to cli ref

### DIFF
--- a/docs/tooling/avalanche-cli.md
+++ b/docs/tooling/avalanche-cli.md
@@ -641,6 +641,223 @@ avalanche subnet upgrade export [subnetName] [flags]
 -h, --help       help for list
 ```
 
+## Node
+
+The `node` command suite provides a collection of tools for creating and maintaining 
+validators on Avalanche Network.
+
+To get started, use the node create command wizard to walk through the
+configuration to make your node a primary validator on Avalanche public network. You can use the 
+rest of the commands to maintain your node and make your node a Subnet Validator.
+
+### Node Create
+
+:::warning
+
+(ALPHA Warning) This command is currently in experimental mode. 
+
+:::
+
+The `node create` command sets up a validator on a cloud server of your choice. 
+The validator will be validating the Avalanche Primary Network and Subnet 
+of your choice. By default, the command runs an interactive wizard. It 
+walks you through all the steps you need to set up a validator.
+Once this command is completed, you will have to wait for the validator
+to finish bootstrapping on the primary network before running further
+commands on it, for example validating a Subnet. You can check the bootstrapping
+status by running avalanche node status 
+
+The created node will be part of group of validators called `<clusterName>`
+and users can call node commands with `<clusterName>` so that the command
+will apply to all nodes in the cluster
+
+**Usage:**
+
+```shell
+  avalanche node create [clusterName] [flags]
+```
+
+**Flags:**
+
+```shell
+  -h, --help   help for create
+```
+
+### Node List
+
+:::warning
+
+(ALPHA Warning) This command is currently in experimental mode. 
+
+:::
+
+The `node list` command lists all clusters together with their nodes.
+
+**Usage:**
+
+```shell
+  avalanche node list [flags]
+```
+
+**Flags:**
+
+```shell
+  -h, --help   help for list
+```
+
+### Node Status
+
+:::warning
+
+(ALPHA Warning) This command is currently in experimental mode. 
+
+:::
+
+The `node status` command gets the bootstrap status of all nodes in a cluster with
+the Primary Network. 
+To get the bootstrap status of a node with a Subnet, use `--subnet` flag
+
+**Usage:**
+
+```shell
+  avalanche node status [clusterName] [flags]
+```
+
+**Flags:**
+
+```shell
+  -h, --help            help for status
+      --subnet string   specify the subnet the node is syncing with
+```
+
+### Node Stop
+
+:::warning
+
+(ALPHA Warning) This command is currently in experimental mode. 
+
+:::
+
+The `node stop` command stops a running node in cloud server
+
+Note that a stopped node may still incur cloud server storage fees.
+
+**Usage:**
+
+```shell
+  avalanche node stop [clusterName] [flags]
+```
+
+**Flags:**
+
+```shell
+  -h, --help   help for stop
+```
+
+### Node Sync
+
+:::warning
+
+(ALPHA Warning) This command is currently in experimental mode. 
+
+:::
+
+The `node sync` command enables all nodes in a cluster to be bootstrapped to a Subnet. 
+You can check the Subnet bootstrap status by calling avalanche `node status <clusterName> --subnet <subnetName>`
+
+**Usage:**
+
+```shell
+  avalanche node sync [clusterName] [subnetName] [flags]
+```
+
+**Flags:**
+
+```shell
+  -h, --help   help for sync
+```
+
+### Node Validate
+
+:::warning
+
+(ALPHA Warning) This command is currently in experimental mode. 
+
+:::
+
+The `node validate` command suite provides a collection of commands for nodes to join
+the Primary Network and Subnets as validators.
+If any of the commands is run before the nodes are bootstrapped on the Primary Network, the command 
+will fail. You can check the bootstrap status by calling `avalanche node status <clusterName>`
+
+### Node Validate Primary
+
+:::warning
+
+(ALPHA Warning) This command is currently in experimental mode. 
+
+:::
+
+The `node validate primary` command enables all nodes in a cluster to be validators of Primary
+Network.
+
+**Usage:**
+
+```shell
+  avalanche node validate primary [clusterName] [flags]
+```
+
+**Flags:**
+
+```shell
+  -f, --fuji testnet              set up validator in fuji (alias to testnet
+  -h, --help                      help for primary
+  -k, --key string                select the key to use [fuji only]
+  -g, --ledger                    use ledger instead of key (always true on mainnet, defaults to false on fuji)
+      --ledger-addrs strings      use the given ledger addresses
+  -m, --mainnet                   set up validator in mainnet
+      --stake-amount uint         how many AVAX to stake in the validator
+      --staking-period duration   how long validator validates for after start time
+  -t, --testnet fuji              set up validator in testnet (alias to fuji)
+```
+
+### Node Validate Subnet
+
+:::warning
+
+(ALPHA Warning) This command is currently in experimental mode. 
+
+:::
+
+The `node validate subnet` command enables all nodes in a cluster to be validators of a Subnet.
+If the command is run before the nodes are Primary Network validators, the command will first
+make the nodes Primary Network validators before making them Subnet validators. 
+If The command is run before the nodes are bootstrapped on the Primary Network, the command
+will fail. 
+You can check the bootstrap status by calling avalanche node status `<clusterName>`
+If The command is run before the nodes are synced to the Subnet, the command will fail.
+You can check the Subnet sync status by calling avalanche node status `<clusterName> --subnet <subnetName>`
+
+**Usage:**
+
+```shell
+  avalanche node validate subnet [clusterName] [subnetName] [flags]
+```
+
+**Flags:**
+
+```shell
+  -f, --fuji testnet              set up validator in fuji (alias to testnet
+  -h, --help                      help for subnet
+  -k, --key string                select the key to use [fuji only]
+  -g, --ledger                    use ledger instead of key (always true on mainnet, defaults to false on fuji)
+      --ledger-addrs strings      use the given ledger addresses
+  -m, --mainnet                   set up validator in mainnet
+      --stake-amount uint         how many AVAX to stake in the validator
+      --staking-period duration   how long validator validates for after start time
+  -t, --testnet fuji              set up validator in testnet (alias to fuji)
+```
+
 ## Network
 
 The `network` command suite provides a collection of tools for managing local Subnet


### PR DESCRIPTION
# Docs PR Template

## Why this should be merged

Node cms not added to cli ref

## How this works

Added them

## How these changes were tested 

Looked at the generated docs

## Workflow checks

- [] ran `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [] ran `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [] completed the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass
- [] if a doc was removed/deleted, the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path
