### PR TITLE
added new tool - PARSIQ API & SDK

### DIFF
--- a/docs/tooling/README.md
+++ b/docs/tooling/README.md
@@ -13,6 +13,7 @@ pagination_label: Tooling Quick Links
 | [**🔌 RPC Providers**](/tooling/rpc-providers.md)      | List of RPC endpoints available for the Avalanche Network |  |
 | [**Glacier API**](/tooling/glacier.md)      | Avalanche's performant API that allows web3 developers to more easily access indexed blockchain data | [API](https://glacier-api.avax.network/api#/) |
 | [**Metrics API**](/tooling/metrics.md)      | Power your analytics with metrics such as Subnet usage, staking operations, and more | [API](https://metrics.avax.network/) |
+| [**PARSIQ API & SDK**](/tooling/parsiq.md)      | PARSIQ is a reliable blockchain data indexer, helping developers to seamlessly access and process Web3 data - both raw and custom. | [API](https://www.parsiq.net/) |
 | [**Hyper SDK**](https://github.com/ava-labs/hypersdk#readme)      | Opinionated framework for building hyper-scalable blockchains on Avalanche | [GitHub](https://github.com/ava-labs/hypersdk#readme) |
 | [**AvalancheGo Installer Script**](/tooling/avalanchego-installer.md)      | A shell (bash) script that installs AvalancheGo on any Linux computer | [GitHub](https://github.com/ava-labs/avalanche-docs/blob/master/scripts/avalanchego-installer.sh#readme) |
 | [**Avalanche Network Runner**](/tooling/network-runner.md)      | ANR allows a user to define, create and interact with a network of Avalanche nodes | [GitHub](https://github.com/ava-labs/avalanche-network-runner) |

--- a/docs/tooling/parsiq.md
+++ b/docs/tooling/parsiq.md
@@ -1,0 +1,35 @@
+---
+tags: [Tooling, PARSIQ API & SDK]
+description: PARSIQ is a reliable, fully customizable blockchain data indexer, helping developers to seamlessly access, process and utilize Web3 data - both raw and custom.
+---
+# PARSIQ API & SDK
+
+**[<ins>PARSIQ</ins>](https://www.parsiq.net/)** is a reliable, fully customizable blockchain data indexer, helping developers to seamlessly access, process and utilize Web3 data - both raw and custom.
+
+Check out **[<ins>this introduction video</ins>](https://www.youtube.com/watch?v=kQJYJGt62hc)**
+to get started.
+
+## PARSIQ Tsunami API
+
+PARSIQ Tsunami API is a highly efficient API to fetch raw Web3 data:
+- Events, calls, transactions (internal included), transfers, contracts, blocks - you name it. Possibility to use unlimited blockrange makes Tsunami a hard-to-beat solution for realiably getting large amounts of data from the blockchain. CSV Export is available.
+- Get decoded, human readable data right out of the box.
+- Need an up to date feeds of data streamed to you in real time? Give our low latency Real Time Streaming service a try.
+
+:::info Endpoints
+
+Please check out our [<ins>PARSIQ API Reference</ins>](https://docs.parsiq.net/reference/introduction) to see all the available endpoints.
+
+:::
+
+## PARSIQ SDK
+
+Some more complicated cases where custom data needs to be stored, accumulated, and calculated, cannot be covered by an API. In that cases, use PARSIQ SDK or go for a Custom Data Lake. They allow you to set up data bases and data processing logic to solve your specific use case. 
+
+:::info SDK Documentation
+
+Please see [<ins>PARSIQ SDK documentation</ins>](https://docs.parsiq.net/reference/your-own-web3-api) for more details.
+
+:::
+
+---

--- a/sidebars.json
+++ b/sidebars.json
@@ -388,6 +388,7 @@
     },
     "tooling/glacier",
     "tooling/metrics",
+    "tooling/parsiq",
     {
       "type": "link",
       "label": "HyperSDK",


### PR DESCRIPTION
# Docs PR Template

## Why this should be merged

One more tool for working with Avax was added - PARSIQ API & SDK, blockchain data indexer.

## How this works

The changes are the description and links to PARSIQ.

## How these changes were tested 

The changes can be seen on Tooling page, and also on the sidebar, and PARSIQ page. The were tested by running Docusaurus, checking the page and the links.
![image](https://github.com/ava-labs/avalanche-docs/assets/7903312/72157f56-2b03-43b4-acf7-ddafc0b04595)


## Workflow checks

- [+] ran `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [+] ran `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [+] completed the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass
- [-] if a doc was removed/deleted, the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [-] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [-] `_redirects` were manually verified with the cloudflare preview link
- [+] `sidebars.json` reflects all changes made to file path
