### PR TITLE
Add HDD warning on install script page

### DIFF
--- a/docs/nodes/run/with-installer.md
+++ b/docs/nodes/run/with-installer.md
@@ -24,6 +24,13 @@ hardware with the following minimum specifications.
 - OS: Ubuntu 20.04 or MacOS &gt;= 12
 - Network: sustained 5Mbps up/down bandwidth
 
+:::caution
+
+Please do not try running a node on an HDD, as you may get poor and random 
+read/write latencies, therefore reducing performance and reliability.
+
+:::
+
 :::note
 
 HW requirements shall scale with the amount of AVAX staked on

--- a/docs/nodes/run/with-installer.md
+++ b/docs/nodes/run/with-installer.md
@@ -26,7 +26,7 @@ hardware with the following minimum specifications.
 
 :::caution
 
-Please do not try running a node on an HDD, as you may get poor and random 
+Using an HDD may result in poor and random 
 read/write latencies, therefore reducing performance and reliability.
 
 :::


### PR DESCRIPTION
Warns users not to use HDD for validators on both the manual and install script page for consistency 