### PR TITLE
add gtm for GA4 and cookies banner

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,9 +41,8 @@ const config = {
         theme: {
           customCss: require.resolve("./src/css/custom.css"),
         },
-        gtag: {
-          trackingID: "G-HGX2HKR5GK",
-          anonymizeIP: true,
+        googleTagManager: {
+          containerId: "GTM-MHVBTGVC",
         },
       }),
     ],


### PR DESCRIPTION
migrating the GA4 tag to a GTM container, which also has Termly compliance integrated.