### PR TITLE
fix: typo in VM intro guide + RPC Chain description

### DIFF
--- a/docs/build/vm/create/any-lang-vm.md
+++ b/docs/build/vm/create/any-lang-vm.md
@@ -46,7 +46,7 @@ the _client_ interfaces exposed by AvalancheGo.
 ## Starting Process 
 
 Your VM is started by AvalancheGo launching your binary. Your binary is started as a sub-process
-of AvalancheGo. While launching your binary, avalanche's go passes an environment variable
+of AvalancheGo. While launching your binary, AvalancheGo passes an environment variable
 `AVALANCHE_VM_RUNTIME_ENGINE_ADDR` containing an url. We must use this url to initialize a
 `vm.Runtime` client. 
 
@@ -55,7 +55,6 @@ Your VM, after having started a grpc server implementing the VM interface must c
 with the following parameters.
 
 - `protocolVersion` : It must match the `supported plugin version` of the 
-
 [AvalancheGo release](https://github.com/ava-labs/AvalancheGo/releases) you are using. 
 It is always part of the release notes.
 

--- a/docs/build/vm/intro.md
+++ b/docs/build/vm/intro.md
@@ -30,8 +30,8 @@ of the blockchain.
 ## Blockchain
 
 A blockchain relies on two major components: The **Consensus Engine** and the **VM**. The VM defines
-application specific behavior and how blocks are built and parsed to create the blockchain. VMs
-all run on top of the Avalanche Consensus Engine, which allows nodes in the network to agree on the
+application specific behavior and how blocks are built and parsed to create the blockchain. All VMs
+run on top of the Avalanche Consensus Engine, which allows nodes in the network to agree on the
 state of the blockchain. Here's a quick example of how VMs interact with consensus:
 
 1. A node wants to update the blockchain's state
@@ -63,8 +63,14 @@ In order to install a VM, its binary must be installed in the `AvalancheGo` plug
 Multiple VMs can be installed in this location.
 
 Each VM runs as a separate process from AvalancheGo and communicates with `AvalancheGo` using gRPC
-calls. This is functionality is enabled by `rpcchainvm`, a special VM that wraps around other VM
-implementations so that they can communicate back and forth with the AvalancheGo.
+calls. This functionality is enabled by **RPCChainVM**, a special VM which wraps around other VM
+implementations and bridges the VM and AvalancheGo, establishing a standardized communication 
+protocol between them.
+
+During VM creation, handshake messages are exchanged via RPCChainVM between AvalancheGo and the 
+VM installation. Ensure matching RPCChainVM protocol versions to avoid 
+[errors](https://github.com/ava-labs/avalanchego/pull/2021), by updating your VM or using a 
+different version of AvalancheGo. Note that some VMs may not support the latest protocol version.
 
 ### API Handlers
 
@@ -118,7 +124,7 @@ if err := vm.Initialize(
 ```
 
 You can refer to the
-[implementation](https://github.com/ava-labs/timestampvm/blob/main/timestampvm/vm.go#L75)) of
+[implementation](https://github.com/ava-labs/timestampvm/blob/main/timestampvm/vm.go#L75) of
 `vm.initialize` in the TimestampVM repository.
 
 ## Interfaces

--- a/docs/build/vm/intro.md
+++ b/docs/build/vm/intro.md
@@ -67,10 +67,16 @@ calls. This functionality is enabled by **RPCChainVM**, a special VM which wraps
 implementations and bridges the VM and AvalancheGo, establishing a standardized communication 
 protocol between them.
 
-During VM creation, handshake messages are exchanged via RPCChainVM between AvalancheGo and the 
-VM installation. Ensure matching RPCChainVM protocol versions to avoid 
+:::info
+
+During VM creation, handshake messages are exchanged via **RPCChainVM** between AvalancheGo and the 
+VM installation. Ensure matching **RPCChainVM** protocol versions to avoid 
 [errors](https://github.com/ava-labs/avalanchego/pull/2021), by updating your VM or using a 
-different version of AvalancheGo. Note that some VMs may not support the latest protocol version.
+[different version of AvalancheGo](https://github.com/ava-labs/AvalancheGo/releases).
+
+Note that some VMs may not support the latest protocol version.
+
+:::
 
 ### API Handlers
 


### PR DESCRIPTION
## Why this should be merged

We recently found developers puzzled by errors produced during VM installation with AvalancheGo, for example:
> "error while creating vm: handshake failed: protocol version mismatch avalanchego: 28, vm: 27"

## How this works

This PR provides more context around how the RPCChainVM protocol enables communication between AvalancheGo and VM. Also adds actionable measures to be taken before one starts installing their own VM in AvalancheGo.