### PR TITLE
fix bootstrappers link

### DIFF
--- a/docs/nodes/maintain/node-bootstrap.md
+++ b/docs/nodes/maintain/node-bootstrap.md
@@ -62,7 +62,7 @@ before completing its bootstrap. To solve this chicken-and-egg situation the
 Avalanche Foundation maintains a trusted default set of validators called
 beacons (but users are free to configure their own). Beacon Node-IDs and IP
 addresses are listed in the [AvalancheGo
-codebase](https://github.com/ava-labs/avalanchego/blob/master/genesis/beacons.go).
+codebase](https://github.com/ava-labs/avalanchego/blob/master/genesis/bootstrappers.json).
 Every node has the beacon list available from the start and can reach out to them
 as soon as it starts.
 


### PR DESCRIPTION
# Docs PR Template

## Why this should be merged

Fixes a broken link to the now renamed boostrappers.json file
## How this works

Fixed the broken link with the correct one

## How these changes were tested 

Opened the link

## To prevent any errors while building

- [x] run `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [x] run `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [x] complete the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass

### If a document was removed/deleted
N/A
- [] the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path

### If a document was moved
N/A
- [] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path
