### PR TITLE
add thirdweb docs and deprecate truffle

### DIFF
--- a/.github/styles/Vocab/Products/accept.txt
+++ b/.github/styles/Vocab/Products/accept.txt
@@ -296,6 +296,7 @@ Tencent
 testnet
 Testnet
 textlint
+thirdweb
 toolchain
 Toolchains
 trie

--- a/docs/build/dapp/advanced/integrate-exchange.md
+++ b/docs/build/dapp/advanced/integrate-exchange.md
@@ -131,7 +131,7 @@ home. We have tutorials and repositories for several popular development
 environments:
 
 - [Core and Remix](/build/dapp/smart-contracts/remix-deploy.md)
-- [Truffle](/build/dapp/smart-contracts/toolchains/truffle.md)
+- [thirdweb](/build/dapp/smart-contracts/toolchains/thirdweb.md)
 - [Hardhat](/build/dapp/smart-contracts/toolchains/hardhat.md)
 
 ## Ingesting On-Chain Data

--- a/docs/build/dapp/launch-dapp.md
+++ b/docs/build/dapp/launch-dapp.md
@@ -192,9 +192,9 @@ There is a
 for using Remix to deploy smart contracts on Avalanche. It relies on Core
 for access to the Avalanche network.
 
-### Truffle
+### thirdweb
 
-You can also use Truffle to test and deploy smart contracts on Avalanche. Find out how in this [tutorial](/build/dapp/smart-contracts/toolchains/truffle.md).
+You can also use thirdweb to test and deploy smart contracts on Avalanche. Find out how in this [tutorial](/build/dapp/smart-contracts/toolchains/thirdweb.md).
 
 ### Hardhat
 
@@ -240,8 +240,8 @@ signal that your users can trust your contracts, and it is strongly recommended
 for all production contracts.
 
 See
-[this](/build/dapp/smart-contracts/verification/verify-truffle.md)
-for a detailed tutorial with Truffle.
+[this](/build/dapp/smart-contracts/verification/verify-hardhat.md)
+for a detailed tutorial with Hardhat.
 
 ## Contract Security Checks
 

--- a/docs/build/dapp/smart-contracts/toolchains/thirdweb.md
+++ b/docs/build/dapp/smart-contracts/toolchains/thirdweb.md
@@ -1,0 +1,118 @@
+---
+tags: [Build, Dapps]
+description: Launching any new or existing Solidity decentralized app on Avalanche C-Chain fosters the same developer experience as Ethereum, but benefits from the security, speed, and interoperability of the Avalanche Network.
+sidebar_label: Thirdweb
+pagination_label: Using thirdweb with the Avalanche C-Chain
+sidebar_position: 1
+keywords: [make a smartcontract, deploy a smartcontract, smartcontract development, thirdweb sdk, use thirdweb to deploy a smartcontract]
+---
+
+# Deploy a Smart Contract on Avalanche Using thirdweb
+
+## Introduction
+
+This tutorial walks through creating and deploying a smart contract using thirdweb's command line
+interface. 
+
+---
+
+Alternatively, you can deploy a prebuilt contract for NFTs, tokens, or marketplace directly from the
+thirdweb Explore page:
+
+1. Go to the thirdweb Explore page: <https://thirdweb.com/explore>
+
+2. Choose the type of contract you want to deploy from the available options: NFTs, tokens,
+marketplace, and more.
+3. Follow the on-screen prompts to configure and deploy your contract.
+
+> For more information on different contracts available on Explore, check out [thirdweb’s documentation.](https://portal.thirdweb.com/pre-built-contracts)
+
+---
+
+## Creating Contracts
+
+To create a new smart contract using thirdweb CLI, follow these steps:
+
+1. In your CLI run the following command:
+
+   ```bash
+   npx thirdweb create contract
+   ```
+
+2. Input your preferences for the command line prompts:
+   1. Give your project a name.
+   2. Choose your preferred framework: Hardhat or Foundry.
+   3. Name your smart contract.
+   4. Choose the type of base contract: Empty, [ERC20](https://portal.thirdweb.com/solidity/base-contracts/erc20base),
+   [ERC721](https://portal.thirdweb.com/solidity/base-contracts/erc721base), or [ERC1155](https://portal.thirdweb.com/solidity/base-contracts/erc1155base).
+   5. Add any desired [extensions](https://portal.thirdweb.com/solidity/extensions).
+3. Once created, navigate to your project’s directory and open in your preferred code editor.
+4. In the `contracts` folder, you will find the smart contract written in Solidity.
+
+   The following is code for an ERC721Base contract without specified extensions. It implements all
+   of the logic inside the [`ERC721Base.sol`](https://github.com/thirdweb-dev/contracts/blob/main/contracts/base/ERC721Base.sol)
+   contract; which implements the
+   [`ERC721A`](https://github.com/thirdweb-dev/contracts/blob/main/contracts/eip/ERC721A.sol) standard.
+
+   ```solidity
+   // SPDX-License-Identifier: MIT
+   pragma solidity ^0.8.0;
+
+   import "@thirdweb-dev/contracts/base/ERC721Base.sol";
+
+   contract Contract is ERC721Base {
+       constructor(
+           string memory _name,
+           string memory _symbol,
+           address _royaltyRecipient,
+           uint128 _royaltyBps
+       ) ERC721Base(_name, _symbol, _royaltyRecipient, _royaltyBps) {}
+   }
+   ```
+
+   This contract inherits the functionality of ERC721Base through the following steps:
+
+   - Importing the ERC721Base contract.
+   - Inheriting the contract by declaring that our contract is an ERC721Base contract.
+   - Implementing any required methods, such as the constructor.
+
+5. After modifying your contract with your desired custom logic, you may deploy it to Avalanche
+with the following command:
+
+   ```bash
+   npx thirdweb deploy
+   ```
+
+## Deploying Contracts
+
+Deploy allows you to deploy a smart contract to any EVM compatible network without configuring RPC
+URLs, exposing your private keys, writing scripts, and other additional setup such as verifying your
+contract.
+
+1. To deploy your smart contract using deploy, navigate to the root directory of your project and
+execute the following command:
+
+   ```bash
+   npx thirdweb deploy
+   ```
+
+   Executing this command will trigger the following actions:
+
+   - Compiling all the contracts in the current directory.
+   - Providing the option to select which contracts you wish to deploy.
+   - Uploading your contract source code (ABI) to IPFS.
+
+2. When it is completed, it will open a dashboard interface to finish filling out the parameters.
+   - `_name`: contract name
+   - `_symbol`: symbol or "ticker"
+   - `_royaltyRecipient`: wallet address to receive royalties from secondary sales
+   - `_royaltyBps`: basis points (bps) that will be given to the royalty recipient for each
+   secondary sale. For example: 500 = 5%.
+3. Select "Avalanche" as the network.
+4. Manage additional settings on your contract’s dashboard as needed such as uploading NFTs,
+configuring permissions, and more.
+
+For additional information on deploying smart contracts with thirdweb, please reference [thirdweb’s documentation](https://portal.thirdweb.com/deploy).
+
+If you have any further questions or encounter any issues during the process, please reach out to
+thirdweb support at [support.thirdweb.com](http://support.thirdweb.com/).

--- a/docs/deprecated/truffle.md
+++ b/docs/deprecated/truffle.md
@@ -3,10 +3,13 @@ tags: [Build, Dapps]
 description: Launching any new or existing Solidity decentralized app on Avalanche C-Chain fosters the same developer experience as Ethereum, but benefits from the security, speed, and interoperability of the Avalanche Network.
 sidebar_label: Truffle
 pagination_label: Using Truffle with the Avalanche C-Chain
-sidebar_position: 1
 ---
 
 # Using Truffle with the Avalanche C-Chain
+
+:::warning
+This document has been deprecated and is no longer maintained. It may contain incorrect/obsolete information.
+:::
 
 ## Introduction
 

--- a/docs/deprecated/verify-truffle.md
+++ b/docs/deprecated/verify-truffle.md
@@ -7,6 +7,10 @@ pagination_label: Verifying Smart Contracts with Truffle Verify
 
 # Verifying Smart Contracts with Truffle Verify
 
+:::warning
+This document has been deprecated and is no longer maintained. It may contain incorrect/obsolete information.
+:::
+
 _This tutorial includes items from the truffle [quickstart docs](https://www.trufflesuite.com/docs/truffle/quickstart)_
 
 _Inspired by [truffle verify docs](https://www.npmjs.com/package/truffle-plugin-verify)_

--- a/docs/learn/avalanche/virtual-machines.md
+++ b/docs/learn/avalanche/virtual-machines.md
@@ -70,7 +70,7 @@ or on their own Subnet using the
 [Subnet-EVM](https://github.com/ava-labs/subnet-evm) for advanced use cases that require more customization.
 
 Both C-Chain and the Subnet-EVM are compatible with Ethereum tooling like Remix, Core, MetaMask,
-Truffle, and more.
+thirdweb, and more.
 
 To learn more about smart contract support, click [here](build/dapp/launch-dapp.md).
 

--- a/static/_redirects
+++ b/static/_redirects
@@ -541,3 +541,6 @@
 /dapps/developer-toolchains/using-hardhat-with-the-avalanche-c-chain /build/dapp/smart-contracts/toolchains/hardhat 301
 /dapps/developer-toolchains/using-truffle-with-the-avalanche-c-chain /build/dapp/smart-contracts/toolchains/truffle 301
 
+# 10/05/23
+/build/dapp/smart-contracts/toolchains/truffle /deprecated/truffle 301
+/build/dapp/smart-contracts/verification/verify-truffle /deprecated/verify-truffle 301


### PR DESCRIPTION
changes migrated from https://github.com/ava-labs/avalanche-docs/pull/1376
@atharvadeosthale 

## Why this should be merged

Truffle [announced](https://x.com/trufflesuite/status/1704946902393860589?s=20) they were sunsetting their suite of tools a few weeks ago, and thirdweb had raised a PR around the same time of the docs revamp. This PR adds thirdweb's tutorial and information in place of truffle's. 

## How this works

- created thirdweb doc
- moved truffle docs to deprecated folder 
- added new paths to `_redirects`  

## To prevent any errors while building

- [x] run `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [x] run `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [x] complete the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass

### If a document was moved

- [x] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [x] `_redirects` were manually verified with the cloudflare preview link
- [x] `sidebars.json` reflects all changes made to file path
