### PR TITLE
update: avalanchego-installer.sh

### DIFF
--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -132,9 +132,15 @@ check_reqs_rhel () {
   fi
 }
 getOsType () {
+foundOS="$(uname)"                              #get OS
+if [ "$foundOS" = "Linux" ]; then
   which yum 1>/dev/null 2>&1 && { echo "RHEL"; return; }
   which zypper 1>/dev/null 2>&1 && { echo "openSUSE"; return; }
   which apt-get 1>/dev/null 2>&1 && { echo "Debian"; return; }
+else
+  echo "$foundOS";
+  return;
+fi
 }
 
 
@@ -241,19 +247,12 @@ elif [ "$osType" = "RHEL" ]; then
   check_reqs_rhel
 else
   #sorry, don't know you.
-  echo "Unsupported linux flavour/distribution: $osType"
+  echo "Unsupported OS or linux distribution found: $osType"
   echo "Exiting."
   exit
 fi
 foundIP="$(dig +short myip.opendns.com @resolver1.opendns.com)"
 foundArch="$(uname -m)"                         #get system architecture
-foundOS="$(uname)"                              #get OS
-if [ "$foundOS" != "Linux" ]; then
-  #sorry, don't know you.
-  echo "Unsupported operating system: $foundOS!"
-  echo "Exiting."
-  exit
-fi
 if [ "$foundArch" = "aarch64" ]; then
   getArch="arm64"                               #we're running on arm arch (probably RasPi)
   echo "Found arm64 architecture..."


### PR DESCRIPTION
## Why this should be merged

The Installer script is not supported for macOS. But it doesn't throw an error message indicating that the user is on an unsupported OS. Instead, it simply exits after the `Preparing environment...` line.

Made changes to check if the user is running on macOS and terminated with a self-explanatory message.

## How this works

The problem is that the `getOsType` function is not compatible with macOS. It simply doesn't do anything. Not even a blank space or garbage value is returned. This results in the `osType` check failing and the program halts without any error message.

Effectively, [this](https://github.com/ava-labs/avalanche-docs/blob/master/scripts/avalanchego-installer.sh#L244) message should echo on the terminal.

I have included commands in the `getOsType` function to check if the OS is different than Linux. This was initially being checked [here](https://github.com/ava-labs/avalanche-docs/blob/master/scripts/avalanchego-installer.sh#L250).

## How these changes were tested 

Ran the script again to test and the below image is the result.

<img width="461" alt="Screenshot 2023-10-10 at 3 20 21 PM" src="https://github.com/ava-labs/avalanche-docs/assets/39340292/a576e478-8f50-492d-b697-2f999b224d2b">
