### PR TITLE
Update rpc-providers.md

### DIFF
--- a/.github/styles/Vocab/Products/accept.txt
+++ b/.github/styles/Vocab/Products/accept.txt
@@ -202,6 +202,7 @@ NFTs
 Nimish
 NodeID
 NodeIDs
+Nodies
 NOWNodes
 npm
 npx

--- a/docs/tooling/rpc-providers.md
+++ b/docs/tooling/rpc-providers.md
@@ -276,6 +276,7 @@ Note: on Fuji Testnet, the URL is `https://avalanche-fuji.infura.io/v3/YOUR-API-
 [Nodies](https://nodies.app) supports the C, X, P, and DFK Subnet chains.
 
 Features:
+
  - Generous free tier
  - Globally distributed infrastructure in 3+ geographic regions
  - Decentralized and Centralized API's

--- a/docs/tooling/rpc-providers.md
+++ b/docs/tooling/rpc-providers.md
@@ -277,9 +277,9 @@ Note: on Fuji Testnet, the URL is `https://avalanche-fuji.infura.io/v3/YOUR-API-
 
 Features:
 
- - Generous free tier
- - Globally distributed infrastructure in 3+ geographic regions
- - Decentralized and Centralized API's
+- Generous free tier
+- Globally distributed infrastructure in 3+ geographic regions
+- Decentralized and Centralized API's
 
 #### HTTP
 

--- a/docs/tooling/rpc-providers.md
+++ b/docs/tooling/rpc-providers.md
@@ -286,7 +286,9 @@ Features:
 - For `C-Chain`, the URL is  `https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/C/rpc`
 - For `X-Chain`, the URL is  `https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/X`
 - For `P-Chain`, the URL is  `https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/P`
-- For `DFK-Subnet`, the URL is `https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/q2aTwKuyzgs8pynF7UXBZCU7DejbZbZ6EUyHr3JQzYgwNPUPi/rpc`
+- For `DFK-Subnet`, the URL is
+`https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/q2aTwKuyzgs8pynF7UXBZCU7DejbZbZ6EUyHr3JQzYgwNPUPi/rpc`
+
 ### QuickNode
 
 [QuickNode](https://www.quicknode.com/chains/avax) supports the X-Chain,

--- a/docs/tooling/rpc-providers.md
+++ b/docs/tooling/rpc-providers.md
@@ -271,6 +271,21 @@ currently only supports the C-Chain.
 
 Note: on Fuji Testnet, the URL is `https://avalanche-fuji.infura.io/v3/YOUR-API-KEY`.
 
+### Nodies
+
+[Nodies](https://nodies.app) supports the C, X, P, and DFK Subnet chains.
+
+Features:
+ - Generous free tier
+ - Globally distributed infrastructure in 3+ geographic regions
+ - Decentralized and Centralized API's
+
+#### HTTP
+
+- For `C-Chain`, the URL is  `https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/C/rpc`
+- For `X-Chain`, the URL is  `https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/X`
+- For `P-Chain`, the URL is  `https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/P`
+- For `DFK-Subnet`, the URL is `https://lb.nodies.app/v1/105f8099e80f4123976b59df1ebfb433/ext/bc/q2aTwKuyzgs8pynF7UXBZCU7DejbZbZ6EUyHr3JQzYgwNPUPi/rpc`
 ### QuickNode
 
 [QuickNode](https://www.quicknode.com/chains/avax) supports the X-Chain,


### PR DESCRIPTION
# Docs PR Template

## Why this should be merged

We support public and private RPC to support the AVAx chain. This allows developers to have a diverse set of rpc providers in the event that one goes down or becomes unrelaible.

<please give a thorough description of why these changes are necessary>

## How this works

We have a globally distributed load balancer that proxies traffic to avax nodes.

## How these changes were tested 

Readme preview

## To prevent any errors while building

- [] run `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [] run `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [] complete the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass

### If a document was removed/deleted

- [] the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path

### If a document was moved

- [] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path
