### PR TITLE
Update how-to-stake.md

### DIFF
--- a/docs/nodes/validate/how-to-stake.md
+++ b/docs/nodes/validate/how-to-stake.md
@@ -71,7 +71,7 @@ On Fuji Testnet, all staking parameters are the same as those on Mainnet except 
 
 ## Validators
 
-**Validators** secure Avalanche, create new blocks/vertices, and process
+**Validators** secure Avalanche, create new blocks, and process
 transactions. To achieve consensus, validators repeatedly sample each other. The
 probability that a given validator is sampled is proportional to its stake.
 


### PR DESCRIPTION
Removing "vertices" since DAG is not a thing anymore


# Docs PR Template

## Why this should be merged

Since X-chain linearization, validators operate on blocks and not vertices anymore

## How this works

tiny fix

## How these changes were tested 

edited from site directly, not tested needed

## To prevent any errors while building

- [] run `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [] run `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [] complete the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass

### If a document was removed/deleted

- [] the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path

### If a document was moved

- [] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path
