### PR TITLE
Fix broken link to Avalanche Network Runner

### DIFF
--- a/docs/learn/avalanche/fuji.md
+++ b/docs/learn/avalanche/fuji.md
@@ -34,6 +34,6 @@ To receive testnet tokens, users can request funds from the
 documentation.
 - While Fuji Network is a valuable resource, developers also
 have the option to explore
-[Avalanche Network Runner](https://docs.avax.network/tooling/network-runner)
+[Avalanche Network Runner](/tooling/network-runner.md)
 as an alternative means of locally testing their projects, ensuring comprehensive evaluation and 
 fine-tuning before interacting with the wider network. 

--- a/docs/learn/avalanche/fuji.md
+++ b/docs/learn/avalanche/fuji.md
@@ -34,6 +34,6 @@ To receive testnet tokens, users can request funds from the
 documentation.
 - While Fuji Network is a valuable resource, developers also
 have the option to explore
-[Avalanche Network Runner](https://docs.avax.network/quickstart/tools-list#avalanche-network-runner-anr)
+[Avalanche Network Runner](https://docs.avax.network/tooling/network-runner)
 as an alternative means of locally testing their projects, ensuring comprehensive evaluation and 
 fine-tuning before interacting with the wider network. 


### PR DESCRIPTION
## Why this should be merged

I found a broken link while reading the docs. This change fixes it.

## How these changes were tested 

I clicked the link in the markdown preview

## To prevent any errors while building

- [ ] run `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [ ] run `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [ ] complete the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass