### PR TITLE
Deprecated IPC API

### DIFF
--- a/docs/nodes/configure/avalanchego-config-flags.md
+++ b/docs/nodes/configure/avalanchego-config-flags.md
@@ -93,11 +93,6 @@ available. Defaults to `false`. See
 If set to `false`, this node will not expose the Info API. Defaults to `true`. See
 [here](/reference/avalanchego/info-api.md) for more information.
 
-#### `--api-ipcs-enabled` (boolean)
-
-If set to `true`, this node will expose the IPCs API. Defaults to `false`. See
-[here](/reference/avalanchego/ipc-api.md) for more information.
-
 #### `--api-keystore-enabled` (boolean)
 
 If set to `true`, this node will expose the Keystore API. Defaults to `false`.
@@ -532,18 +527,6 @@ List of acceptable host names in API requests. Provide the wildcard (`'*'`) to a
 requests from all hosts. API requests where the `Host` field is empty or an IP address
 will always be accepted. An API call whose HTTP `Host` field isn't acceptable will
 receive a 403 error code. Defaults to `localhost`.
-
-## IPCs
-
-#### `--ipcs-chain-ids` (string)
-
-Comma separated list of chain ids to connect to (for example
-`11111111111111111111111111111111LpoYY,4R5p2RXDGLqaifZE4hHWH9owe34pfoBULn1DrQTWivjg8o4aH`).
-There is no default value.
-
-#### `--ipcs-path` (string)
-
-The directory (Unix) or named pipe prefix (Windows) for IPC sockets. Defaults to `/tmp`.
 
 ## File Descriptor Limit
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/nodes/configure/avalanchego-config-flags.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/nodes/configure/avalanchego-config-flags.md
@@ -92,11 +92,6 @@ disponible. Por defecto, es `false`. Ver
 Si se establece en `false`, este nodo no expondrá la API de Información. Por defecto, es `true`. Ver
 [aquí](/reference/avalanchego/info-api.md) para más información.
 
-#### `--api-ipcs-enabled` (booleano)
-
-Si se establece en `true`, este nodo expondrá la API de IPCs. Por defecto, es `false`. Ver
-[aquí](/reference/avalanchego/ipc-api.md) para más información.
-
 #### `--api-keystore-enabled` (booleano)
 
 Si se establece en `true`, este nodo expondrá la API de Keystore. Por defecto, es `false`.
@@ -482,18 +477,6 @@ Orígenes permitidos en el puerto HTTP. De forma predeterminada, es `*`, lo que 
 
 Lista de nombres de host aceptables en las solicitudes de API. Proporcione el comodín (`'*'`) para aceptar
 solicitudes de todos los hosts. Una llamada de API cuyo campo `Host` HTTP no sea aceptable recibirá un código de error 403. De forma predeterminada, es `localhost`.
-
-## IPCs
-
-#### `--ipcs-chain-ids` (string)
-
-Lista separada por comas de los IDs de cadena a los que conectarse (por ejemplo,
-`11111111111111111111111111111111LpoYY,4R5p2RXDGLqaifZE4hHWH9owe34pfoBULn1DrQTWivjg8o4aH`).
-No hay un valor predeterminado.
-
-#### `--ipcs-path` (string)
-
-El directorio (Unix) o el prefijo de la tubería con nombre (Windows) para los sockets IPC. De forma predeterminada, es `/tmp`.
 
 ## Límite de descriptores de archivo
 


### PR DESCRIPTION
## Why this should be merged

The IPC API has been deprecated: https://github.com/ava-labs/avalanchego/pull/2168#issue-1942101224

## How this works

removed all relevant config flags 
