### PR TITLE
Fix broken links

### DIFF
--- a/docs/build/cross-chain/awm/overview.md
+++ b/docs/build/cross-chain/awm/overview.md
@@ -18,7 +18,7 @@ sidebar_position: 0
 # Avalanche Warp Messaging
 
 Avalanche Warp Messaging (AWM) enables native cross-Subnet communication and allows
-[Virtual Machine (VM)](/learn/avalanche/virtual-machines) developers to implement arbitrary
+[Virtual Machine (VM)](/learn/avalanche/virtual-machines.md) developers to implement arbitrary
 communication protocols
 between any two Subnets.
 

--- a/docs/build/cross-chain/awm/overview.md
+++ b/docs/build/cross-chain/awm/overview.md
@@ -18,7 +18,7 @@ sidebar_position: 0
 # Avalanche Warp Messaging
 
 Avalanche Warp Messaging (AWM) enables native cross-Subnet communication and allows
-[Virtual Machine (VM)](/learn/avalanche/subnets-overview.md#virtual-machines) developers to implement arbitrary
+[Virtual Machine (VM)](/learn/avalanche/virtual-machines) developers to implement arbitrary
 communication protocols
 between any two Subnets.
 

--- a/docs/build/subnet/README.md
+++ b/docs/build/subnet/README.md
@@ -7,7 +7,7 @@ pagination_label: Subnets Overview
 ---
 
 Avalanche Subnets are a subset of Avalanche Primary Network validators agreeing to run the same
-[Virtual Machines (VM)](/learn/avalanche/virtual-machines). Subnets
+[Virtual Machines (VM)](/learn/avalanche/virtual-machines.md). Subnets
 enable extra dimensions of reliability, efficiency, and data sovereignty. See [here](/learn/avalanche/subnets-overview.md)
 for a broad overview.
 

--- a/docs/build/subnet/README.md
+++ b/docs/build/subnet/README.md
@@ -7,7 +7,7 @@ pagination_label: Subnets Overview
 ---
 
 Avalanche Subnets are a subset of Avalanche Primary Network validators agreeing to run the same
-[Virtual Machines (VM)](/learn/avalanche/subnets-overview.md#virtual-machines). Subnets
+[Virtual Machines (VM)](/learn/avalanche/virtual-machines). Subnets
 enable extra dimensions of reliability, efficiency, and data sovereignty. See [here](/learn/avalanche/subnets-overview.md)
 for a broad overview.
 

--- a/docs/build/subnet/deploy/fuji-testnet-subnet.md
+++ b/docs/build/subnet/deploy/fuji-testnet-subnet.md
@@ -36,7 +36,7 @@ run-through of this tutorial.
 ## Virtual Machine
 
 Avalanche can run multiple blockchains. Each blockchain is an instance of a
-[Virtual Machine](/learn/avalanche/subnets-overview.md#virtual-machines), much like an object in
+[Virtual Machine](/learn/avalanche/virtual-machines), much like an object in
 an object-oriented language is an instance of a class.
 That's, the VM defines the behavior of the blockchain.
 
@@ -49,13 +49,13 @@ most other Ethereum client features.
 ## Fuji Testnet
 
 For this tutorial, it's recommended that you follow
-[Run an Avalanche Node Manually](/nodes/run/node-manually.md#connect-to-fuji-testnet)
+[Run an Avalanche Node Manually](/nodes/run/node-manually.md#run-an-avalanche-node-from-source)
 and this step below particularly to start your node on `Fuji`:
 
 _To connect to the Fuji Testnet instead of the main net, use argument `--network-id=Fuji`_
 
 Also it's worth pointing out that
-[it only needs 1 AVAX to become a validator on the Fuji Testnet](/nodes/validate/what-is-staking.md#fuji-testnet)
+[it only needs 1 AVAX to become a validator on the Fuji Testnet](/nodes/validate/what-is-staking.md)
 and you can get the test token from the [faucet](https://faucet.avax.network/). If you already have an AVAX
 balance greater than zero on Mainnet, paste your C-Chain address there, and request test tokens. Otherwise, 
 please request a faucet coupon on 
@@ -237,8 +237,8 @@ After following these 3 steps, your test key should now have a balance on the P-
 
 ## Create an EVM Subnet
 
-Creating a Subnet with `Avalanche-CLI` for `Fuji` works the same way as with a
-[local network](/build/subnet/deploy/local-subnet.md#create-a-custom-subnet-configuration). In fact,
+Creating a Subnet with `Avalanche-CLI` for `Fuji` works the same way as with a local network. 
+In fact,
 the `create` commands only creates a specification of your Subnet on the local file system.
 Afterwards the
 Subnet needs to be _deployed_. This allows to reuse configs, by creating the config with the
@@ -568,7 +568,7 @@ To request permission to validate a Subnet, the following steps are required:
 Before a node can be a validator on a Subnet, the node is required to already be a validator on the
 primary network, which means that your node has **fully bootstrapped**.
 
-See [here](/nodes/validate/add-a-validator.md#add-a-validator-with-avalanche-wallet) on how to
+See [here](/nodes/validate/add-a-validator.md#add-a-validator-with-core-extension) on how to
 become a validator.
 
 :::

--- a/docs/build/subnet/deploy/fuji-testnet-subnet.md
+++ b/docs/build/subnet/deploy/fuji-testnet-subnet.md
@@ -36,7 +36,7 @@ run-through of this tutorial.
 ## Virtual Machine
 
 Avalanche can run multiple blockchains. Each blockchain is an instance of a
-[Virtual Machine](/learn/avalanche/virtual-machines), much like an object in
+[Virtual Machine](/learn/avalanche/virtual-machines.md), much like an object in
 an object-oriented language is an instance of a class.
 That's, the VM defines the behavior of the blockchain.
 

--- a/docs/build/subnet/deploy/mainnet-subnet.md
+++ b/docs/build/subnet/deploy/mainnet-subnet.md
@@ -267,7 +267,7 @@ To request permission to validate a Subnet, the following steps are required:
 Adding a validator on a Subnet requires that the node is already a validator on the primary network,
 which means that your node has **fully bootstrapped**.
 
-See [here](/nodes/validate/add-a-validator.md#add-a-validator-with-avalanche-wallet) on how to become
+See [here](/nodes/validate/add-a-validator.md#add-a-validator-with-core-extension) on how to become
 a validator.
 
 :::

--- a/docs/build/subnet/info/wagmi.md
+++ b/docs/build/subnet/info/wagmi.md
@@ -181,7 +181,7 @@ set manager address and making calls on the precompiled contract.
 
 We will use [Remix](https://remix.ethereum.org) online Solidity IDE and the [Core Browser
 Extension](https://support.avax.network/en/articles/6066879-core-extension-how-do-i-add-the-core-extension).
-Core comes with WAGMI network built-in. MetaMask will do as well but you will need to [add WAGMI](/build/subnet/info/wagmi.md#adding-wagmi-to-metamask) yourself.
+Core comes with WAGMI network built-in. MetaMask will do as well but you will need to [add WAGMI](/build/subnet/info/wagmi.md#adding-wagmi-to-core) yourself.
 
 First using Core, we open the account as the owner `0x6f0f6DA1852857d7789f68a28bba866671f3880D`.
 

--- a/docs/build/subnet/upgrade/considerations-subnet-upgrade.md
+++ b/docs/build/subnet/upgrade/considerations-subnet-upgrade.md
@@ -60,7 +60,7 @@ cumulative weight is connected and working at all times.
 
 It is mandatory that the cumulative weight of all validators in the Subnet must be at least
 the value of
-[`snow-sample-size`](/nodes/configure/avalanchego-config-flags.md#snow-sample-size-int) (default
+[`snow-sample-size`](/nodes/configure/avalanchego-config-flags.md#consensus-parameters) (default
 20). For example, if there is only one validator in the Subnet, its weight must be at least
 `snow-sample-size` . Hence, when assigning weight to the nodes, always use values greater than 20.
 Recall that a validator's weight can't be changed while it is validating, so take care to use an

--- a/docs/build/subnet/upgrade/considerations-subnet-upgrade.md
+++ b/docs/build/subnet/upgrade/considerations-subnet-upgrade.md
@@ -60,7 +60,7 @@ cumulative weight is connected and working at all times.
 
 It is mandatory that the cumulative weight of all validators in the Subnet must be at least
 the value of
-[`snow-sample-size`](/nodes/configure/avalanchego-config-flags.md#consensus-parameters) (default
+[`snow-sample-size`](/nodes/configure/avalanchego-config-flags.md#--snow-sample-size-int) (default
 20). For example, if there is only one validator in the Subnet, its weight must be at least
 `snow-sample-size` . Hence, when assigning weight to the nodes, always use values greater than 20.
 Recall that a validator's weight can't be changed while it is validating, so take care to use an

--- a/docs/build/subnet/upgrade/customize-a-subnet.md
+++ b/docs/build/subnet/upgrade/customize-a-subnet.md
@@ -91,7 +91,7 @@ other chains can cause issues. One suggestion is to check with [chainlist.org](h
 to avoid ID collision, reserve and publish your ChainID properly.
 
 You can use `eth_getChainConfig` RPC call to get the current chain config. See
-[here](/reference/subnet-evm/api#ethgetchainconfig) for more info.
+[here](/reference/subnet-evm/api#eth_getchainconfig) for more info.
 
 #### Hard Forks
 

--- a/docs/build/subnet/upgrade/customize-a-subnet.md
+++ b/docs/build/subnet/upgrade/customize-a-subnet.md
@@ -91,7 +91,7 @@ other chains can cause issues. One suggestion is to check with [chainlist.org](h
 to avoid ID collision, reserve and publish your ChainID properly.
 
 You can use `eth_getChainConfig` RPC call to get the current chain config. See
-[here](/reference/subnet-evm/api#eth_getchainconfig) for more info.
+[here](/reference/subnet-evm/api.md#eth_getchainconfig) for more info.
 
 #### Hard Forks
 

--- a/docs/build/vm/create/rust-vm.md
+++ b/docs/build/vm/create/rust-vm.md
@@ -1294,7 +1294,7 @@ others that weren't already installed previously in the response.
 
 Now, this VM's static API can be accessed at endpoints `/ext/vm/timestampvm-rs` and
 `/ext/vm/timestamp-rs`. For more details about VM configs, see
-[here](/nodes/configure/avalanchego-config-flags.md#vm-configs).
+[here](/nodes/configure/avalanchego-config-flags.md#virtual-machine-vm-configs).
 
 In this tutorial, we used the VM's ID as the executable name to simplify the process. However,
 AvalancheGo would also accept `timestampvm-rs` or `timestamp-rs` since those are registered aliases

--- a/docs/build/vm/golang-vms/golang-vm-simple.md
+++ b/docs/build/vm/golang-vms/golang-vm-simple.md
@@ -1302,7 +1302,7 @@ others that weren't already installed previously in the response.
 
 Now, this VM's static API can be accessed at endpoints `/ext/vm/timestampvm` and
 `/ext/vm/timestamp`. For more details about VM configs, see
-[here](/nodes/configure/avalanchego-config-flags.md#vm-configs).
+[here](/nodes/configure/avalanchego-config-flags.md#virtual-machine-vm-configs).
 
 In this tutorial, we used the VM's ID as the executable name to simplify the process. However,
 AvalancheGo would also accept `timestampvm` or `timestamp` since those are registered aliases in

--- a/docs/build/vm/rust-vms/installing-vm.md
+++ b/docs/build/vm/rust-vms/installing-vm.md
@@ -60,7 +60,7 @@ others that weren't already installed previously in the response.
 
 Now, this VM's static API can be accessed at endpoints `/ext/vm/timestampvm-rs` and
 `/ext/vm/timestamp-rs`. For more details about VM configs, see
-[here](/nodes/configure/avalanchego-config-flags.md#vm-configs).
+[here](/nodes/configure/avalanchego-config-flags.md#virtual-machine-vm-configs).
 
 In this tutorial, we used the VM's ID as the executable name to simplify the process. However,
 AvalancheGo would also accept `timestampvm-rs` or `timestamp-rs` since those are registered aliases

--- a/docs/deprecated/tutorials-contest/2022/local-subnet-development/README.md
+++ b/docs/deprecated/tutorials-contest/2022/local-subnet-development/README.md
@@ -227,7 +227,7 @@ This tutorial will cover interacting with the Subnet through
 ### Step 4.1: Using Remix
 
 First, we will be adding our Subnet to [MetaMask](https://metamask.io/). To add
-the Subnet, refer to [Deploy a Smart Contract on Your Subnet-EVM Using Remix and MetaMask](/build/subnet/utility/deploy-smart-contract-to-subnet.md#step-1-setting-up-metamask)
+the Subnet, refer to [Deploy a Smart Contract on Your Subnet-EVM Using Remix and MetaMask](/build/subnet/utility/deploy-smart-contract-to-subnet.md#using-remix)
 you should replace the values with your Subnet values that are printed out after
 you have created it. If your balance is zero after you add Subnet to the
 MetaMask, refer to [Access Funded Accounts](#access-funded-accounts).

--- a/docs/learn/avalanche/subnets-overview.md
+++ b/docs/learn/avalanche/subnets-overview.md
@@ -56,7 +56,7 @@ _Different blockchain-based applications may require validators to have certain
 properties such as large amounts of RAM or CPU power._
 
 - A Subnet could require that validators
-  meet certain [hardware requirements](/nodes/run/node-manually.md#requirements) so
+  meet certain [hardware requirements](/nodes/run/node-manually.md#hardware-and-os-requirements) so
   that the application doesn’t suffer from low performance due to slow validators.
 
 ### Launch a Network Designed With Compliance In Mind

--- a/docs/nodes/maintain/setting-up-node-monitoring.md
+++ b/docs/nodes/maintain/setting-up-node-monitoring.md
@@ -142,7 +142,7 @@ Prometheus web interface, available on `http://your-node-host-ip:9090/`
 You may need to do `sudo ufw allow 9090/tcp` if the firewall is on, and/or
 adjust the security settings to allow connections to port 9090 if the node is
 running on a cloud instance. For AWS, you can look it up
-[here](/nodes/run/third-party/aws-node.md#f8df).
+[here](/nodes/run/third-party/aws-node.md#create-a-security-group).
 If on public internet, make sure to only allow your IP to connect!
 
 :::

--- a/docs/nodes/run/third-party/google-cloud-node.md
+++ b/docs/nodes/run/third-party/google-cloud-node.md
@@ -39,7 +39,7 @@ basis on which you can easily build further automation.
 ## Architectural Description
 
 This section aims to describe the architecture of the system that the steps in
-the [Setup Instructions](#setup-instructions) section deploy when enacted. This
+the [Setup Instructions](#-setup-instructions) section deploy when enacted. This
 is done so that the executor can not only deploy the reference architecture, but
 also understand and potentially optimize it for their needs.
 

--- a/docs/nodes/validate/what-is-staking.md
+++ b/docs/nodes/validate/what-is-staking.md
@@ -21,5 +21,5 @@ a decentralized network must require that network influence is paid with a
 scarce resource. This makes it infeasibly expensive for an attacker to gain
 enough influence over the network to compromise its security. On Avalanche, the scarce
 resource is the native token,
-[AVAX](/learn/avalanche/intro.md#avax). For a node to validate
+[AVAX](/learn/avalanche/avax.md). For a node to validate
 a blockchain on Avalanche, it must stake AVAX.

--- a/docs/reference/avalanchego/admin-api.md
+++ b/docs/reference/avalanchego/admin-api.md
@@ -227,7 +227,7 @@ curl -X POST --data '{
 ### `admin.loadVMs`
 
 Dynamically loads any virtual machines installed on the node as plugins. See
-[here](/build/vm/intro#load-a-vm) for more information on how to install a
+[here](/build/vm/intro#installing-a-vm) for more information on how to install a
 virtual machine on a node.
 
 **Signature:**

--- a/docs/reference/avalanchego/p-chain/txn-format.md
+++ b/docs/reference/avalanchego/p-chain/txn-format.md
@@ -10,7 +10,7 @@ pagination_label: P-Chain Transaction Format
 This file is meant to be the single source of truth for how we serialize
 transactions in Avalanche’s Platform Virtual Machine, aka the `Platform Chain`
 or `P-Chain`. This document uses the [primitive serialization](/reference/standards/serialization-primitives.md) format for packing and
-[secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) for cryptographic
+[secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) for cryptographic
 user identification.
 
 ## Codec ID
@@ -219,7 +219,7 @@ Outputs have two possible type: `SECP256K1TransferOutput`, `SECP256K1OutputOwner
 
 ## SECP256K1 Transfer Output
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) transfer output
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) transfer output
 allows for sending a quantity of an asset to a collection of addresses after a
 specified Unix time. The only valid asset is AVAX.
 
@@ -310,7 +310,7 @@ Let’s make a secp256k1 transfer output with:
 
 ## SECP256K1 Output Owners Output
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) output owners
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) output owners
 output will receive the staking rewards when the lock up period ends.
 
 ### What SECP256K1 Output Owners Output Contains
@@ -396,7 +396,7 @@ Inputs have one possible type: `SECP256K1TransferInput`.
 
 ## SECP256K1 Transfer Input
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) transfer input
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) transfer input
 allows for spending an unspent secp256k1 transfer output.
 
 ### What SECP256K1 Transfer Input Contains
@@ -2151,7 +2151,7 @@ of the inputs or operations.
 
 ## SECP256K1 Credential
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) credential
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) credential
 contains a list of 65-byte recoverable signatures.
 
 ### What SECP256K1 Credential Contains

--- a/docs/reference/avalanchego/x-chain/api.md
+++ b/docs/reference/avalanchego/x-chain/api.md
@@ -7,7 +7,7 @@ pagination_label: X-Chain API
 
 # X-Chain API
 
-The [X-Chain](/learn/avalanche/avalanche-platform.md#exchange-chain-x-chain),
+The [X-Chain](/learn/avalanche/avalanche-platform.md#x-chain),
 Avalanche’s native platform for creating and trading assets, is an instance of the Avalanche Virtual
 Machine (AVM). This API allows clients to create and trade assets on the X-Chain and other instances
 of the AVM.

--- a/docs/reference/avalanchego/x-chain/txn-format.md
+++ b/docs/reference/avalanchego/x-chain/txn-format.md
@@ -271,7 +271,7 @@ Outputs have four possible types:
 
 ## SECP256K1 Mint Output
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) mint output is
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) mint output is
 an output that is owned by a collection of addresses.
 
 ### What SECP256K1 Mint Output Contains
@@ -359,7 +359,7 @@ Let’s make a SECP256K1 mint output with:
 
 ## SECP256K1 Transfer Output
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) transfer output
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) transfer output
 allows for sending a quantity of an asset to a collection of addresses after a
 specified Unix time.
 
@@ -662,7 +662,7 @@ Inputs have one possible type: `SECP256K1TransferInput`.
 
 ## SECP256K1 Transfer Input
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) transfer input
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) transfer input
 allows for spending an unspent secp256k1 transfer output.
 
 ### What SECP256K1 Transfer Input Contains
@@ -737,7 +737,7 @@ Operations have three possible types: `SECP256K1MintOperation`, `NFTMintOp`, and
 
 ## SECP256K1 Mint Operation
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) mint operation
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) mint operation
 consumes a SECP256K1 mint output, creates a new mint output and sends a transfer
 output to a new set of owners.
 
@@ -786,7 +786,7 @@ message SECP256K1MintOperation {
 
 ### SECP256K1 Mint Operation Example
 
-Let’s make a [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) mint
+Let’s make a [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) mint
 operation with:
 
 - **`TypeId`**: `8`
@@ -1148,7 +1148,7 @@ credentials match the order of the inputs or operations.
 
 ## SECP256K1 Credential
 
-A [secp256k1](/reference/standards/cryptographic-primitives.md#secp-256-k1-addresses) credential
+A [secp256k1](/reference/standards/cryptographic-primitives.md#secp256k1-addresses) credential
 contains a list of 65-byte recoverable signatures.
 
 ### What SECP256K1 Credential Contains

--- a/docs/reference/standards/guides/issuing-api-calls.md
+++ b/docs/reference/standards/guides/issuing-api-calls.md
@@ -35,7 +35,7 @@ If you're making RPC calls to remote nodes, then the instead of `127.0.0.1` you
 should use the public IP of the server where the node is. Note that by default
 the node will only accept API calls on the local interface, so you will need to
 set up the
-[`http-host`](/nodes/configure/chain-config-flags.md#--http-host-string)
+[`http-host`](/nodes/configure/avalanchego-config-flags.md#--http-host-string)
 config flag on the node. Also, you will need to make sure the firewall and/or
 security policy allows access to the `http-port` from the internet.
 

--- a/docs/reference/standards/guides/x-chain-migration.md
+++ b/docs/reference/standards/guides/x-chain-migration.md
@@ -32,14 +32,14 @@ after the network upgrade has occurred.
 ## Vertex -> Block Indexing
 
 Before Cortina, indexing the X-Chain required polling the
-[/ext/index/X/vtx](/reference/avalanchego/index-api.md#x-chain-vertices) endpoint to fetch new
+`/ext/index/X/vtx` endpoint to fetch new
 vertices. During the Cortina activation, a “stop vertex” will be produced using
 a [new codec
 version](https://github.com/ava-labs/avalanchego/blob/c27721a8da1397b218ce9e9ec69839b8a30f9860/snow/engine/avalanche/vertex/codec.go#L17-L18)
 that will contain no transactions. This new vertex type will be the [same
 format](https://github.com/ava-labs/avalanchego/blob/c27721a8da1397b218ce9e9ec69839b8a30f9860/snow/engine/avalanche/vertex/stateless_vertex.go#L95-L102)
 as previous vertices. To ensure historical data can still be accessed in
-Cortina, the [/ext/index/X/vtx](/reference/avalanchego/index-api.md#x-chain-vertices) will remain
+Cortina, the `/ext/index/X/vtx` will remain
 accessible even though it will no longer be populated with chain data.
 
 :::note

--- a/docs/tooling/avalanchejs-overview.md
+++ b/docs/tooling/avalanchejs-overview.md
@@ -152,7 +152,7 @@ Run the script:
 
 ### JavaScript File
 
-As Node.js is already installed per [requirements](/#Requirements),
+As Node.js is already installed per [requirements](#requirements),
 simply run the script:
 
 `node script-name.js`

--- a/docs/tooling/cli-create-deploy-subnets/deploy-fuji-testnet-subnet.md
+++ b/docs/tooling/cli-create-deploy-subnets/deploy-fuji-testnet-subnet.md
@@ -36,7 +36,7 @@ run-through of this tutorial.
 ## Virtual Machine
 
 Avalanche can run multiple blockchains. Each blockchain is an instance of a
-[Virtual Machine](/learn/avalanche/virtual-machines), much like an object in
+[Virtual Machine](/learn/avalanche/virtual-machines.md), much like an object in
 an object-oriented language is an instance of a class.
 That's, the VM defines the behavior of the blockchain.
 

--- a/docs/tooling/cli-create-deploy-subnets/deploy-fuji-testnet-subnet.md
+++ b/docs/tooling/cli-create-deploy-subnets/deploy-fuji-testnet-subnet.md
@@ -36,7 +36,7 @@ run-through of this tutorial.
 ## Virtual Machine
 
 Avalanche can run multiple blockchains. Each blockchain is an instance of a
-[Virtual Machine](/learn/avalanche/subnets-overview.md#virtual-machines), much like an object in
+[Virtual Machine](/learn/avalanche/virtual-machines), much like an object in
 an object-oriented language is an instance of a class.
 That's, the VM defines the behavior of the blockchain.
 
@@ -49,13 +49,13 @@ most other Ethereum client features.
 ## Fuji Testnet
 
 For this tutorial, it's recommended that you follow
-[Run an Avalanche Node Manually](/nodes/run/node-manually.md#connect-to-fuji-testnet)
+[Run an Avalanche Node Manually](/nodes/run/node-manually.md#5-start-the-node)
 and this step below particularly to start your node on `Fuji`:
 
 _To connect to the Fuji Testnet instead of the main net, use argument `--network-id=Fuji`_
 
 Also it's worth pointing out that
-[it only needs 1 AVAX to become a validator on the Fuji Testnet](/nodes/validate/what-is-staking.md#fuji-testnet)
+[it only needs 1 AVAX to become a validator on the Fuji Testnet](/nodes/validate/what-is-staking.md)
 and you can get the test token from the [faucet](https://faucet.avax.network/).
 
 To get the NodeID of this `Fuji` node, call the following curl command to [info.getNodeID](/reference/avalanchego/info-api.md#infogetnodeid):
@@ -231,7 +231,7 @@ After following these 3 steps, your test key should now have a balance on the P-
 ## Create an EVM Subnet
 
 Creating a Subnet with `Avalanche-CLI` for `Fuji` works the same way as with a
-[local network](/build/subnet/deploy/local-subnet.md#create-a-custom-subnet-configuration). In fact,
+local network. In fact,
 the `create` commands only creates a specification of your Subnet on the local file system.
 Afterwards the
 Subnet needs to be _deployed_. This allows to reuse configs, by creating the config with the
@@ -561,7 +561,7 @@ To request permission to validate a Subnet, the following steps are required:
 Before a node can be a validator on a Subnet, the node is required to already be a validator on the
 primary network, which means that your node has **fully bootstrapped**.
 
-See [here](/nodes/validate/add-a-validator.md#add-a-validator-with-avalanche-wallet) on how to
+See [here](/nodes/validate/add-a-validator.md#add-a-validator-with-core-extension) on how to
 become a validator.
 
 :::

--- a/docs/tooling/cli-create-deploy-subnets/deploy-mainnet-subnet.md
+++ b/docs/tooling/cli-create-deploy-subnets/deploy-mainnet-subnet.md
@@ -267,7 +267,7 @@ To request permission to validate a Subnet, the following steps are required:
 Adding a validator on a Subnet requires that the node is already a validator on the primary network,
 which means that your node has **fully bootstrapped**.
 
-See [here](/nodes/validate/add-a-validator.md#add-a-validator-with-avalanche-wallet) on how to become
+See [here](/nodes/validate/add-a-validator.md#add-a-validator-with-core-extension) on how to become
 a validator.
 
 :::

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/awm/overview.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/awm/overview.md
@@ -18,7 +18,7 @@ sidebar_position: 0
 # Avalanche Warp Messaging
 
 Avalanche Warp Messaging (AWM) enables native cross-Subnet communication and allows
-[Virtual Machine (VM)](/learn/avalanche/virtual-machines) developers to implement arbitrary
+[Virtual Machine (VM)](/learn/avalanche/virtual-machines.md) developers to implement arbitrary
 communication protocols
 between any two Subnets.
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/awm/overview.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/awm/overview.md
@@ -18,7 +18,7 @@ sidebar_position: 0
 # Avalanche Warp Messaging
 
 Avalanche Warp Messaging (AWM) enables native cross-Subnet communication and allows
-[Virtual Machine (VM)](/learn/avalanche/subnets-overview.md#virtual-machines) developers to implement arbitrary
+[Virtual Machine (VM)](/learn/avalanche/virtual-machines) developers to implement arbitrary
 communication protocols
 between any two Subnets.
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/README.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/README.md
@@ -6,7 +6,7 @@ sidebar_label: 🔗 Enlaces rápidos
 pagination_label: Resumen de Subnets
 ---
 
-Las Subnets de Avalanche son un subconjunto de validadores de la red primaria de Avalanche que acuerdan ejecutar las mismas [Máquinas Virtuales (VM)](/learn/avalanche/virtual-machines). Las Subnets permiten dimensiones adicionales de confiabilidad, eficiencia y soberanía de datos. Consulta [aquí](/learn/avalanche/subnets-overview.md) para obtener una visión general amplia.
+Las Subnets de Avalanche son un subconjunto de validadores de la red primaria de Avalanche que acuerdan ejecutar las mismas [Máquinas Virtuales (VM)](/learn/avalanche/virtual-machines.md). Las Subnets permiten dimensiones adicionales de confiabilidad, eficiencia y soberanía de datos. Consulta [aquí](/learn/avalanche/subnets-overview.md) para obtener una visión general amplia.
 
 ## 🔗 Enlaces rápidos de Subnets
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/README.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/README.md
@@ -6,7 +6,7 @@ sidebar_label: 🔗 Enlaces rápidos
 pagination_label: Resumen de Subnets
 ---
 
-Las Subnets de Avalanche son un subconjunto de validadores de la red primaria de Avalanche que acuerdan ejecutar las mismas [Máquinas Virtuales (VM)](/learn/avalanche/subnets-overview.md#virtual-machines). Las Subnets permiten dimensiones adicionales de confiabilidad, eficiencia y soberanía de datos. Consulta [aquí](/learn/avalanche/subnets-overview.md) para obtener una visión general amplia.
+Las Subnets de Avalanche son un subconjunto de validadores de la red primaria de Avalanche que acuerdan ejecutar las mismas [Máquinas Virtuales (VM)](/learn/avalanche/virtual-machines). Las Subnets permiten dimensiones adicionales de confiabilidad, eficiencia y soberanía de datos. Consulta [aquí](/learn/avalanche/subnets-overview.md) para obtener una visión general amplia.
 
 ## 🔗 Enlaces rápidos de Subnets
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/fuji-testnet-subnet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/fuji-testnet-subnet.md
@@ -36,7 +36,7 @@ ejecución de este tutorial.
 ## Máquina Virtual
 
 Avalanche puede ejecutar múltiples blockchains. Cada blockchain es una instancia de una
-[Máquina Virtual](/learn/avalanche/subnets-overview.md#virtual-machines), al igual que un objeto en
+[Máquina Virtual](/learn/avalanche/virtual-machines), al igual que un objeto en
 un lenguaje orientado a objetos es una instancia de una clase.
 Es decir, la VM define el comportamiento de la blockchain.
 
@@ -55,7 +55,7 @@ y este paso a continuación en particular para iniciar tu nodo en `Fuji`:
 _Para conectarte a la Testnet Fuji en lugar de a la red principal, usa el argumento `--network-id=Fuji`_
 
 También vale la pena señalar que
-[solo se necesita 1 AVAX para convertirse en un validador en la Testnet Fuji](/nodes/validate/what-is-staking.md#fuji-testnet)
+[solo se necesita 1 AVAX para convertirse en un validador en la Testnet Fuji](/nodes/validate/what-is-staking.md)
 y puedes obtener el token de prueba desde el [faucet](https://faucet.avax.network/). Si ya tienes un saldo AVAX
 mayor que cero en Mainnet, pega tu dirección de C-Chain allí y solicita tokens de prueba. De lo contrario,
 solicita un cupón de faucet en
@@ -553,7 +553,7 @@ La nueva Subnet creada en los pasos anteriores aún no tiene validadores dedicad
 
 Antes de que un nodo pueda ser un validador en una Subnet, se requiere que el nodo ya sea un validador en la red primaria, lo que significa que tu nodo se ha **inicializado completamente**.
 
-Consulta [aquí](/nodes/validate/add-a-validator.md#add-a-validator-with-avalanche-wallet) cómo convertirte en un validador.
+Consulta [aquí](/nodes/validate/add-a-validator.md#add-a-validator-with-core-extension) cómo convertirte en un validador.
 
 :::
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/fuji-testnet-subnet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/fuji-testnet-subnet.md
@@ -36,7 +36,7 @@ ejecución de este tutorial.
 ## Máquina Virtual
 
 Avalanche puede ejecutar múltiples blockchains. Cada blockchain es una instancia de una
-[Máquina Virtual](/learn/avalanche/virtual-machines), al igual que un objeto en
+[Máquina Virtual](/learn/avalanche/virtual-machines.md), al igual que un objeto en
 un lenguaje orientado a objetos es una instancia de una clase.
 Es decir, la VM define el comportamiento de la blockchain.
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/mainnet-subnet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/mainnet-subnet.md
@@ -265,7 +265,7 @@ Para solicitar permiso para validar una Subnet, se requieren los siguientes paso
 Agregar un validador en una Subnet requiere que el nodo ya sea un validador en la red primaria,
 lo que significa que tu nodo se ha **iniciado completamente**.
 
-Consulta [aquí](/nodes/validate/add-a-validator.md#add-a-validator-with-avalanche-wallet) cómo convertirte
+Consulta [aquí](/nodes/validate/add-a-validator.md#add-a-validator-with-core-extension) cómo convertirte
 en un validador.
 
 :::

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/info/wagmi.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/info/wagmi.md
@@ -159,7 +159,7 @@ consideren adecuado. Para hacer eso, todo lo que se necesita es acceso a la red,
 establecida y realizar llamadas al contrato precompilado.
 
 Usaremos [Remix](https://remix.ethereum.org) un IDE de Solidity en línea y la [Extensión del Navegador Core](https://support.avax.network/en/articles/6066879-core-extension-how-do-i-add-the-core-extension).
-Core viene con la red WAGMI incorporada. MetaMask también servirá, pero deberá [agregar WAGMI](/build/subnet/info/wagmi.md#adding-wagmi-to-metamask) usted mismo.
+Core viene con la red WAGMI incorporada. MetaMask también servirá, pero deberá [agregar WAGMI](/build/subnet/info/wagmi.md#adding-wagmi-to-core) usted mismo.
 
 Primero, usando Core, abrimos la cuenta como propietario `0x6f0f6DA1852857d7789f68a28bba866671f3880D`.
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/upgrade/considerations-subnet-upgrade.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/upgrade/considerations-subnet-upgrade.md
@@ -58,7 +58,7 @@ Como operador de una Subnet, debes asegurarte de que, hagas lo que hagas, al men
 
 Es obligatorio que el peso acumulativo de todos los validadores en la Subnet sea al menos
 el valor de
-[`snow-sample-size`](/nodes/configure/avalanchego-config-flags.md#snow-sample-size-int) (valor predeterminado
+[`snow-sample-size`](/nodes/configure/avalanchego-config-flags.md#consensus-parameters) (valor predeterminado
 20). Por ejemplo, si solo hay un validador en la Subnet, su peso debe ser al menos
 `snow-sample-size`. Por lo tanto, al asignar peso a los nodos, siempre usa valores mayores que 20.
 Recuerda que el peso de un validador no se puede cambiar mientras está validando, así que asegúrate de usar un

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/upgrade/considerations-subnet-upgrade.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/upgrade/considerations-subnet-upgrade.md
@@ -58,7 +58,7 @@ Como operador de una Subnet, debes asegurarte de que, hagas lo que hagas, al men
 
 Es obligatorio que el peso acumulativo de todos los validadores en la Subnet sea al menos
 el valor de
-[`snow-sample-size`](/nodes/configure/avalanchego-config-flags.md#consensus-parameters) (valor predeterminado
+[`snow-sample-size`](/nodes/configure/avalanchego-config-flags.md#--snow-sample-size-int) (valor predeterminado
 20). Por ejemplo, si solo hay un validador en la Subnet, su peso debe ser al menos
 `snow-sample-size`. Por lo tanto, al asignar peso a los nodos, siempre usa valores mayores que 20.
 Recuerda que el peso de un validador no se puede cambiar mientras está validando, así que asegúrate de usar un

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/create/golang-vm-simple.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/create/golang-vm-simple.md
@@ -1302,7 +1302,7 @@ others that weren't already installed previously in the response.
 
 Now, this VM's static API can be accessed at endpoints `/ext/vm/timestampvm` and
 `/ext/vm/timestamp`. For more details about VM configs, see
-[here](/nodes/configure/avalanchego-config-flags.md#vm-configs).
+[here](/nodes/configure/avalanchego-config-flags.md#virtual-machine-vm-configs).
 
 In this tutorial, we used the VM's ID as the executable name to simplify the process. However,
 AvalancheGo would also accept `timestampvm` or `timestamp` since those are registered aliases in

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/create/rust-vm.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/create/rust-vm.md
@@ -1295,7 +1295,7 @@ others that weren't already installed previously in the response.
 
 Now, this VM's static API can be accessed at endpoints `/ext/vm/timestampvm-rs` and
 `/ext/vm/timestamp-rs`. For more details about VM configs, see
-[here](/nodes/configure/avalanchego-config-flags.md#vm-configs).
+[here](/nodes/configure/avalanchego-config-flags.md#virtual-machine-vm-configs).
 
 In this tutorial, we used the VM's ID as the executable name to simplify the process. However,
 AvalancheGo would also accept `timestampvm-rs` or `timestamp-rs` since those are registered aliases

--- a/i18n/es/docusaurus-plugin-content-docs/current/learn/avalanche/subnets-overview.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/learn/avalanche/subnets-overview.md
@@ -48,7 +48,7 @@ Los operadores de nodos que validan una Subnet con múltiples blockchains no nec
 
 _Las diferentes aplicaciones basadas en blockchain pueden requerir que los validadores tengan ciertas propiedades como grandes cantidades de RAM o poder de CPU._
 
-- Una Subnet podría requerir que los validadores cumplan con ciertos [requisitos de hardware](/nodes/run/node-manually.md#requirements) para que la aplicación no sufra un rendimiento bajo debido a validadores lentos.
+- Una Subnet podría requerir que los validadores cumplan con ciertos [requisitos de hardware](/nodes/run/node-manually.md#hardware-and-os-requirements) para que la aplicación no sufra un rendimiento bajo debido a validadores lentos.
 
 ### Lanzar una Red Diseñada con Cumplimiento en Mente
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/nodes/maintain/setting-up-node-monitoring.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/nodes/maintain/setting-up-node-monitoring.md
@@ -124,7 +124,7 @@ Observa el estado `active (running)` (presiona `q` para salir). También puedes 
 :::warning
 
 Es posible que necesites hacer `sudo ufw allow 9090/tcp` si el firewall está activado y/o ajustar la configuración de seguridad para permitir conexiones al puerto 9090 si el nodo se está ejecutando en una instancia en la nube. Para AWS, puedes consultarlo
-[aquí](/nodes/run/third-party/aws-node.md#f8df).
+[aquí](/nodes/run/third-party/aws-node.md#create-a-security-group).
 Si está en Internet público, ¡asegúrate de permitir solo que tu IP se conecte!
 
 :::

--- a/i18n/es/docusaurus-plugin-content-docs/current/nodes/validate/what-is-staking.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/nodes/validate/what-is-staking.md
@@ -12,4 +12,4 @@ El staking es el proceso en el que los usuarios bloquean sus tokens para apoyar 
 
 ## ¿Cómo funciona la prueba de participación?
 
-Para resistir los ataques [sybil](https://support.avalabs.org/en/articles/4064853-what-is-a-sybil-attack), una red descentralizada debe requerir que la influencia en la red se pague con un recurso escaso. Esto hace que sea demasiado caro para un atacante obtener suficiente influencia sobre la red para comprometer su seguridad. En Avalanche, el recurso escaso es el token nativo, [AVAX](/learn/avalanche/intro.md#avax). Para que un nodo valide una blockchain en Avalanche, debe hacer staking de AVAX.
+Para resistir los ataques [sybil](https://support.avalabs.org/en/articles/4064853-what-is-a-sybil-attack), una red descentralizada debe requerir que la influencia en la red se pague con un recurso escaso. Esto hace que sea demasiado caro para un atacante obtener suficiente influencia sobre la red para comprometer su seguridad. En Avalanche, el recurso escaso es el token nativo, [AVAX](/learn/avalanche/avax.md). Para que un nodo valide una blockchain en Avalanche, debe hacer staking de AVAX.


### PR DESCRIPTION
This PR fixes all broken anchors for the english docs which appear on build as warning.

The only one remaining as a warning is from an autogenerated doc

```
Exhaustive list of all broken anchors found:
- Broken anchor on source page path = /build/cross-chain/teleporter/overview:
   -> linking to #teleporter-protocol (resolved as: /build/cross-chain/teleporter/overview#teleporter-protocol)
```


