### PR TITLE
feat(AvalancheGo): add ACP Signaling flags in docs

### DIFF
--- a/docs/nodes/configure/avalanchego-config-flags.md
+++ b/docs/nodes/configure/avalanchego-config-flags.md
@@ -58,7 +58,7 @@ among currently supported file format (see
 #### `--acp-support` (integer)
 
 The `--acp-support` flag allows an AvalancheGo node to express support for a specific
-Avalanche Consensus Protocol (ACP) using its stake. This feature enables node
+Avalanche Community Proposals (ACP) using its stake. This feature enables validator node
 operators to participate actively in the governance of the network by endorsing
 proposals identified by their unique ACP IDs.
 

--- a/docs/nodes/configure/avalanchego-config-flags.md
+++ b/docs/nodes/configure/avalanchego-config-flags.md
@@ -62,7 +62,7 @@ Avalanche Community Proposals (ACP) using its stake. This feature enables valida
 operators to participate actively in the governance of the network by endorsing
 proposals identified by their unique ACP IDs.
 
-Usage: `--acp-support=[<ACP_ID>, <ACP_ID>, ...]`
+Usage: `--acp-support=<ACP_ID>,<ACP_ID>,...`
 
 #### `--acp-object` (array of integers)
 
@@ -71,7 +71,7 @@ effectively using its stake to oppose the proposal. This mechanism is part of th
 network's governance process, allowing stakeholders to express dissent against
 specific protocol changes or updates.
 
-Usage: `--acp-object=[<ACP_ID>, <ACP_ID>, ...]`
+Usage: `--acp-object=<ACP_ID>,<ACP_ID>,...`
 
 ## APIs
 

--- a/docs/nodes/configure/avalanchego-config-flags.md
+++ b/docs/nodes/configure/avalanchego-config-flags.md
@@ -55,23 +55,23 @@ among currently supported file format (see
 
 ## ACPs
 
-#### `--acp-support` (integer)
+#### `--acp-support` (array of integers)
 
 The `--acp-support` flag allows an AvalancheGo node to express support for a specific
 Avalanche Community Proposals (ACP) using its stake. This feature enables validator node
 operators to participate actively in the governance of the network by endorsing
 proposals identified by their unique ACP IDs.
 
-Usage: ```--acp-support=<ACP_ID>```
+Usage: `--acp-support=[<ACP_ID>, <ACP_ID>, ...]`
 
-#### `--acp-object` (integer)
+#### `--acp-object` (array of integers)
 
 The `--acp-object` flag enables an AvalancheGo node to formally raise objection to a specific ACP,
 effectively using its stake to oppose the proposal. This mechanism is part of the
 network's governance process, allowing stakeholders to express dissent against
 specific protocol changes or updates.
 
-Usage: ```--acp-object=<ACP_ID>```
+Usage: `--acp-object=[<ACP_ID>, <ACP_ID>, ...]`
 
 ## APIs
 

--- a/docs/nodes/configure/avalanchego-config-flags.md
+++ b/docs/nodes/configure/avalanchego-config-flags.md
@@ -53,6 +53,26 @@ Specifies the format of the base64 encoded config content. JSON, TOML, YAML are
 among currently supported file format (see
 [here](https://github.com/spf13/viper#reading-config-files) for full list). Defaults to `JSON`.
 
+## ACPs
+
+#### `--acp-support` (integer)
+
+The `--acp-support` flag allows an AvalancheGo node to express support for a specific
+Avalanche Consensus Protocol (ACP) using its stake. This feature enables node
+operators to participate actively in the governance of the network by endorsing
+proposals identified by their unique ACP IDs.
+
+Usage: ```--acp-support=<ACP_ID>```
+
+#### `--acp-object` (integer)
+
+The `--acp-object` flag enables an AvalancheGo node to formally raise objection to a specific ACP,
+effectively using its stake to oppose the proposal. This mechanism is part of the
+network's governance process, allowing stakeholders to express dissent against
+specific protocol changes or updates.
+
+Usage: ```--acp-object=<ACP_ID>```
+
 ## APIs
 
 #### `--api-admin-enabled` (boolean)


### PR DESCRIPTION
## Why this should be merged

ACP Signaling flags make it easy for validator node operators to participate in the ACP governance. We need appropriate reference docs for the config flags in order to make sure it's easy to follow.

## How these changes were tested 

Checked on my local node.

## Additions needed

@joshua-kim we'd like to add info on how a user can specify multiple ACPs in one single request. will also need info on if and how a user can change his opinion from support to conflict or vice-versa on an ACP