### PR TITLE
Add subnet evm durango docs

### DIFF
--- a/docs/build/subnet/deploy/custom-vm-subnet.md
+++ b/docs/build/subnet/deploy/custom-vm-subnet.md
@@ -8,7 +8,7 @@ sidebar_position: 5
 
 # Create a Subnet with a Custom Virtual Machine
 
-This tutorial walks through the process of creating a Subnet with a custom virtual machine and 
+This tutorial walks through the process of creating a Subnet with a custom virtual machine and
 deploying it locally.
 Although the tutorial uses a fork of Subnet-EVM as an example, you can extend its lessons to support
 any custom VM binary.
@@ -30,8 +30,8 @@ The repository cloning method used is HTTPS, but SSH can be used too:
 
 `git clone git@github.com:ava-labs/subnet-evm.git`
 
-You can find more about SSH and how to use it 
-[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh). 
+You can find more about SSH and how to use it
+[here](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh).
 :::
 
 ### Modify and Build Subnet-EVM
@@ -69,48 +69,47 @@ compatible with your custom VM.
 
 ```json
 {
-    "config": {
-        "byzantiumBlock": 0,
-        "chainId": 12345,
-        "constantinopleBlock": 0,
-        "eip150Block": 0,
-        "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-        "eip155Block": 0,
-        "eip158Block": 0,
-        "feeConfig": {
-            "gasLimit": 15000000,
-            "targetBlockRate": 2,
-            "minBaseFee": 25000000000,
-            "targetGas": 15000000,
-            "baseFeeChangeDenominator": 36,
-            "minBlockGasCost": 0,
-            "maxBlockGasCost": 1000000,
-            "blockGasCostStep": 200000
-        },
-        "homesteadBlock": 0,
-        "istanbulBlock": 0,
-        "muirGlacierBlock": 0,
-        "petersburgBlock": 0,
-        "subnetEVMTimestamp": 0
+  "config": {
+    "byzantiumBlock": 0,
+    "chainId": 12345,
+    "constantinopleBlock": 0,
+    "eip150Block": 0,
+    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
+    "eip155Block": 0,
+    "eip158Block": 0,
+    "feeConfig": {
+      "gasLimit": 15000000,
+      "targetBlockRate": 2,
+      "minBaseFee": 25000000000,
+      "targetGas": 15000000,
+      "baseFeeChangeDenominator": 36,
+      "minBlockGasCost": 0,
+      "maxBlockGasCost": 1000000,
+      "blockGasCostStep": 200000
     },
-    "nonce": "0x0",
-    "timestamp": "0x0",
-    "extraData": "0x",
-    "gasLimit": "0xe4e1c0",
-    "difficulty": "0x0",
-    "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "coinbase": "0x0000000000000000000000000000000000000000",
-    "alloc": {
-        "8db97c7cece249c2b98bdc0226cc4c2a57bf52fc": {
-            "balance": "0xd3c21bcecceda1000000"
-        }
-    },
-    "airdropHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "airdropAmount": null,
-    "number": "0x0",
-    "gasUsed": "0x0",
-    "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-    "baseFeePerGas": null
+    "homesteadBlock": 0,
+    "istanbulBlock": 0,
+    "muirGlacierBlock": 0,
+    "petersburgBlock": 0
+  },
+  "nonce": "0x0",
+  "timestamp": "0x0",
+  "extraData": "0x",
+  "gasLimit": "0xe4e1c0",
+  "difficulty": "0x0",
+  "mixHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "coinbase": "0x0000000000000000000000000000000000000000",
+  "alloc": {
+    "8db97c7cece249c2b98bdc0226cc4c2a57bf52fc": {
+      "balance": "0xd3c21bcecceda1000000"
+    }
+  },
+  "airdropHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "airdropAmount": null,
+  "number": "0x0",
+  "gasUsed": "0x0",
+  "parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+  "baseFeePerGas": null
 }
 ```
 
@@ -294,9 +293,9 @@ The command should return
 
 ```json
 {
-    "jsonrpc": "2.0",
-    "id": 1,
-    "result": "0xd3c21bcecceda1000000"
+  "jsonrpc": "2.0",
+  "id": 1,
+  "result": "0xd3c21bcecceda1000000"
 }
 ```
 

--- a/docs/build/subnet/maintain/view-subnets.md
+++ b/docs/build/subnet/maintain/view-subnets.md
@@ -38,8 +38,6 @@ To see detailed information about your deployed Subnets, add the `--deployed` fl
 +-------------+-------------+---------------------------------------------------+---------------+-----------------------------------------------------------------+---------+
 ```
 
-
-
 ## Describe Subnet Configurations
 
 To see the details of a specific configuration, run
@@ -155,7 +153,6 @@ Example:
         "petersburgBlock": 0,
         "istanbulBlock": 0,
         "muirGlacierBlock": 0,
-        "subnetEVMTimestamp": 0,
         "feeConfig": {
             "gasLimit": 15000000,
             "targetBlockRate": 2,

--- a/docs/build/subnet/upgrade/customize-a-subnet.md
+++ b/docs/build/subnet/upgrade/customize-a-subnet.md
@@ -908,7 +908,7 @@ If you want to use Warp messaging in an existing Subnet-EVM chain, you should co
 
 :::warning
 
-Currently Warp Precompile can only be activated in Fuji after Durango occurs. Durango in Fuji is set at 11 AM ET, February 13th 2024. If you plan to use Warp messaging in your own Subnet-EVM chain in Fuji you should upgrade to `subnet-evm@v0.6.0-fuji` and coordinate your precompile upgrade. Warp Config's "blockTimestamp" must be set after Durango date (February 13th 2024 11 AM ET).
+Currently Warp Precompile can only be activated in Mainnet after Durango occurs. Durango in Mainnet is set at 11 AM ET (4 PM UTC) on Wednesday, March 6th, 2024. If you plan to use Warp messaging in your own Subnet-EVM chain in Mainnet you should upgrade to `subnet-evm@v0.6.0` or later and coordinate your precompile upgrade. Warp Config's "blockTimestamp" must be set after `1709740800`, Durango date (11 AM ET (4 PM UTC) on Wednesday, March 6th, 2024).
 
 :::
 

--- a/docs/build/subnet/upgrade/customize-a-subnet.md
+++ b/docs/build/subnet/upgrade/customize-a-subnet.md
@@ -1,7 +1,7 @@
 ---
 tags: [Build, Subnets]
 description: How to customize a Subnet by utilizing Genesis, Precompile, and Blockchain Configs.
-sidebar_label: Customize a Subnet 
+sidebar_label: Customize a Subnet
 pagination_label: Customize your EVM-Powered Subnet
 sidebar_position: 1
 ---
@@ -53,7 +53,6 @@ The default genesis Subnet-EVM provided below has some well defined parameters:
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 15000000,
       "minBaseFee": 25000000000,
@@ -96,19 +95,19 @@ You can use `eth_getChainConfig` RPC call to get the current chain config. See
 #### Hard Forks
 
 `homesteadBlock`, `eip150Block`, `eip150Hash`, `eip155Block`, `byzantiumBlock`, `constantinopleBlock`,
-`petersburgBlock`, `istanbulBlock`, `muirGlacierBlock`, `subnetEVMTimestamp` are hard fork activation
+`petersburgBlock`, `istanbulBlock`, `muirGlacierBlock` are EVM hard fork activation
 times. Changing these may cause issues, so treat them carefully.
 
 #### Fee Config
 
 `gasLimit`: Sets the max amount of gas consumed per block. This restriction puts a cap on the
-amount of computation that can be done in a single block, which in turn sets a limit on the 
+amount of computation that can be done in a single block, which in turn sets a limit on the
 maximum gas usage allowed for a single transaction.
 For reference, C-Chain value is set to `15,000,000`.
 
 `targetBlockRate`: Sets the target rate of block production in seconds. A target of 2 will target
-producing a block every 2 seconds. If the network starts producing blocks at a faster rate, it 
-indicates that more blocks than anticipated are being issued to the network, resulting in an 
+producing a block every 2 seconds. If the network starts producing blocks at a faster rate, it
+indicates that more blocks than anticipated are being issued to the network, resulting in an
 increase in base fees.
 For C-chain this value is set to `2`.
 
@@ -129,7 +128,7 @@ For reference, the C-chain value is set to `36`. This value sets the
 base fee to increase or decrease by a factor of `1/36` of the parent block's
 base fee.
 
-`minBlockGasCost`: Sets the minimum amount of gas to charge for the production of a block. 
+`minBlockGasCost`: Sets the minimum amount of gas to charge for the production of a block.
 This value is set to `0` in C-Chain.
 
 `maxBlockGasCost`: Sets the maximum amount of gas to charge for the production of a block.
@@ -166,16 +165,16 @@ set to match the `gasLimit` set in the `feeConfig`. You do not need to change an
 header fields.
 
 `nonce`, `mixHash` and `difficulty` are remnant parameters from Proof of Work systems.
-For Avalanche, these don't play any relevant role, so you should just leave them as their 
+For Avalanche, these don't play any relevant role, so you should just leave them as their
 default values:
 
-`nonce`: The result of the mining process iteration is this value. It can be any value in 
+`nonce`: The result of the mining process iteration is this value. It can be any value in
 the genesis block. Default value is `0x0`.
 
-`mixHash`: The combination of `nonce` and `mixHash` allows to verify that the Block has really been 
+`mixHash`: The combination of `nonce` and `mixHash` allows to verify that the Block has really been
 cryptographically mined, thus, from this aspect, is valid. Default value is `0x0000000000000000000000000000000000000000000000000000000000000000`.
 
-`difficulty`: The difficulty level applied during the nonce discovering process of this block. 
+`difficulty`: The difficulty level applied during the nonce discovering process of this block.
 Default value is `0x0`.
 
 `timestamp`: The timestamp of the creation of the genesis block. This is commonly set to `0x0`.
@@ -186,9 +185,9 @@ Default value is `0x0`.
 the same value as in the [fee config](#fee-config). The value `e4e1c0` is
 hexadecimal and is equal to `15,000,000`.
 
-`coinbase`: Refers to the address of the block producers. This also means it represents the 
+`coinbase`: Refers to the address of the block producers. This also means it represents the
 recipient of the block reward. It is usually set
-to `0x0000000000000000000000000000000000000000` for the genesis block. To allow fee recipients in 
+to `0x0000000000000000000000000000000000000000` for the genesis block. To allow fee recipients in
 Subnet-EVM, refer to [this section.](#setting-a-custom-fee-recipient)
 
 `parentHash`: This is the Keccak 256-bit hash of the entire parent block’s header. It is
@@ -198,7 +197,7 @@ genesis block.
 
 `gasUsed`: This is the amount of gas used by the genesis block. It is usually set to `0x0`.
 
-`number`: This is the number of the genesis block. This required to be `0x0` for the genesis. 
+`number`: This is the number of the genesis block. This required to be `0x0` for the genesis.
 Otherwise it will error.
 
 ### Genesis Examples
@@ -308,11 +307,11 @@ contracts can be activated through `ChainConfig` (in genesis or as an upgrade).
 ### AllowList Interface
 
 The `AllowList` interface is used by precompiles to check if a given address is allowed to use a
-precompiled contract. `AllowList` consist of two main roles, `Admin` and `Enabled`. `Admin` can
-add/remove other `Admin` and `Enabled` addresses. `Enabled` addresses can use the precompiled
-contract, but cannot modify other roles.
+precompiled contract. `AllowList` consist of three roles, `Admin`, `Manager` and `Enabled`. `Admin` can add/remove other `Admin` and `Enabled` addresses.
+`Manager` is introduced with Durango upgrade and can add/remove `Enabled` addresses, without the ability to add/remove `Admin` or `Manager` addresses.
+`Enabled` addresses can use the precompiled contract, but cannot modify other roles.
 
-`AllowList` adds `adminAddresses` and `enabledAddresses` fields to precompile contract configurations.
+`AllowList` adds `adminAddresses`, `managerAddresses`, `enabledAddresses` fields to precompile contract configurations.
 For instance fee manager precompile contract configuration looks like this:
 
 ```json
@@ -320,7 +319,8 @@ For instance fee manager precompile contract configuration looks like this:
   "feeManagerConfig": {
     "blockTimestamp": 0,
     "adminAddresses": [<list of addresses>],
-    "enabledAddresses": [<list of addresses>]
+    "managerAddresses": [<list of addresses>],
+    "enabledAddresses": [<list of addresses>],
   }
 }
 ```
@@ -328,20 +328,30 @@ For instance fee manager precompile contract configuration looks like this:
 `AllowList` configuration affects only the related precompile. For instance, the admin address in
 `feeManagerConfig` does not affect admin addresses in other activated precompiles.
 
-The `AllowList` solidity interface is defined as follows, and can be found in [IAllowList.sol](https://github.com/ava-labs/subnet-evm/blob/5faabfeaa021a64c2616380ed2d6ec0a96c8f96d/contract-examples/contracts/IAllowList.sol):
+The `AllowList` solidity interface is defined as follows, and can be found in [IAllowList.sol](https://github.com/ava-labs/subnet-evm/blob/helloworld-official-tutorial-v2/contracts/contracts/interfaces/IAllowList.sol):
 
 ```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IAllowList {
-  // Set [addr] to have the admin role over the precompile
+  event RoleSet(
+    uint256 indexed role,
+    address indexed account,
+    address indexed sender,
+    uint256 oldRole
+  );
+
+  // Set [addr] to have the admin role over the precompile contract.
   function setAdmin(address addr) external;
 
   // Set [addr] to be enabled on the precompile contract.
   function setEnabled(address addr) external;
 
-  // Set [addr] to have no role the precompile contract.
+  // Set [addr] to have the manager role over the precompile contract.
+  function setManager(address addr) external;
+
+  // Set [addr] to have no role for the precompile contract.
   function setNone(address addr) external;
 
   // Read the status of [addr].
@@ -351,6 +361,10 @@ interface IAllowList {
 
 `readAllowList(addr)` will return a uint256 with a value of 0, 1, or 2, corresponding to the roles
 `None`, `Enabled`, and `Admin` respectively.
+
+`RoleSet` is an event that is emitted when a role is set for an address. It includes the role, the modified
+address, the sender as indexed parameters and the old role as unindexed parameter. Events in precompiles are
+activated after Durango upgrade.
 
 _Note: `AllowList` is not an actual contract but just an interface. It's not callable by itself._
 _This is used by other precompiles. Check other precompile sections to see how this works._
@@ -439,7 +453,7 @@ transactions on chain. Like the previous section, you can activate the precompil
 
 In this example, `0x8db97C7cEcE249c2b98bDC0226Cc4C2A57BF52FC` is named as the
 `Admin` of the `TransactionAllowList`. This enables them to add other `Admins` or to add
-`Allowed`. Both `Admins` and `Enabled` can submit transactions to the chain.
+`Allowed`. `Admins`, `Manager` and `Enabled` can submit transactions to the chain.
 
 The `Stateful Precompile` contract powering the `TxAllowList` adheres to the
 [AllowList Solidity interface](#allowlist-interface) at `0x0200000000000000000000000000000000000002`
@@ -449,15 +463,15 @@ The `Stateful Precompile` contract powering the `TxAllowList` adheres to the
   something like:
   ![admin fail](/img/admin_fail.png)
 
-- If you attempt to submit a transaction but you are not an `Admin` or not
+- If you attempt to submit a transaction but you are not an `Admin`, `Manager` or not
   `Enabled`, you will see something like: `cannot issue transaction from non-allow listed address`
 
 - If you call `readAllowList(addr)` then you can read the current role of `addr`, which will return
-  a `uint256` with a value of 0, 1, or 2, corresponding to the roles `None`, `Allowed`, and `Admin` respectively.
+  a `uint256` with a value of 0, 1, 2 or 3 corresponding to the roles `None`, `Allowed`, `Admin` and `Manager` respectively.
 
 :::warning
 
-If you remove all of the admins from the allow list, it will no longer be possible to update the
+If you remove all of the admins and managers from the allow list, it will no longer be possible to update the
 allow list without modifying the Subnet-EVM to schedule a network upgrade.
 
 :::
@@ -499,7 +513,7 @@ can provide `nativeMinterConfig` in genesis:
 }
 ```
 
-`adminAddresses` denotes admin accounts who can add other `Admin` or `Enabled` accounts. `Admin` and
+`adminAddresses` denotes admin accounts who can add other `Admin`, `Manager` or `Enabled` accounts. `Admin`, `Manager` and
 `Enabled` are both eligible to mint native coins for other addresses. `ContractNativeMinter` uses
 same methods as in `ContractDeployerAllowList`.
 
@@ -515,6 +529,12 @@ pragma solidity ^0.8.0;
 import "./IAllowList.sol";
 
 interface INativeMinter is IAllowList {
+  event NativeCoinMinted(
+    address indexed sender,
+    address indexed recipient,
+    uint256 amount
+  );
+
   // Mint [amount] number of native coins and send to [addr]
   function mintNativeCoin(address addr, uint256 amount) external;
 }
@@ -522,10 +542,11 @@ interface INativeMinter is IAllowList {
 
 `mintNativeCoin` takes an address and amount of native coins to be minted. The amount denotes the
 amount in minimum denomination of native coins (10^18). For example, if you want to mint 1 native
-coin (in AVAX), you need to pass 1 \* 10^18 as the amount.
+coin (in AVAX), you need to pass 1 \* 10^18 as the amount. A `NativeCoinMinted` event is emitted with the
+sender, recipient and amount when a native coin is minted.
 
 Note that this uses `IAllowList` interface directly, meaning that it uses the same `AllowList`
-interface functions like `readAllowList` and `setAdmin`, `setEnabled`, `setNone`. For more information
+interface functions like `readAllowList` and `setAdmin`, `setManager`, `setEnabled`, `setNone`. For more information
 see [AllowList Solidity interface](#allowlist-interface).
 
 :::warning
@@ -596,6 +617,22 @@ pragma solidity ^0.8.0;
 import "./IAllowList.sol";
 
 interface IFeeManager is IAllowList {
+  struct FeeConfig {
+    uint256 gasLimit;
+    uint256 targetBlockRate;
+    uint256 minBaseFee;
+    uint256 targetGas;
+    uint256 baseFeeChangeDenominator;
+    uint256 minBlockGasCost;
+    uint256 maxBlockGasCost;
+    uint256 blockGasCostStep;
+  }
+  event FeeConfigChanged(
+    address indexed sender,
+    FeeConfig oldFeeConfig,
+    FeeConfig newFeeConfig
+  );
+
   // Set fee config fields to contract storage
   function setFeeConfig(
     uint256 gasLimit,
@@ -632,7 +669,7 @@ interface IFeeManager is IAllowList {
 ```
 
 FeeConfigManager precompile uses `IAllowList` interface directly, meaning that it uses the same
-`AllowList` interface functions like `readAllowList` and `setAdmin`, `setEnabled`, `setNone`. For
+`AllowList` interface functions like `readAllowList` and `setAdmin`, `setManager`, `setEnabled`, `setNone`. For
 more information see [AllowList Solidity interface](#allowlist-interface).
 
 In addition to the `AllowList` interface, the FeeConfigManager adds the following capabilities:
@@ -640,7 +677,8 @@ In addition to the `AllowList` interface, the FeeConfigManager adds the followin
 - `getFeeConfig` - retrieves the current dynamic fee config
 - `getFeeConfigLastChangedAt` - retrieves the timestamp of the last block where the fee config was updated
 - `setFeeConfig` - sets the dynamic fee config on chain (see [here](#fee-config) for details on the
-  fee config parameters)
+  fee config parameters). This function can only be called by an `Admin`, `Manager` or `Enabled` address.
+- `FeeConfigChanged` - an event that is emitted when the fee config is updated. Topics include the sender, the old fee config, and the new fee config.
 
 You can also get the fee configuration at a block with the `eth_feeConfig` RPC method. For more
 information see [here](/reference/subnet-evm/api#eth_feeconfig).
@@ -691,7 +729,7 @@ the genesis file:
 }
 ```
 
-`adminAddresses` denotes admin accounts who can add other `Admin` or `Enabled` accounts. `Admin` and
+`adminAddresses` denotes admin accounts who can add other `Admin` or `Enabled` accounts. `Admin`, `Manager` and
 `Enabled` are both eligible to change the current fee mechanism.
 
 The precompile implements the `RewardManager` interface which includes the `AllowList` interface.
@@ -708,6 +746,19 @@ pragma solidity ^0.8.0;
 import "./IAllowList.sol";
 
 interface IRewardManager is IAllowList {
+  // RewardAddressChanged is the event logged whenever reward address is modified
+  event RewardAddressChanged(
+    address indexed sender,
+    address indexed oldRewardAddress,
+    address indexed newRewardAddress
+  );
+
+  // FeeRecipientsAllowed is the event logged whenever fee recipient is modified
+  event FeeRecipientsAllowed(address indexed sender);
+
+  // RewardsDisabled is the event logged whenever rewards are disabled
+  event RewardsDisabled(address indexed sender);
+
   // setRewardAddress sets the reward address to the given address
   function setRewardAddress(address addr) external;
 
@@ -750,6 +801,14 @@ In addition to the `AllowList` interface, the `RewardManager` adds the following
   custom fee recipients are allowed first.
 
 - `areFeeRecipientsAllowed` - returns true if custom fee recipients are allowed.
+
+- `RewardAddressChanged` - an event that is emitted when the reward address is updated. Topics include
+  the sender, the old reward address, and the new reward address.
+
+- `FeeRecipientsAllowed` - an event that is emitted when fee recipients are allowed. Topics include the
+  sender.
+
+- `RewardsDisabled` - an event that is emitted when rewards are disabled. Topics include the sender.
 
 These 3 mechanisms (burning, sending to a predefined address, and enabling fees to be collected by
 block producers) cannot be enabled at the same time. Enabling one mechanism will take over the
@@ -856,7 +915,7 @@ Currently Warp Precompile can only be activated in Fuji after Durango occurs. Du
 ## Contract Examples
 
 Subnet-EVM contains example contracts for precompiles under `/contracts`. It's a hardhat
-project with tests and tasks. For more information see 
+project with tests and tasks. For more information see
 [contract examples README](https://github.com/ava-labs/subnet-evm/tree/master/contracts#subnet-evm-contracts).
 
 ## Network Upgrades: Enable/Disable Precompiles

--- a/docs/build/subnet/upgrade/upgrade-durango.md
+++ b/docs/build/subnet/upgrade/upgrade-durango.md
@@ -1,0 +1,217 @@
+---
+tags: [Build, Subnets, Durango]
+description: How to upgrade existing Subnet precompiles for DUrango
+sidebar_label: Upgrade a Subnet for Durango
+pagination_label: Upgrade Subnet Precompiles for Durango
+sidebar_position: 1
+---
+
+# How to Upgrade Your Precompiles and Subnet-EVM for Durango
+
+## Introduction
+
+Durango will be activated on the Avalanche Mainnet at 11 AM ET (4 PM UTC) on Wednesday, March 6th, 2024. Subnet-EVM introduces a set of new features and backwards-incompatible changes with the Durango network upgrade.This guide will walk you through the process of upgrading your Subnet-EVM and precompiles for the Durango network upgrade. The Durango network upgrade introduces new features and improvements to the Avalanche platform and Subnet-EVM. This guide will help you ensure that your Subnet-EVM and precompiles are compatible with the Durango network upgrade.
+
+Note: Subnet-EVM already performs these upgrades in native stateful precompiles. This guide is for users who have custom precompiles and need to upgrade them for Durango.
+
+Durango introduces following changes to Subnet-EVM:
+
+- Avalanche Warp Messaging
+- Events in Precompiles
+- Manager Role
+- Non-Strict Mode
+- Shanghai Upgrade [(ACP-24)](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/24-shanghai-eips.md)
+  - Shangai Upgrade will be activated with Durango without any further modification in Subnet-EVM.
+
+## Avalanche Warp Messaging
+
+Avalanche Warp Messaging (AWM) is a new feature introduced with the Durango network upgrade. It enables native cross-Subnet communication and allows [Virtual Machine (VM)](/learn/avalanche/virtual-machines.md) developers to implement arbitrary communication protocols between any two Subnets. For more information about AWM see [here](../../cross-chain/awm/overview.md).
+
+Warp Precompile must be enabled for Subnets after Durango. For more information the precompile and activation see [here](./customize-a-subnet.md#avalanche-warp-messaging)
+
+## Events
+
+Subnet-EVM Native Precompiles will start emitting events with the Durango network upgrade. This will allow you to listen to events emitted by Subnet-EVM native precompiles. Following events will be introduced:
+
+- `event RoleSet(uint256 indexed role, address indexed account, address indexed sender, uint256 oldRole)`: This event will be emitted when a role is set for an account. Precompiles that uses `IAllowList` interface will emit this event without requiring any changes. The event contains the role, account, sender as indexed parameters and old role as unindex parameter.
+- `event FeeConfigChanged(address indexed sender, FeeConfig oldFeeConfig, FeeConfig newFeeConfig)`: This event will be emitted when the fee configuration is changed in `FeeManager` precompile. The event contains the sender as indexed parameter and old and new fee configuration as unindexed parameters.
+- `event NativeCoinMinted(address indexed sender, address indexed recipient, uint256 amount)`: This event will be emitted whe new native coins are minted. The event contains the sender, recipient as indexed parameters and the amount as unindexed parameter.
+- `event RewardAddressChanged(address indexed sender, address indexed oldRewardAddress, address indexed newRewardAddress)`: This event will be emitted when the reward address is changed in `RewardManager` precompile. The event contains the sender, old and new reward addresses as unindexed parameters.
+- `event FeeRecipientsAllowed(address indexed sender)`: This event will be emitted when the fee recipients are allowed in `RewardManager` precompile. The event contains the sender as indexed parameter.
+- `event RewardsDisabled(address indexed sender)`: This event will be emitted when the rewards are disabled in `RewardManager` precompile. The event contains the sender as indexed parameter.
+
+### Custom Events
+
+Events above are already introduced and handled in Subnet-EVM native precompiles. If you have a custom precompile, you can start emitting your custom events using Durango activation. In order to do this you can define your custom event in your solidity interface and regenerate the go bindings using `precompilegen` tool, for more information see [here](../../vm/evm/generate-precompile.md).
+
+Generally ou will generate an `event.go` file in addition to your existing precompile files. You need to implement how to emit your events and your events' gas costs, as in [hello world example](../../vm/evm/defining-precompile.md#event-file). In this guide we will use the hello world example to demonstrate how to emit custom events. The event that will be introduced is:
+
+```solidity
+event GreetingChanged(address indexed sender, string oldGreeting, string newGreeting)
+```
+
+It will be emitted when the greeting is changed in the hello world precompile. You can find the hello world precompile [here](https://github.com/ava-labs/subnet-evm/tree/helloworld-official-tutorial-v2/precompile/contracts/helloworld). We also assume that hello world precompile is already deployed before Durango and we will be upgrading it for Durango.
+
+#### Adjusting Gas Costs
+
+Adjusting gas costs for your custom events is very important. Emitted events are written to state and consume resources. You should make sure you're charging the right amount of gas before emitting your event. `precompilegen` tool automatically generates a scaffold for your gas calculations, however you should review and adjust the gas costs according to your needs, especially if you're using any arbitrary size data in your events. Gas cost function for the event `GreetingChanged(address indexed sender, string oldGreeting, string newGreeting)` looks like this:
+
+```go
+func GetGreetingChangedEventGasCost(data GreetingChangedEventData) uint64 {
+	gas := contract.LogGas // base gas cost
+
+	// Add topics gas cost (2 topics)
+	// Topics always include the signature hash of the event. The rest are the indexed event arguments.
+	gas += contract.LogTopicGas * 2
+
+	// CUSTOM CODE STARTS HERE
+	// Keep in mind that the data here will be encoded using the ABI encoding scheme.
+	// So the computation cost might change according to the data type + data size and should be charged accordingly.
+	// i.e gas += LogDataGas * uint64(len(data.oldGreeting))
+	gas += contract.LogDataGas * uint64(len(data.OldGreeting)) // * ...
+	// CUSTOM CODE ENDS HERE
+	// CUSTOM CODE STARTS HERE
+	// Keep in mind that the data here will be encoded using the ABI encoding scheme.
+	// So the computation cost might change according to the data type + data size and should be charged accordingly.
+	// i.e gas += LogDataGas * uint64(len(data.newGreeting))
+	gas += contract.LogDataGas * uint64(len(data.NewGreeting)) // * ...
+	// CUSTOM CODE ENDS HERE
+
+	// CUSTOM CODE STARTS HERE
+	return gas
+}
+```
+
+We have charged the base gas cost, topics gas cost and data gas cost for the old and new greeting. Topic gas cost includes 2 topics, one for the signature hash of the event and the other for the indexed sender argument. Data gas cost is calculated according to the data type and size. If you're not using any arbitrary size data in your events, you can define it as a constant.
+
+#### Durango Activation Check
+
+After completing defining your custom events, you need to pack your events, charge your event gas and emit them in your precompile functions. Since this procedure is non-backward compatible, you need to ensure that this will only be activated after the Durango network upgrade.
+
+You can use the `contract.IsDurangoActivated` function to check if the Durango network upgrade is activated. For Hello World example, we will be changing `setGreeting` function starting [here](https://github.com/ava-labs/subnet-evm/blob/helloworld-official-tutorial-v2/precompile/contracts/helloworld/contract.go#L187) via following:
+
+```go
+if contract.IsDurangoActivated(accessibleState) {
+ ...
+}
+```
+
+Note: this activation won't be needed if you plan to deploy your custom precompile after Durango.
+
+#### Event Packers
+
+Event packers and unpackers will be automatically generated with the `precompilegen` tool. You can use these packers and unpackers to pack and unpack your custom events. For hello world example:
+
+```go
+if remainingGas, err = contract.DeductGas(remainingGas, contract.ReadGasCostPerSlot); err != nil {
+  return nil, 0, err
+}
+oldGreeting := GetGreeting(stateDB)
+
+eventData := GreetingChangedEventData{
+  OldGreeting: oldGreeting,
+  NewGreeting: inputStruct,
+}
+topics, data, err := PackGreetingChangedEvent(caller, eventData)
+if err != nil {
+  return nil, remainingGas, err
+}
+```
+
+This will first charge gas for fetching the old greeting from the state fetch and then fetch it from the state. Then it will pack the event data with old and new greeting as unindexed event data.
+
+#### Emitting Events
+
+After packing the event data, you can charge the event gas and emit your custom events using the `stateDB.AddLog` function. For hello world example it starts [here](https://github.com/ava-labs/subnet-evm/blob/helloworld-official-tutorial-v2/precompile/contracts/helloworld/contract.go#L203-L214):
+
+```go
+// Charge the gas for emitting the event.
+eventGasCost := GetGreetingChangedEventGasCost(eventData)
+if remainingGas, err = contract.DeductGas(remainingGas, eventGasCost); err != nil {
+  return nil, 0, err
+}
+
+// Emit the event
+stateDB.AddLog(
+  ContractAddress,
+  topics,
+  data,
+  accessibleState.GetBlockContext().Number().Uint64(),
+)
+```
+
+## Manager Role
+
+Durango introduces a new role called the manager role. The manager role is a mid-role between `Admin` and `Enabled`. The manager role is considered as an `Enabled` account and perform restricted state-changing operations in precompiles. Manager role also can modify other `Enabled` accounts. It can appoint new `Enabled` accounts and remove existing `Enabled` accounts. Manager role cannot modify other `Manager` or `Admin` accounts. For more information about AllowList see [here](./customize-a-subnet.md#allowlist-interface).
+
+If you have any precompile using AllowList, you can issue a call to `setManager` in your precompile to appoint new Manager accounts. For upgrades or new precompiles with allowlist config you can use `managerAddresses` as follow:
+
+```json
+{
+  "feeManagerConfig": {
+    "blockTimestamp": 0,
+    "adminAddresses": [<list of addresses>],
+    "managerAddresses": [<list of addresses>],
+    "enabledAddresses": [<list of addresses>],
+  }
+}
+```
+
+## Non-Strict Mode
+
+Strict mode unpacking prevents using extra padded bytes in inputs. This created some issue in few legacy contracts like Gnosis Multisig wallet. For more information about strict mode see [solidity docs](https://docs.soliditylang.org/en/latest/abi-spec.html#strict-encoding-mode).
+
+For Hello world example we were using this `UnpackSetGreetingInput` with strict mode enabled before:
+
+```go
+func UnpackSetGreetingInput(input []byte) (string, error) {
+  // This function was using strict mode unpacking by default.
+	res, err := HelloWorldABI.UnpackInput("setGreeting", input)
+	if err != nil {
+		return "", err
+	}
+	unpacked := *abi.ConvertType(res[0], new(string)).(*string)
+	return unpacked, nil
+}
+```
+
+In order to handle extra padded bytes, Subnet-EVM will start using non-strict mode with Durango in `Input Unpackers`. However since this change will be non-backward compatible you need to ensure that this will only be activated after the Durango network upgrade. You can use the `contract.IsDurangoActivated` function to check if the Durango network upgrade is activated. Now we will using this function to start using non-strict mode unpacking:
+
+```go
+// UnpackSetGreetingInput attempts to unpack [input] into the string type argument
+// assumes that [input] does not include selector (omits first 4 func signature bytes)
+// if [useStrictMode] is true, it will return an error if the length of [input] is not [common.HashLength]
+func UnpackSetGreetingInput(input []byte, useStrictMode bool) (string, error) {
+	// Initially we had this check to ensure that the input was the correct length.
+	// However solidity does not always pack the input to the correct length, and allows
+	// for extra padding bytes to be added to the end of the input. Therefore, we have removed
+	// this check with the Durango. We still need to keep this check for backwards compatibility.
+	if useStrictMode && len(input) > common.HashLength {
+		return "", ErrInputExceedsLimit
+	}
+	res, err := HelloWorldABI.UnpackInput("setGreeting", input, useStrictMode)
+	if err != nil {
+		return "", err
+	}
+	unpacked := *abi.ConvertType(res[0], new(string)).(*string)
+	return unpacked, nil
+}
+```
+
+To call this function in `setGreeting` we should use Durango activation as follows [here](https://github.com/ava-labs/subnet-evm/blob/helloworld-official-tutorial-v2/precompile/contracts/helloworld/contract.go#L159-L167):
+
+```go
+// do not use strict mode after Durango
+useStrictMode := !contract.IsDurangoActivated(accessibleState)
+// attempts to unpack [input] into the arguments to the SetGreetingInput.
+// Assumes that [input] does not include selector
+// You can use unpacked [inputStruct] variable in your code
+inputStruct, err := UnpackSetGreetingInput(input, useStrictMode)
+if err != nil {
+  return nil, remainingGas, err
+}
+```
+
+This will ensure that non-strict mode unpacking is used after Durango activation.
+
+Note: This should not impose any critial issue for your custom precompiles. However if your precompile is mainly used from other deployed contracts (Solidity) you should do this transition in order to increase the compatibility of your precompile.

--- a/docs/build/vm/evm/defining-precompile.md
+++ b/docs/build/vm/evm/defining-precompile.md
@@ -267,7 +267,7 @@ accessibleState.GetStateDB().AddLog(
 
 In this file you should set your event's gas cost and implement the `Get{EventName}EventGasCost` function. This function should take the data you want to emit and calculate the gas cost. In this example we defined our event as follow, and plan to emit it in the `setGreeting` function:
 
-```sol
+```solidity
   event GreetingChanged(address indexed sender, string oldGreeting, string newGreeting);
 ```
 

--- a/docs/build/vm/evm/defining-tests.md
+++ b/docs/build/vm/evm/defining-tests.md
@@ -107,7 +107,7 @@ doing so, `helloWorld` is now a contract of type `IHelloWorld` and when we call 
 that contract, we will be redirected to the HelloWorld precompile address. The below code snippet
 can be copied and pasted into a new file called `ExampleHelloWorld.sol`:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "./IHelloWorld.sol";
@@ -151,7 +151,7 @@ For the test contract we write our test in `./contracts/test/ExampleHelloWorldTe
 
 <!-- vale on -->
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "../ExampleHelloWorld.sol";
@@ -198,7 +198,7 @@ contract ExampleHelloWorldTest is AllowListTest {
 
 For Precompile-EVM, you should import `AllowListTest` with `@avalabs/subnet-evm-contracts` NPM package:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "../ExampleHelloWorld.sol";

--- a/docs/build/vm/evm/executing-tests.md
+++ b/docs/build/vm/evm/executing-tests.md
@@ -35,7 +35,6 @@ Note: it's important that this has the same name as the HardHat test file we cre
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,
@@ -92,23 +91,20 @@ the e2e test is to declare the new test in `/tests/precompile/solidity/suites.go
 At the bottom of the file you will see the following code commented out:
 
 ```go
-	// TODO: can we refactor this so that it automagically checks to ensure each hardhat test file matches the name of a hardhat genesis file
-	// and then runs the hardhat tests for each one without forcing precompile developers to modify this file.
 	// ADD YOUR PRECOMPILE HERE
 	/*
-		ginkgo.It("your precompile", ginkgo.Label("Precompile"), ginkgo.Label("YourPrecompile"), func() {
-			ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-			defer cancel()
-			// Specify the name shared by the genesis file in ./tests/precompile/genesis/{your_precompile}.json
-			// and the test file in ./contracts/tests/{your_precompile}.ts
-			// If you want to use a different test command and genesis path than the defaults, you can
-			// use the utils.RunTestCMD. See utils.RunDefaultHardhatTests for an example.
-			utils.RunDefaultHardhatTests(ctx, "your_precompile")
-		})
+  ginkgo.It("your precompile", ginkgo.Label("Precompile"), ginkgo.Label("YourPrecompile"), func() {
+    ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+    defer cancel()
+
+    // Specify the name shared by the genesis file in ./tests/precompile/genesis/{your_precompile}.json
+    // and the test file in ./contracts/tests/{your_precompile}.ts
+    blockchainID := subnetsSuite.GetBlockchainID("{your_precompile}")
+    runDefaultHardhatTests(ctx, blockchainID, "{your_precompile}")
 	*/
 ```
 
-`utils.RunDefaultHardhatTests` will run the default Hardhat test command and use the default genesis
+`runDefaultHardhatTests` will run the default Hardhat test command and use the default genesis
 path.
 If you want to use a different test command and genesis path than the defaults, you can use the
 `utils.CreateSubnet` and `utils.RunTestCMD`.
@@ -123,12 +119,13 @@ After modifying the `It` node, it should look like the following (you can copy a
 directly if you prefer):
 
 ```go
-	ginkgo.It("hello world", ginkgo.Label("Precompile"), ginkgo.Label("HelloWorld"), func() {
-		ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-		defer cancel()
+  ginkgo.It("hello world", ginkgo.Label("Precompile"), ginkgo.Label("HelloWorld"), func() {
+    ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+    defer cancel()
 
-		utils.RunDefaultHardhatTests(ctx, "hello_world")
-	})
+    blockchainID := subnetsSuite.GetBlockchainID("hello_world")
+    runDefaultHardhatTests(ctx, blockchainID, "hello_world")
+  })
 ```
 
 Now that we've set up the new ginkgo test, we can run the ginkgo test that we want by using the
@@ -161,7 +158,7 @@ Once you've built AvalancheGo, you can confirm that it was successful by printin
 This should print something like the following (if you are running AvalancheGo v1.9.7):
 
 ```bash
-avalanche/1.9.7 [database=v1.4.5, rpcchainvm=22, commit=3e3e40f2f4658183d999807b724245023a13f5dc]
+avalanchego/1.11.0 [database=v1.4.5, rpcchainvm=33, commit=c60f7d2dd10c87f57382885b59d6fb2c763eded7, go=1.21.7]
 ```
 
 This path will be used later as the environment variable `AVALANCHEGO_EXEC_PATH` in the network runner.
@@ -196,7 +193,7 @@ $GOPATH/src/github.com/ava-labs/avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu
 This should give similar output:
 
 ```bash
-Subnet-EVM/v0.5.2@9a1c5482c83c32b29630ff171cb20ccc889d760e [AvalancheGo=v1.10.2, rpcchainvm=26]
+Subnet-EVM/v0.6.1 [AvalancheGo=v1.11.1, rpcchainvm=33]
 ```
 
 </TabItem>
@@ -223,7 +220,7 @@ $GOPATH/src/github.com/ava-labs/avalanchego/build/plugins/srEXiWaHuhNyGwPUi444Tu
 This should give similar output:
 
 ```bash
-Precompile-EVM/v0.0.0 Subnet-EVM/v0.5.2 [AvalancheGo=v1.10.2, rpcchainvm=26]
+Precompile-EVM/v0.2.0 Subnet-EVM/v0.6.1 [AvalancheGo=v1.11.1, rpcchainvm=33]
 ```
 
 </TabItem>

--- a/docs/build/vm/evm/generate-precompile.md
+++ b/docs/build/vm/evm/generate-precompile.md
@@ -48,7 +48,7 @@ cd contracts/
 
 Create a new file called `IHelloWorld.sol` and copy and paste the below code:
 
-```sol
+```solidity
 // (c) 2022-2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -107,13 +107,13 @@ This is already added to the `package.json` file.
 You can install it by running `npm install`.
 In order to import `IAllowList` interface, you can use the following import statement:
 
-```sol
+```solidity
 import "@avalabs/subnet-evm-contracts/contracts/interfaces/IAllowList.sol";
 ```
 
 The full file looks like this:
 
-```sol
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 import "@avalabs/subnet-evm-contracts/contracts/interfaces/IAllowList.sol";

--- a/docs/build/vm/evm/generate-precompile.md
+++ b/docs/build/vm/evm/generate-precompile.md
@@ -15,8 +15,7 @@ In this section, we will go over the process for automatically generating the te
 you can configure accordingly for your stateful precompile.
 
 First, we must create the Solidity interface that we want our precompile to implement. This will be
-the HelloWorld Interface. It will have two simple functions, `sayHello()` and `setGreeting()`. These
-two functions will demonstrate the getting and setting respectively of a value stored in the
+the HelloWorld Interface. It will have two simple functions, `sayHello()`, `setGreeting()` and an event `GreetingChanged` These two functions will demonstrate the getting and setting respectively of a value stored in the
 precompile's state space.
 
 The `sayHello()` function is a `view` function, meaning it does not modify the state of the precompile
@@ -52,12 +51,22 @@ Create a new file called `IHelloWorld.sol` and copy and paste the below code:
 ```sol
 // (c) 2022-2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
+
 // SPDX-License-Identifier: MIT
+
 pragma solidity >=0.8.0;
 import "./IAllowList.sol";
+
 interface IHelloWorld is IAllowList {
+  event GreetingChanged(
+    address indexed sender,
+    string oldGreeting,
+    string newGreeting
+  );
+
   // sayHello returns the stored greeting string
   function sayHello() external view returns (string calldata result);
+
   // setGreeting  stores the greeting string
   function setGreeting(string calldata response) external;
 }
@@ -108,9 +117,17 @@ The full file looks like this:
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 import "@avalabs/subnet-evm-contracts/contracts/interfaces/IAllowList.sol";
+
 interface IHelloWorld is IAllowList {
+  event GreetingChanged(
+    address indexed sender,
+    string oldGreeting,
+    string newGreeting
+  );
+
   // sayHello returns the stored greeting string
   function sayHello() external view returns (string calldata result);
+
   // setGreeting stores the greeting string
   function setGreeting(string calldata response) external;
 }
@@ -152,6 +169,62 @@ This generates the ABI code under `./abis/IHelloWorld.abi`.
 
 ```json
 [
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "oldGreeting",
+        "type": "string"
+      },
+      {
+        "indexed": false,
+        "internalType": "string",
+        "name": "newGreeting",
+        "type": "string"
+      }
+    ],
+    "name": "GreetingChanged",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "uint256",
+        "name": "role",
+        "type": "uint256"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "sender",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldRole",
+        "type": "uint256"
+      }
+    ],
+    "name": "RoleSet",
+    "type": "event"
+  },
   {
     "inputs": [
       { "internalType": "address", "name": "addr", "type": "address" }
@@ -195,6 +268,15 @@ This generates the ABI code under `./abis/IHelloWorld.abi`.
       { "internalType": "string", "name": "response", "type": "string" }
     ],
     "name": "setGreeting",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      { "internalType": "address", "name": "addr", "type": "address" }
+    ],
+    "name": "setManager",
     "outputs": [],
     "stateMutability": "nonpayable",
     "type": "function"
@@ -299,7 +381,7 @@ precompile template under its own directory via `--out ./helloworld` flag.
 
 <!-- markdownlint-enable MD013 -->
 
-This generates a precompile template files `contract.go`, `contract.abi`, `config.go`, `module.go`
+This generates a precompile template files `contract.go`, `contract.abi`, `config.go`, `module.go`, `event.go`
 and `README.md` files. `README.md` explains general guidelines for precompile development.
 You should carefully read this file before modifying the precompile template.
 
@@ -310,25 +392,27 @@ There are some must-be-done changes waiting in the generated file. Each area req
 Additionally there are other files you need to edit to activate your precompile.
 These areas are highlighted with comments "ADD YOUR PRECOMPILE HERE".
 For testing take a look at other precompile tests in contract_test.go and config_test.go in other precompile folders.
-See the tutorial in <https://docs.avax.network/subnets/hello-world-precompile-tutorial> for more information about precompile development.
 General guidelines for precompile development:
+
 1- Set a suitable config key in generated module.go. E.g: "yourPrecompileConfig"
 2- Read the comment and set a suitable contract address in generated module.go. E.g:
 ContractAddress = common.HexToAddress("ASUITABLEHEXADDRESS")
 3- It is recommended to only modify code in the highlighted areas marked with "CUSTOM CODE STARTS HERE". Typically, custom codes are required in only those areas.
 Modifying code outside of these areas should be done with caution and with a deep understanding of how these changes may impact the EVM.
-4- Set gas costs in generated contract.go
-5- Force import your precompile package in precompile/registry/registry.go
-6- Add your config unit tests under generated package config_test.go
-7- Add your contract unit tests under generated package contract_test.go
-8- Additionally you can add a full-fledged VM test for your precompile under plugin/vm/vm_test.go. See existing precompile tests for examples.
-9- Add your solidity interface and test contract to contracts/contracts
-10- Write solidity contract tests for your precompile in contracts/contracts/test/
-11- Write TypeScript DS-Test counterparts for your solidity tests in contracts/test/
-12- Create your genesis with your precompile enabled in tests/precompile/genesis/
-13- Create e2e test for your solidity test in tests/precompile/solidity/suites.go
-14- Run your e2e precompile Solidity tests with './scripts/run_ginkgo.sh`
+4- If you have any event defined in your precompile, review the generated event.go file and set your event gas costs. You should also emit your event in your function in the contract.go file.
+5- Set gas costs in generated contract.go
+6- Force import your precompile package in precompile/registry/registry.go
+7- Add your config unit tests under generated package config_test.go
+8- Add your contract unit tests under generated package contract_test.go
+9- Additionally you can add a full-fledged VM test for your precompile under plugin/vm/vm_test.go. See existing precompile tests for examples.
+10- Add your solidity interface and test contract to contracts/contracts
+11- Write solidity contract tests for your precompile in contracts/contracts/test
+12- Write TypeScript DS-Test counterparts for your solidity tests in contracts/test
+13- Create your genesis with your precompile enabled in tests/precompile/genesis/
+14- Create e2e test for your solidity test in tests/precompile/solidity/suites.go
+15- Run your e2e precompile Solidity tests with './scripts/run_ginkgo.sh`
 ```
 
 Let's follow these steps and create our HelloWorld precompile!
+
 <!-- markdownlint-enable MD013 -->

--- a/docs/build/vm/evm/intro.md
+++ b/docs/build/vm/evm/intro.md
@@ -134,7 +134,7 @@ with the original precompile interface!
 The AllowList enables a precompile to enforce permissions on addresses. The AllowList is not a contract
 itself, but a helper structure to provide a control mechanism for wrapping contracts.
 It provides an `AllowListConfig` to the precompile so that it can take an initial configuration
-from genesis/upgrade. It also provides 4 functions to set/read the permissions. In this tutorial, we
+from genesis/upgrade. It also provides functions to set/read the permissions. In this tutorial, we
 used `IAllowList` interface to provide permission control to the `HelloWorld` precompile.
 `IAllowList` is defined in Subnet-EVM under [`./contracts/contracts/interfaces/IAllowList.sol`](https://github.com/ava-labs/subnet-evm/blob/helloworld-official-tutorial-v2/contracts/contracts/interfaces/IAllowList.sol).
 The interface is as follows:
@@ -142,13 +142,27 @@ The interface is as follows:
 ```sol
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
+
 interface IAllowList {
+  event RoleSet(
+    uint256 indexed role,
+    address indexed account,
+    address indexed sender,
+    uint256 oldRole
+  );
+
   // Set [addr] to have the admin role over the precompile contract.
   function setAdmin(address addr) external;
+
   // Set [addr] to be enabled on the precompile contract.
   function setEnabled(address addr) external;
+
+  // Set [addr] to have the manager role over the precompile contract.
+  function setManager(address addr) external;
+
   // Set [addr] to have no role for the precompile contract.
   function setNone(address addr) external;
+
   // Read the status of [addr].
   function readAllowList(address addr) external view returns (uint256 role);
 }

--- a/docs/build/vm/evm/intro.md
+++ b/docs/build/vm/evm/intro.md
@@ -139,7 +139,7 @@ used `IAllowList` interface to provide permission control to the `HelloWorld` pr
 `IAllowList` is defined in Subnet-EVM under [`./contracts/contracts/interfaces/IAllowList.sol`](https://github.com/ava-labs/subnet-evm/blob/helloworld-official-tutorial-v2/contracts/contracts/interfaces/IAllowList.sol).
 The interface is as follows:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/custom-vm-subnet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/custom-vm-subnet.md
@@ -90,8 +90,7 @@ compatible con tu VM personalizada.
     "homesteadBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "petersburgBlock": 0,
-    "subnetEVMTimestamp": 0
+    "petersburgBlock": 0
   },
   "nonce": "0x0",
   "timestamp": "0x0",

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/defining-tests.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/defining-tests.md
@@ -105,18 +105,21 @@ hacerlo, `helloWorld` es ahora un contrato de tipo `IHelloWorld` y cuando llamam
 ese contrato, seremos redirigidos a la dirección del precompilador HelloWorld. El siguiente fragmento de código
 se puede copiar y pegar en un nuevo archivo llamado `ExampleHelloWorld.sol`:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "./IHelloWorld.sol";
+
 // ExampleHelloWorld muestra cómo se puede usar el precompilador HelloWorld en un contrato inteligente.
 contract ExampleHelloWorld {
   address constant HELLO_WORLD_ADDRESS =
     0x0300000000000000000000000000000000000000;
   IHelloWorld helloWorld = IHelloWorld(HELLO_WORLD_ADDRESS);
+
   function sayHello() public view returns (string memory) {
     return helloWorld.sayHello();
   }
+
   function setGreeting(string calldata greeting) public {
     helloWorld.setGreeting(greeting);
   }
@@ -146,20 +149,23 @@ Para el contrato de prueba, escribimos nuestra prueba en `./contracts/test/Examp
 
 <!-- vale on -->
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "../ExampleHelloWorld.sol";
 import "../interfaces/IHelloWorld.sol";
 import "./AllowListTest.sol";
+
 contract ExampleHelloWorldTest is AllowListTest {
   IHelloWorld helloWorld = IHelloWorld(HELLO_WORLD_ADDRESS);
+
   function step_getDefaultHelloWorld() public {
     ExampleHelloWorld example = new ExampleHelloWorld();
     address exampleAddress = address(example);
     assertRole(helloWorld.readAllowList(exampleAddress), AllowList.Role.None);
     assertEq(example.sayHello(), "Hello World!");
   }
+
   function step_doesNotSetGreetingBeforeEnabled() public {
     ExampleHelloWorld example = new ExampleHelloWorld();
     address exampleAddress = address(example);
@@ -168,6 +174,7 @@ contract ExampleHelloWorldTest is AllowListTest {
       assertTrue(false, "setGreeting should fail");
     } catch {}
   }
+
   function step_setAndGetGreeting() public {
     ExampleHelloWorld example = new ExampleHelloWorld();
     address exampleAddress = address(example);
@@ -189,20 +196,23 @@ contract ExampleHelloWorldTest is AllowListTest {
 
 Para Precompile-EVM, debes importar AllowListTest con el paquete NPM @avalabs/subnet-evm-contracts:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 import "../ExampleHelloWorld.sol";
 import "../interfaces/IHelloWorld.sol";
 import "@avalabs/subnet-evm-contracts/contracts/test/AllowListTest.sol";
+
 contract ExampleHelloWorldTest is AllowListTest {
   IHelloWorld helloWorld = IHelloWorld(HELLO_WORLD_ADDRESS);
+
   function step_getDefaultHelloWorld() public {
     ExampleHelloWorld example = new ExampleHelloWorld();
     address exampleAddress = address(example);
     assertRole(helloWorld.readAllowList(exampleAddress), AllowList.Role.None);
     assertEq(example.sayHello(), "Hello World!");
   }
+
   function step_doesNotSetGreetingBeforeEnabled() public {
     ExampleHelloWorld example = new ExampleHelloWorld();
     address exampleAddress = address(example);
@@ -211,6 +221,7 @@ contract ExampleHelloWorldTest is AllowListTest {
       assertTrue(false, "setGreeting should fail");
     } catch {}
   }
+
   function step_setAndGetGreeting() public {
     ExampleHelloWorld example = new ExampleHelloWorld();
     address exampleAddress = address(example);

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/executing-tests.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/executing-tests.md
@@ -33,7 +33,6 @@ Nota: es importante que este archivo tenga el mismo nombre que el archivo de pru
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,
@@ -133,8 +132,6 @@ Deberías haber clonado [AvalancheGo](https://github.com/ava-labs/avalanchego) d
 cd $GOPATH/src/github.com/ava-labs/avalanchego
 ./scripts/build.sh
 ```
-
-
 
 Una vez que hayas construido AvalancheGo, puedes confirmar que fue exitoso imprimiendo la versión:
 
@@ -286,8 +283,6 @@ INFO [01-27|10:33:51.002] Executing                                cmd="./script
 
 Después de que `BeforeSuite` se complete con éxito, omitirá todas las pruebas de precompilación etiquetadas
 excepto la prueba de `HelloWorld`:
-
-
 
 ```bash
 S [OMITIDO]

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/generate-precompile.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/generate-precompile.md
@@ -49,15 +49,17 @@ cd contracts/
 
 Crea un nuevo archivo llamado `IHelloWorld.sol` y copia y pega el siguiente código:
 
-```sol
+```solidity
 // (c) 2022-2023, Ava Labs, Inc. Todos los derechos reservados.
 // Consulta el archivo LICENSE para conocer los términos de licencia.
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 import "./IAllowList.sol";
+
 interface IHelloWorld is IAllowList {
   // sayHello devuelve la cadena de saludo almacenada
   function sayHello() external view returns (string calldata result);
+
   // setGreeting almacena la cadena de saludo
   function setGreeting(string calldata response) external;
 }
@@ -98,19 +100,21 @@ Esto ya se ha agregado al archivo `package.json`.
 Puedes instalarlo ejecutando `npm install`.
 Para importar la interfaz `IAllowList`, puedes usar la siguiente declaración de importación:
 
-```sol
+```solidity
 import "@avalabs/subnet-evm-contracts/contracts/interfaces/IAllowList.sol";
 ```
 
 El archivo completo se ve así:
 
-```sol
+```solidity
 // SPDX-License-Identifier: MIT
 pragma solidity >=0.8.0;
 import "@avalabs/subnet-evm-contracts/contracts/interfaces/IAllowList.sol";
+
 interface IHelloWorld is IAllowList {
   // sayHello devuelve la cadena de saludo almacenada
   function sayHello() external view returns (string calldata result);
+
   // setGreeting almacena la cadena de saludo
   function setGreeting(string calldata response) external;
 }

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/hello-world-precompile-tutorial.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/hello-world-precompile-tutorial.md
@@ -1580,7 +1580,6 @@ Note: it's important that this has the same name as the HardHat test file we cre
     "petersburgBlock": 0,
     "istanbulBlock": 0,
     "muirGlacierBlock": 0,
-    "subnetEVMTimestamp": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/hello-world-precompile-tutorial.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/hello-world-precompile-tutorial.md
@@ -139,7 +139,7 @@ used `IAllowList` interface to provide permission control to the `HelloWorld` pr
 `IAllowList` is defined in Subnet-EVM under [`./contracts/contracts/interfaces/IAllowList.sol`](https://github.com/ava-labs/subnet-evm/blob/helloworld-official-tutorial-v2/contracts/contracts/interfaces/IAllowList.sol).
 The interface is as follows:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -343,7 +343,7 @@ cd contracts/
 
 Create a new file called `IHelloWorld.sol` and copy and paste the below code:
 
-```sol
+```solidity
 // (c) 2022-2023, Ava Labs, Inc. All rights reserved.
 // See the file LICENSE for licensing terms.
 
@@ -401,13 +401,13 @@ npm install
 
 In order to import `IAllowList` interface, you can use the following import statement:
 
-```sol
+```solidity
 import "@avalabs/subnet-evm-contracts/contracts/interfaces/IAllowList.sol";
 ```
 
 The full file looks like this:
 
-```sol
+```solidity
 // SPDX-License-Identifier: MIT
 
 pragma solidity >=0.8.0;
@@ -1288,7 +1288,7 @@ doing so, `helloWorld` is now a contract of type `IHelloWorld` and when we call 
 that contract, we will be redirected to the HelloWorld precompile address. The below code snippet
 can be copied and pasted into a new file called `ExampleHelloWorld.sol`:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -1333,7 +1333,7 @@ For the test contract we write our test in `./contracts/test/ExampleHelloWorldTe
 
 <!-- vale on -->
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
@@ -1386,7 +1386,7 @@ contract ExampleHelloWorldTest is AllowListTest {
 
 For Precompile-EVM, you should import `AllowListTest` with `@avalabs/subnet-evm-contracts` NPM package:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/intro.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/intro.md
@@ -138,16 +138,20 @@ usamos la interfaz `IAllowList` para proporcionar control de permisos a la preco
 `IAllowList` está definido en Subnet-EVM bajo [`./contracts/contracts/interfaces/IAllowList.sol`](https://github.com/ava-labs/subnet-evm/blob/helloworld-official-tutorial-v2/contracts/contracts/interfaces/IAllowList.sol).
 La interfaz es la siguiente:
 
-```sol
+```solidity
 //SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
+
 interface IAllowList {
   // Set [addr] to have the admin role over the precompile contract.
   function setAdmin(address addr) external;
+
   // Set [addr] to be enabled on the precompile contract.
   function setEnabled(address addr) external;
+
   // Set [addr] to have no role for the precompile contract.
   function setNone(address addr) external;
+
   // Read the status of [addr].
   function readAllowList(address addr) external view returns (uint256 role);
 }

--- a/i18n/es/docusaurus-plugin-content-docs/current/reference/subnet-evm/api.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/reference/subnet-evm/api.md
@@ -1,14 +1,15 @@
 ---
 tags: [Subnet-EVM]
 description: This page is an overview of the Subnet-EVM API associated with AvalancheGo.
-sidebar_label: API 
+sidebar_label: API
 pagination_label: Subnet-EVM API
 ---
+
 # Subnet-EVM API
 
 [Subnet-EVM](https://github.com/ava-labs/subnet-evm) APIs are identical to
-[Coreth](/reference/avalanchego/c-chain/api.md) C-Chain APIs, except Avalanche Specific APIs 
-starting with `avax`. Subnet-EVM also supports standard Ethereum APIs as well. For more 
+[Coreth](/reference/avalanchego/c-chain/api.md) C-Chain APIs, except Avalanche Specific APIs
+starting with `avax`. Subnet-EVM also supports standard Ethereum APIs as well. For more
 information about Coreth APIs see [GitHub](https://github.com/ava-labs/coreth).
 
 Subnet-EVM has some additional APIs that are not available in Coreth.


### PR DESCRIPTION
# Docs PR Template

## Why this should be merged

Adds Durango related changes to precompile/subnet-evm docs.

## How this works

* Reviews existing precompile+subnet-evm docs
* Creates a "how to upgrade to Durango" doc

## How these changes were tested 

Locally tested + proof reading

