### PR TITLE
Teleporter examples added to sidebar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,6 @@
 docs/build/cross-chain/awm/deep-dive.md
 docs/build/cross-chain/teleporter/overview.md
 docs/build/cross-chain/teleporter/deep-dive.md
-docs/build/cross-chain/teleporter/examples.md
 docs/build/cross-chain/teleporter/getting-started.md
 docs/build/cross-chain/teleporter/upgradeability.md
 docs/build/cross-chain/teleporter/cli.md

--- a/configs/remoteContent.js
+++ b/configs/remoteContent.js
@@ -41,20 +41,22 @@ function replaceRelativeLinks(content, sourceBaseUrl) {
 
 // Function to insert lines after the first line of Teleporter docs (for Academy course)
 function insertLinesAfterFirstLine(content, newLines) {
-    let lines = content.split('\n');
-  
-    if (newLines.length > 0 && lines.length > 0) {
-        lines.splice(1, 0, ...newLines);
-    }
+  let lines = content.split("\n");
 
-    return lines.join('\n');
+  if (newLines.length > 0 && lines.length > 0) {
+    lines.splice(1, 0, ...newLines);
+  }
+
+  return lines.join("\n");
 }
 
-let newLines = [`
+let newLines = [
+  `
 :::info 
 Dive deeper into Teleporter and kickstart your journey in building cross-chain dApps by enrolling in our [<ins>Teleporter course</ins>](https://academy.avax.network/course/teleporter).
 :::
-`];
+`,
+];
 
 const remoteContent = [
   [
@@ -107,7 +109,10 @@ ${updatedContent}`,
             "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/"
           );
 
-          const newContent = insertLinesAfterFirstLine(updatedContent, newLines);
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            newLines
+          );
 
           return {
             filename: "overview.md",
@@ -143,7 +148,10 @@ ${newContent}`,
             "https://github.com/ava-labs/teleporter/blob/main/"
           );
 
-          const newContent = insertLinesAfterFirstLine(updatedContent, newLines);
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            newLines
+          );
 
           return {
             filename: "deep-dive.md",
@@ -166,7 +174,7 @@ ${newContent}`,
   [
     "docusaurus-plugin-remote-content",
     {
-      // /docs/build/cross-chain/teleporter/examples.md
+      // /docs/build/cross-chain/teleporter/getting-started.md
       name: "hello-teleporter",
       sourceBaseUrl:
         "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/CrossChainApplications/",
@@ -180,7 +188,10 @@ ${newContent}`,
             "https://github.com/ava-labs/teleporter/blob/main/contracts/src/CrossChainApplications/"
           );
 
-          const newContent = insertLinesAfterFirstLine(updatedContent, newLines);
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            newLines
+          );
 
           return {
             filename: "getting-started.md",
@@ -202,43 +213,7 @@ ${newContent}`,
   [
     "docusaurus-plugin-remote-content",
     {
-      // /docs/build/cross-chain/teleporter/examples.md
-      name: "teleporter-example-applications",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/CrossChainApplications/",
-      documents: ["README.md"],
-      outDir: "docs/build/cross-chain/teleporter/",
-      // change file name and add metadata correct links
-      modifyContent(filename, content) {
-        if (filename.includes("README")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/CrossChainApplications/"
-          );
-
-          const newContent = insertLinesAfterFirstLine(updatedContent, newLines);
-
-          return {
-            filename: "examples.md",
-            content: `---
-tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-description: Teleporter is an EVM-compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging. This directory includes cross-chain applications that are built on top of the Teleporter protocol.
-keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-sidebar_label: Example Applications
-sidebar_position: 4
----
-
-${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/build/cross-chain/teleporter/examples.md
+      // /docs/build/cross-chain/teleporter/cli.md
       name: "teleporter-cli",
       sourceBaseUrl:
         "https://raw.githubusercontent.com/ava-labs/teleporter/main/cmd/teleporter-cli/",
@@ -252,7 +227,10 @@ ${newContent}`,
             "https://github.com/ava-labs/teleporter/blob/main/cmd/teleporter-cli/README.md"
           );
 
-          const newContent = insertLinesAfterFirstLine(updatedContent, newLines);
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            newLines
+          );
 
           return {
             filename: "cli.md",
@@ -274,7 +252,7 @@ ${newContent}`,
   [
     "docusaurus-plugin-remote-content",
     {
-      // /docs/build/cross-chain/teleporter/examples.md
+      // /docs/build/cross-chain/teleporter/upgradeability.md
       name: "teleporter-upgradeability",
       sourceBaseUrl:
         "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/upgrades/",
@@ -288,7 +266,10 @@ ${newContent}`,
             "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/upgrades/"
           );
 
-          const newContent = insertLinesAfterFirstLine(updatedContent, newLines);
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            newLines
+          );
 
           return {
             filename: "upgradeability.md",
@@ -310,7 +291,7 @@ ${newContent}`,
   [
     "docusaurus-plugin-remote-content",
     {
-      // /docs/build/cross-chain/teleporter/examples.md
+      // /docs/build/cross-chain/teleporter/evm-integration.md
       name: "awm-evm-integration",
       sourceBaseUrl:
         "https://raw.githubusercontent.com/meaghanfitzgerald/coreth/docs-integration/precompile/contracts/warp/",

--- a/docs/build/cross-chain/README.md
+++ b/docs/build/cross-chain/README.md
@@ -18,6 +18,5 @@ pagination_label: Cross Chain Quick Links
 | [**Overview**](/build/cross-chain/teleporter/overview.md)               | Overview of Teleporter                                                              |
 | [**Deep Dive**](/build/cross-chain/teleporter/deep-dive.md)             | Deep Dive into Teleporter                                                           |
 | [**Getting Started**](/build/cross-chain/teleporter/getting-started.md) | Getting Started with an Example Teleporter Application                              |
-| [**Example Applications**](/build/cross-chain/teleporter/examples.md)   | Examples of Teleporter Cross Chain Applications                                     |
 | [**Upgradeability**](/build/cross-chain/teleporter/upgradeability.md)   | Understand how gateways defined with Teleporter can and cannot be changed over time |
 | [**CLI**](/build/cross-chain/teleporter/cli.md)                         | Interact with the Teleporter Contracts via a command line interface                 |

--- a/docs/tooling/cli-cross-chain/teleporter-on-local-networks.md
+++ b/docs/tooling/cli-cross-chain/teleporter-on-local-networks.md
@@ -1,7 +1,7 @@
 ---
 tags: [Tooling, Avalanche-CLI]
 description: This how-to guide focuses on deploying a couple of teleporter-enabled subnets to a local Avalanche network.
-sidebar_label: Teleporter On a Local Network 
+sidebar_label: Teleporter On a Local Network
 pagination_label: Teleporter On a Local Network
 sidebar_position: 1
 ---
@@ -115,14 +115,13 @@ Notice some details here:
 - Two smart contracts are deployed to each Subnet: Teleporter Messenger smart contract and Teleporter Registry smart contract
 - Both Teleporter smart contracts are also deployed to `C-Chain` in the Local Network
 - [AWM Teleporter Relayer](https://github.com/ava-labs/awm-relayer) is installed, configured and executed in background (A Relayer
-[listens](/build/cross-chain/teleporter/overview#data-flow) for new messages being generated on a source Subnet and sends them to the destination Subnet.)
+  [listens](/build/cross-chain/teleporter/overview#data-flow) for new messages being generated on a source Subnet and sends them to the destination Subnet.)
 
 CLI configures the Relayer to enable every Subnet to send messages to all other Subnets. If you add
 more Subnets, the Relayer will be automatically reconfigured.
 
 When deploying Subnet `<subnet2Name>`, the two Teleporter contracts will not be deployed to C-Chain in Local Network
 as they have already been deployed when we deployed the first Subnet.
-
 
 ```shell
 avalanche subnet deploy <subnet2Name> --local
@@ -199,4 +198,3 @@ You have Teleport-ed your first message in the Local Network!
 
 Relayer related logs can be found at `~/.avalanche-cli/runs/awm-relayer.log`, and
 relayer configuration can be found at `~/.avalanche-cli/runs/awm-relayer-config.json`
-

--- a/docs/tooling/cli-cross-chain/teleporter-on-local-networks.md
+++ b/docs/tooling/cli-cross-chain/teleporter-on-local-networks.md
@@ -14,7 +14,7 @@ After this tutorial, you would have created and deployed two Subnets to the loca
 them to cross-communicate with each other and with the local C-Chain (through Teleporter and the
 underlying Warp technology.)
 
-For more information on Cross Chain messaging through Teleporter and Warp, check:
+For more information on cross chain messaging through Teleporter and Warp, check:
 
 - [Cross Chain References](/build/cross-chain)
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/README.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/README.md
@@ -7,17 +7,16 @@ pagination_label: Enlaces Rápidos de Cadena Cruzada
 
 # 🔗 Enlaces Rápidos de Cadena Cruzada
 
-| Avalanche Warp Messaging                                         |                                                   |
-| :--------------------------------------------------------------- | :------------------------------------------------ |
-| [**Visión General**](/build/cross-chain/awm/overview.md)               | Visión general de la Mensajería de Warp Avalanche              |
-| [**Profundidad**](/build/cross-chain/awm/deep-dive.md)             | Profundización en la Mensajería de Warp Avalanche           |
+| Avalanche Warp Messaging                                         |                                                          |
+| :--------------------------------------------------------------- | :------------------------------------------------------- |
+| [**Visión General**](/build/cross-chain/awm/overview.md)         | Visión general de la Mensajería de Warp Avalanche        |
+| [**Profundidad**](/build/cross-chain/awm/deep-dive.md)           | Profundización en la Mensajería de Warp Avalanche        |
 | [**Integración EVM**](/build/cross-chain/awm/evm-integration.md) | Integración de la Mensajería de Warp Avalanche en la EVM |
 
-| Teleporter                                                              |                                                                                     |
-| :---------------------------------------------------------------------- | :---------------------------------------------------------------------------------- |
-| [**Visión General**](/build/cross-chain/teleporter/overview.md)               | Visión general de Teleporter                                                              |
-| [**Profundidad**](/build/cross-chain/teleporter/deep-dive.md)             | Profundización en Teleporter                                                           |
-| [**Empezando**](/build/cross-chain/teleporter/getting-started.md) | Empezando con una Aplicación de Teleporter de Ejemplo                              |
-| [**Aplicaciones de Ejemplo**](/build/cross-chain/teleporter/examples.md)   | Ejemplos de Aplicaciones de Cadena Cruzada con Teleporter                                     |
-| [**Capacidad de Actualización**](/build/cross-chain/teleporter/upgradeability.md)   | Comprenda cómo las pasarelas definidas con Teleporter pueden y no pueden cambiarse con el tiempo |
-| [**CLI**](/build/cross-chain/teleporter/cli.md)                         | Interactúe con los Contratos de Teleporter a través de una interfaz de línea de comandos                 |
+| Teleporter                                                                        |                                                                                                  |
+| :-------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
+| [**Visión General**](/build/cross-chain/teleporter/overview.md)                   | Visión general de Teleporter                                                                     |
+| [**Profundidad**](/build/cross-chain/teleporter/deep-dive.md)                     | Profundización en Teleporter                                                                     |
+| [**Empezando**](/build/cross-chain/teleporter/getting-started.md)                 | Empezando con una Aplicación de Teleporter de Ejemplo                                            |
+| [**Capacidad de Actualización**](/build/cross-chain/teleporter/upgradeability.md) | Comprenda cómo las pasarelas definidas con Teleporter pueden y no pueden cambiarse con el tiempo |
+| [**CLI**](/build/cross-chain/teleporter/cli.md)                                   | Interactúe con los Contratos de Teleporter a través de una interfaz de línea de comandos         |

--- a/sidebars.json
+++ b/sidebars.json
@@ -341,6 +341,33 @@
       "dirName": "build/cross-chain/teleporter"
     },
     {
+      "type": "category",
+      "label": "Example Projects",
+      "collapsed": false,
+      "items": [
+        {
+          "type": "ref",
+          "label": "Local Deployment",
+          "id": "tooling/cli-cross-chain/teleporter-on-local-networks"
+        },
+        {
+          "type": "link",
+          "label": "Token Bridge",
+          "href": "https://github.com/ava-labs/teleporter-token-bridge#readme"
+        },
+        {
+          "type": "link",
+          "label": "Chainlink VRF",
+          "href": "https://github.com/ava-labs/subnet-vrf-contracts#readme"
+        },
+        {
+          "type": "link",
+          "label": "Run AWM-Relayer",
+          "href": "https://github.com/ava-labs/awm-relayer#readme"
+        }
+      ]
+    },
+    {
       "type": "html",
       "value": "<hr/>"
     }
@@ -485,7 +512,6 @@
       "value": "<hr/>"
     },
     "tooling/avalanchejs-overview",
-  
 
     "tooling/glacier",
     "tooling/metrics",
@@ -570,6 +596,11 @@
       "type": "link",
       "label": "Release Notes",
       "href": "https://github.com/ava-labs/avalanchego/releases"
+    },
+    {
+      "type": "ref",
+      "label": "⛓️ Chain Configs",
+      "id": "nodes/configure/avalanchego-config-flags"
     },
     {
       "type": "html",


### PR DESCRIPTION
## How this works

**Staged here: https://meag-teleporte-examples.avalanche-docs.pages.dev/build/cross-chain**

- removed example applications readme pull 
- created new sidebar subsection with ref links to teleporter examples
-- awm-relayer
-- cli 
-- token bridge
-- subnet chainlink vrf 

<img width="418" alt="image" src="https://github.com/ava-labs/avalanche-docs/assets/99047250/1c0f1bfb-28e4-4f4b-ba92-f8eff9ab8f2f">

`Teleporter on a Local Network` links to [cli doc](https://docs.avax.network/tooling/cli-cross-chain/teleporter-on-local-networks)
`Token Bridge` links to [github](https://github.com/ava-labs/teleporter-token-bridge#readme)
`Chainlink VRF` links to [github](https://github.com/ava-labs/subnet-vrf-contracts#readme)
`Run AWM-Relayer` links to [github](https://github.com/ava-labs/awm-relayer#readme)

## Unrelated changes 
- added ref link to chain configs in the "reference" tab 

