### PR TITLE
remove unnecessary upgrade definitions in genesis

### DIFF
--- a/docs/build/subnet/deploy/custom-vm-subnet.md
+++ b/docs/build/subnet/deploy/custom-vm-subnet.md
@@ -70,13 +70,7 @@ compatible with your custom VM.
 ```json
 {
   "config": {
-    "byzantiumBlock": 0,
     "chainId": 12345,
-    "constantinopleBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
     "feeConfig": {
       "gasLimit": 15000000,
       "targetBlockRate": 2,
@@ -86,11 +80,7 @@ compatible with your custom VM.
       "minBlockGasCost": 0,
       "maxBlockGasCost": 1000000,
       "blockGasCostStep": 200000
-    },
-    "homesteadBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
-    "petersburgBlock": 0
+    }
   },
   "nonce": "0x0",
   "timestamp": "0x0",

--- a/docs/build/subnet/upgrade/customize-a-subnet.md
+++ b/docs/build/subnet/upgrade/customize-a-subnet.md
@@ -43,16 +43,6 @@ The default genesis Subnet-EVM provided below has some well defined parameters:
 {
   "config": {
     "chainId": 43214,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 15000000,
       "minBaseFee": 25000000000,
@@ -96,7 +86,13 @@ You can use `eth_getChainConfig` RPC call to get the current chain config. See
 
 `homesteadBlock`, `eip150Block`, `eip150Hash`, `eip155Block`, `byzantiumBlock`, `constantinopleBlock`,
 `petersburgBlock`, `istanbulBlock`, `muirGlacierBlock` are EVM hard fork activation
-times. Changing these may cause issues, so treat them carefully.
+times. Subnet-EVM provides valid default values for these hard forks (and other network upgrades), so you can omit them in your genesis configuration. You can still change them but changing these may cause issues, so treat them carefully.
+
+:::note
+
+Before Subnet-EVM v0.6.3 these fields were mandatory. If you are using an older version, you need to provide these fields in your genesis configuration. You can find examples in the repository like [here for v0.6.2](https://github.com/ava-labs/subnet-evm/blob/v0.6.2/tests/load/genesis/genesis.json). For the latest version, you can omit these fields like above in [Genesis section](#genesis).
+
+:::
 
 #### Fee Config
 
@@ -1268,6 +1264,36 @@ state modifications at the first block after (or at) `March 8, 2023 1:30:00 AM G
 ```
 
 ## Network Upgrades: Rescheduling Mandatory Network Upgrades
+
+Mandatory Network Upgrades (or hardforks), like Durango, are critical for the network to be on the same page and continue to operate with new rules and features. Mandatory upgrades are scheduled in advance and all network nodes should be upgraded to the new version before the activation time. In Avalanche, activation times are set in the AvalancheGo code and are not configurable by the network operators. Subnet-EVM also utilizes these activation times in AvalancheGo for mandatory upgrades. For instance Durango is scheduled at the same time in all Subnet-EVM networks and primary network.
+
+With Subnet-EVM v0.6.3 and later, you can reschedule mandatory network upgrades in both genesis and later via `upgrade.json` file. Subnet-EVM will continue to provide default activation times for mandatory upgrades in the future, you can reschedule them if needed.
+
+:::caution
+
+Rescheduling mandatory network upgrades is a very advanced operation and should be done only if your network having issues or you have a very good reason to do so. You also might need to reschedule other subsequent activations since upgrades are dependent on each other Rescheduling mandatory network upgrades might create a fork in the network if not done correctly.
+
+:::
+
+In order to reschedule a mandatory network (e.g. Durango) in genesis chain config file, you need to specify the new activation time as follows:
+
+```json
+{
+  "config": {
+    "chainId": 99999,
+    "durangoTimestamp": 1711464683,
+    ...
+  },
+  "alloc": {
+    ...
+  },
+  "nonce": "0x0",
+  "timestamp": "0x0",
+  ...
+}
+```
+
+### Missed Upgrades
 
 A typical case when a network misses any mandatory activation would result in a network that is not able to operate. This is because validators/nodes running the old version would process transactions differently than nodes running the new version and end up different state. This would result in a fork in the network and new nodes would not be able to sync with the network. Normally this puts the chain in a halt and requires a hard fork to fix the issue. Starting with Subnet-EVM v0.6.3, you can reschedule mandatory activations like Durango via upgrade configs (upgrade.json in chain directory). This is a very advanced operation and should be done only if your network cannot operate going forward. The reschedule operation should be coordinated with your entire network nodes. Network upgrade overrides can be defined in the `upgrade.json` as follows:
 

--- a/docs/build/vm/evm/executing-tests.md
+++ b/docs/build/vm/evm/executing-tests.md
@@ -25,16 +25,6 @@ Note: it's important that this has the same name as the HardHat test file we cre
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/docs/deprecated/tutorials-contest/2022/avax-subnet-customization/README.md
+++ b/docs/deprecated/tutorials-contest/2022/avax-subnet-customization/README.md
@@ -391,11 +391,11 @@ used **less** gas than its target, the base fee should **decrease**.
 
 Here are the calculations:
 
-If the parent block used **more** gas than its target:  
- `baseFee = max(1, parentBaseFee * (parentGasUsed - parentGasTarget) / parentGasTarget / baseFeeChangeDenominator)`
+If the parent block used **more** gas than its target:
+`baseFee = max(1, parentBaseFee * (parentGasUsed - parentGasTarget) / parentGasTarget / baseFeeChangeDenominator)`
 
-If the parent block used **less** gas than its target:  
- `baseFee = max(0, parentBaseFee * (parentGasUsed - parentGasTarget) / parentGasTarget / baseFeeChangeDenominator)`
+If the parent block used **less** gas than its target:
+`baseFee = max(0, parentBaseFee * (parentGasUsed - parentGasTarget) / parentGasTarget / baseFeeChangeDenominator)`
 
 The `baseFeeChangeDenominator` is set to `36` in C-Chain. This value sets the
 base fee to increase or decrease by a factor of `1/36` of the parent block's
@@ -922,20 +922,20 @@ This is the `ContractNativeMinter` interface. We know the contract is deployed a
 pragma solidity >=0.8.0;
 
 interface NativeMinterInterface {
-    // Set [addr] to have the admin role over the minter list
-    function setAdmin(address addr) external;
+  // Set [addr] to have the admin role over the minter list
+  function setAdmin(address addr) external;
 
-    // Set [addr] to be enabled on the minter list
-    function setEnabled(address addr) external;
+  // Set [addr] to be enabled on the minter list
+  function setEnabled(address addr) external;
 
-    // Set [addr] to have no role over the minter list
-    function setNone(address addr) external;
+  // Set [addr] to have no role over the minter list
+  function setNone(address addr) external;
 
-    // Read the status of [addr]
-    function readAllowList(address addr) external view returns (uint256);
+  // Read the status of [addr]
+  function readAllowList(address addr) external view returns (uint256);
 
-    // Mint [amount] number of native coins and send to [addr]
-    function mintNativeCoin(address addr, uint256 amount) external;
+  // Mint [amount] number of native coins and send to [addr]
+  function mintNativeCoin(address addr, uint256 amount) external;
 }
 ```
 
@@ -952,26 +952,23 @@ pragma solidity ^0.8.7;
 import "./NativeMinterInterface.sol";
 
 contract Game {
+  // native minter is deployed at 0x0200000000000000000000000000000000000001
+  NativeMinterInterface minter =
+    NativeMinterInterface(0x0200000000000000000000000000000000000001);
 
-    // native minter is deployed at 0x0200000000000000000000000000000000000001
-    NativeMinterInterface minter = NativeMinterInterface(0x0200000000000000000000000000000000000001);
+  function random() internal view returns (uint) {
+    // never use this random number generation in a real project
+    // it's deterministic and easily hackable.
+    return uint(keccak256(abi.encodePacked(block.timestamp)));
+  }
 
-    function random() internal view returns (uint) {
-        // never use this random number generation in a real project
-        // it's deterministic and easily hackable.
-        return uint(keccak256(abi.encodePacked(block.timestamp)));
+  function play() external payable {
+    uint256 randomNumber = random();
+
+    if (randomNumber % 2 == 0) {
+      minter.mintNativeCoin(msg.sender, msg.value * 2);
     }
-
-    function play() external payable {
-        uint256 randomNumber = random();
-
-        if(randomNumber % 2 == 0){
-            minter.mintNativeCoin(
-                msg.sender,
-                msg.value * 2
-            );
-        }
-    }
+  }
 }
 ```
 

--- a/docs/tooling/cli-create-nodes/setup-a-devnet.md
+++ b/docs/tooling/cli-create-nodes/setup-a-devnet.md
@@ -8,7 +8,7 @@ sidebar_position: 2
 
 # Setup a Devnet Using Avalanche-CLI
 
-This page demonstrates how to setup a Devnet of cloud-based validators using Avalanche-CLI, 
+This page demonstrates how to setup a Devnet of cloud-based validators using Avalanche-CLI,
 and deploy a VM into it.
 
 Devnets (Developer Networks) are isolated avalanche networks deployed on the cloud. Similar to local networks
@@ -41,7 +41,7 @@ For the second case we provide three important use cases examples:
 
 - creating a devnet an deploy a preexistent CLI Subnet (same example as the step by step)
 - creating a devnet, create a Subnet based on a Custom VM, and deploy it (similar to [
-this one](/tooling/cli-create-nodes/upload-a-custom-vm-to-cloud))
+  this one](/tooling/cli-create-nodes/upload-a-custom-vm-to-cloud))
 - creating a devnet with warp-enabled Subnets
 
 ## Step by Step
@@ -95,7 +95,7 @@ Give authorization to access AWS resources on behalf of the user:
     No
 ```
 
-Now, the nodes will be created. 
+Now, the nodes will be created.
 
 After that, you will be asked which AvalancheGo version you want to install in the nodes. Select
 the one associated to `<subnetName>`.
@@ -440,16 +440,6 @@ We will create two Subnet-EVM genesis files, both with warp enabled, but with di
 {
   "config": {
     "chainId": 68430,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "subnetEVMTimestamp": 0,
     "dUpgradeTimestamp": 0,
     "feeConfig": {
@@ -490,16 +480,6 @@ We will create two Subnet-EVM genesis files, both with warp enabled, but with di
 {
   "config": {
     "chainId": 68431,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "subnetEVMTimestamp": 0,
     "dUpgradeTimestamp": 0,
     "feeConfig": {
@@ -756,4 +736,3 @@ curl http://52.204.202.216:9650/ext/bc/JjDfmxM3hAEX3VuaKH4PpQskhrvp2pzGTgYLpDwin
 ```
 
 C-Chain endpoint follows the same scheme but with the blockchain alias of `C`: `http://52.204.202.216:9650/ext/bc/C/rpc`
-

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/custom-vm-subnet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/deploy/custom-vm-subnet.md
@@ -70,13 +70,7 @@ compatible con tu VM personalizada.
 ```json
 {
   "config": {
-    "byzantiumBlock": 0,
     "chainId": 12345,
-    "constantinopleBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
     "feeConfig": {
       "gasLimit": 15000000,
       "targetBlockRate": 2,
@@ -86,11 +80,7 @@ compatible con tu VM personalizada.
       "minBlockGasCost": 0,
       "maxBlockGasCost": 1000000,
       "blockGasCostStep": 200000
-    },
-    "homesteadBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
-    "petersburgBlock": 0
+    }
   },
   "nonce": "0x0",
   "timestamp": "0x0",

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/upgrade/customize-a-subnet.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/subnet/upgrade/customize-a-subnet.md
@@ -43,16 +43,6 @@ La Subnet-EVM de genesis predeterminada proporcionada a continuación tiene algu
 {
   "config": {
     "chainId": 43214,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 15000000,
       "minBaseFee": 25000000000,

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/executing-tests.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/executing-tests.md
@@ -23,16 +23,6 @@ Nota: es importante que este archivo tenga el mismo nombre que el archivo de pru
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/hello-world-precompile-tutorial.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/vm/evm/hello-world-precompile-tutorial.md
@@ -1570,16 +1570,6 @@ Note: it's important that this has the same name as the HardHat test file we cre
 {
   "config": {
     "chainId": 99999,
-    "homesteadBlock": 0,
-    "eip150Block": 0,
-    "eip150Hash": "0x2086799aeebeae135c246c65021c82b4e15a2c451340993aacfd2751886514f0",
-    "eip155Block": 0,
-    "eip158Block": 0,
-    "byzantiumBlock": 0,
-    "constantinopleBlock": 0,
-    "petersburgBlock": 0,
-    "istanbulBlock": 0,
-    "muirGlacierBlock": 0,
     "feeConfig": {
       "gasLimit": 20000000,
       "minBaseFee": 1000000000,


### PR DESCRIPTION
With Subnet-EVM v0.6.3 we no longer require hardforks/upgrade timestamps to be present in genesis files. Subnet-EVM can fill defaults for them if they're not defined. 