### PR TITLE
Small rearrangement of the walk through to match avalanche CLI

### DIFF
--- a/docs/tooling/cli-create-deploy-subnets/create-subnet.md
+++ b/docs/tooling/cli-create-deploy-subnets/create-subnet.md
@@ -60,6 +60,10 @@ The following sections walk through each question in the wizard.
 
 Select `SubnetEVM`.
 
+### Subnet-EVM Version
+
+Select `Use latest version`.
+
 ### Enter Your Subnet's ChainID
 
 Choose a positive integer for your EVM-style ChainID.
@@ -74,10 +78,6 @@ tools.
 
 Enter a string to name your Subnet's native token. The token symbol doesn't necessarily need to be unique.
 Example token symbols are AVAX, JOE, and BTC.
-
-### Subnet-EVM Version
-
-Select `Use latest version`.
 
 ### Gas Fee Configuration
 


### PR DESCRIPTION
I made a small rearrangement to the "walk through the wizard" section so it aligns with the order of the questions the wizard asks for creating a subnet in the avalanche CLI
