### PR TITLE
[scripts] build from source if cannot find a release

### DIFF
--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -311,7 +311,7 @@ else
     shouldBuild=false
   fi
   if [ "$shouldBuild" = "false" ]; then
-    echo "Unable to find AvalancheGo version $version. Exiting."
+    echo "Unable to find AvalancheGo release $version. Exiting."
     if [ "$foundAvalancheGo" = "true" ]; then
       echo "Restarting service..."
       sudo systemctl start avalanchego
@@ -319,7 +319,7 @@ else
     exit
   fi
 
-  echo "Unable to find AvalancheGo version $version. Attempting to build $version from source."
+  echo "Unable to find AvalancheGo release $version. Attempting to build $version from source."
   git clone https://github.com/ava-labs/avalanchego
   cd avalanchego
   git checkout $version || {

--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -319,8 +319,22 @@ else
   echo "Unable to find AvalancheGo version $version. Attempting to build $version from source."
   git clone https://github.com/ava-labs/avalanchego
   cd avalanchego
-  git checkout $version
-  ./scripts/build.sh
+  git checkout $version || {
+    echo "Unable to find AvalancheGo commit $version. Exiting."
+    if [ "$foundAvalancheGo" = "true" ]; then
+      echo "Restarting service..."
+      sudo systemctl start avalanchego
+    fi
+    exit
+  }
+  ./scripts/build.sh || {
+    echo "Unable to build AvalancheGo commit $version. Exiting."
+    if [ "$foundAvalancheGo" = "true" ]; then
+      echo "Restarting service..."
+      sudo systemctl start avalanchego
+    fi
+    exit
+  }
 
   echo "Moving node binary..."
   mkdir -p $HOME/avalanche-node

--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -299,12 +299,15 @@ if [[ `wget -S --spider $fileName  2>&1 | grep 'HTTP/1.1 200 OK'` ]]; then
 else
   shouldBuild=true
   if ! command -v git >/dev/null 2>&1 ; then
+    echo "Missing git, will not attempt to build $version from source."
     shouldBuild=false
   fi
   if ! command -v go >/dev/null 2>&1 ; then
+    echo "Missing go, will not attempt to build $version from source."
     shouldBuild=false
   fi
   if ! command -v gcc >/dev/null 2>&1 ; then
+    echo "Missing gcc, will not attempt to build $version from source."
     shouldBuild=false
   fi
   if [ "$shouldBuild" = "false" ]; then


### PR DESCRIPTION
This PR allows the installer to fallback to building from source if a provided AvalancheGo version does not exist. It is used within avalanche-cli to install custom versions of AvalancheGo in devnets and is a no-op for standard usage.