### PR TITLE
avalanchego-installer.sh: add error exit values + improve git download speed

### DIFF
--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -324,8 +324,7 @@ else
   cd avalanchego
   git init
   git remote add origin https://github.com/ava-labs/avalanchego
-  git fetch --depth 1 origin $version
-  git checkout $version || {
+  git fetch --depth 1 origin $version || {
     echo "Unable to find AvalancheGo commit $version. Exiting."
     if [ "$foundAvalancheGo" = "true" ]; then
       echo "Restarting service..."
@@ -333,6 +332,7 @@ else
     fi
     exit 1
   }
+  git checkout $version
   ./scripts/build.sh || {
     echo "Unable to build AvalancheGo commit $version. Exiting."
     if [ "$foundAvalancheGo" = "true" ]; then


### PR DESCRIPTION
# Docs PR Template

## Why this should be merged

Currently avalanchego-installer.sh lacks some error returns and git download speed
when building from source can be improved

## How this works

Add exit value of 1 for all error conditions

## How these changes were tested 

<please give a thorough description of how to view the changes and how they were tested>

## To prevent any errors while building

- [] run `vale /docs/file/path` on all changed `.md` files to ensure all grammar rules pass
- [] run `markdownlint /docs/file/path` on all changed `.md` files to ensure all linting rules pass
- [] complete the above two checks and all additional rules outlined in `style-checker-notes.md` to
  ensure all checks pass

### If a document was removed/deleted

- [] the path to that doc must be redirected to a valid URL via the
  `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path

### If a document was moved

- [] all files that were moved from their current directory to a new path have had their paths
  redirected via the `_redirects` file
- [] `_redirects` were manually verified with the cloudflare preview link
- [] `sidebars.json` reflects all changes made to file path
