### PR TITLE
Remove ref to deleted teleporter docs

### DIFF
--- a/configs/remoteContent.js
+++ b/configs/remoteContent.js
@@ -229,45 +229,6 @@ ${updatedContent}`,
   [
     "docusaurus-plugin-remote-content",
     {
-      // /docs/build/cross-chain/teleporter/getting-started.md
-      name: "hello-teleporter",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/CrossChainApplications/",
-      documents: ["GETTING_STARTED.md"],
-      outDir: "docs/build/cross-chain/teleporter/",
-      // change file name and add metadata correct links
-      modifyContent(filename, content) {
-        if (filename.includes("GETTING_STARTED")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/CrossChainApplications/"
-          );
-
-          const newContent = insertLinesAfterFirstLine(
-            updatedContent,
-            teleporterCourse
-          );
-
-          return {
-            filename: "getting-started.md",
-            content: `---
-tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-description: Teleporter is an EVM-compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging.This section walks through how to build an example cross-chain application on top of the Avalanche Teleporter Protocol.
-keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-sidebar_label: Getting Started
-sidebar_position: 3
----
-
-${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
       // /docs/build/cross-chain/teleporter/cli.md
       name: "teleporter-cli",
       sourceBaseUrl:

--- a/docs/build/cross-chain/README.md
+++ b/docs/build/cross-chain/README.md
@@ -16,7 +16,6 @@ pagination_label: Cross Chain Quick Links
 | Teleporter                                                              |                                                                                     |
 | :---------------------------------------------------------------------- | :---------------------------------------------------------------------------------- |
 | [**Overview**](/build/cross-chain/teleporter/overview.md)               | Overview of Teleporter                                                              |
-| [**Deep Dive**](/build/cross-chain/teleporter/deep-dive.md)             | Deep Dive into Teleporter                                                           |
-| [**Getting Started**](/build/cross-chain/teleporter/getting-started.md) | Getting Started with an Example Teleporter Application                              |
+| [**Deep Dive**](/build/cross-chain/teleporter/deep-dive.md)             | Deep Dive into Teleporter                                                           |                         |
 | [**Upgradeability**](/build/cross-chain/teleporter/upgradeability.md)   | Understand how gateways defined with Teleporter can and cannot be changed over time |
 | [**CLI**](/build/cross-chain/teleporter/cli.md)                         | Interact with the Teleporter Contracts via a command line interface                 |

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/README.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/README.md
@@ -1,6 +1,6 @@
 ---
-etiquetas: [Construir, Funcionalidad de Cadena Cruzada]
-descripción: Funcionalidad de Cadena Cruzada
+tags: [Construir, Funcionalidad de Cadena Cruzada]
+description: Funcionalidad de Cadena Cruzada
 sidebar_label: 🔗 Enlaces Rápidos
 pagination_label: Enlaces Rápidos de Cadena Cruzada
 ---

--- a/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/README.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/build/cross-chain/README.md
@@ -1,22 +1,21 @@
 ---
-tags: [Construir, Funcionalidad de Cadena Cruzada]
-description: Funcionalidad de Cadena Cruzada
+etiquetas: [Construir, Funcionalidad de Cadena Cruzada]
+descripción: Funcionalidad de Cadena Cruzada
 sidebar_label: 🔗 Enlaces Rápidos
 pagination_label: Enlaces Rápidos de Cadena Cruzada
 ---
 
 # 🔗 Enlaces Rápidos de Cadena Cruzada
 
-| Avalanche Warp Messaging                                         |                                                          |
-| :--------------------------------------------------------------- | :------------------------------------------------------- |
-| [**Visión General**](/build/cross-chain/awm/overview.md)         | Visión general de la Mensajería de Warp Avalanche        |
-| [**Profundidad**](/build/cross-chain/awm/deep-dive.md)           | Profundización en la Mensajería de Warp Avalanche        |
-| [**Integración EVM**](/build/cross-chain/awm/evm-integration.md) | Integración de la Mensajería de Warp Avalanche en la EVM |
+| Mensajería de Warp Avalanche                                         |                                                   |
+| :--------------------------------------------------------------- | :------------------------------------------------ |
+| [**Visión General**](/build/cross-chain/awm/overview.md)               | Visión general de la Mensajería de Warp Avalanche              |
+| [**Profundidad**](/build/cross-chain/awm/deep-dive.md)             | Profundidad en la Mensajería de Warp Avalanche           |
+| [**Integración EVM**](/build/cross-chain/awm/evm-integration.md) | Integrando la Mensajería de Warp Avalanche en la EVM |
 
-| Teleporter                                                                        |                                                                                                  |
-| :-------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------------- |
-| [**Visión General**](/build/cross-chain/teleporter/overview.md)                   | Visión general de Teleporter                                                                     |
-| [**Profundidad**](/build/cross-chain/teleporter/deep-dive.md)                     | Profundización en Teleporter                                                                     |
-| [**Empezando**](/build/cross-chain/teleporter/getting-started.md)                 | Empezando con una Aplicación de Teleporter de Ejemplo                                            |
-| [**Capacidad de Actualización**](/build/cross-chain/teleporter/upgradeability.md) | Comprenda cómo las pasarelas definidas con Teleporter pueden y no pueden cambiarse con el tiempo |
-| [**CLI**](/build/cross-chain/teleporter/cli.md)                                   | Interactúe con los Contratos de Teleporter a través de una interfaz de línea de comandos         |
+| Teleporter                                                              |                                                                                     |
+| :---------------------------------------------------------------------- | :---------------------------------------------------------------------------------- |
+| [**Visión General**](/build/cross-chain/teleporter/overview.md)               | Visión general de Teleporter                                                              |
+| [**Profundidad**](/build/cross-chain/teleporter/deep-dive.md)             | Profundidad en Teleporter                                                           |                         |
+| [**Capacidad de Actualización**](/build/cross-chain/teleporter/upgradeability.md)   | Comprenda cómo las pasarelas definidas con Teleporter pueden y no pueden cambiarse con el tiempo |
+| [**CLI**](/build/cross-chain/teleporter/cli.md)                         | Interactúa con los contratos de Teleporter a través de una interfaz de línea de comandos                 |


### PR DESCRIPTION
The CrossChainApplications examples were removed from the teleporter repo: https://github.com/ava-labs/teleporter/pull/394 , they will be moved to the avalanche-starter-kit repo (https://github.com/ava-labs/avalanche-starter-kit/issues/5) . 

The build fails because it cannot find these files. Removing the Getting started teleporter doc until the  the examples are moved. I'll add it again afterwards.