### PR TITLE
Fix build errors, add hardcoded ACP explainer

### DIFF
--- a/.github/styles/Vocab/Products/accept.txt
+++ b/.github/styles/Vocab/Products/accept.txt
@@ -16,6 +16,7 @@ alloc
 Alloc
 alloweds
 ANR's
+ANCs
 Ansible
 API's
 apis
@@ -150,6 +151,7 @@ infeasibly
 Infura
 inlined
 ints
+interoperate
 IPCs
 ipfs
 IPFS

--- a/.gitignore
+++ b/.gitignore
@@ -17,7 +17,6 @@ docs/build/cross-chain/teleporter/upgradeability.md
 docs/build/cross-chain/teleporter/cli.md
 docs/build/cross-chain/awm/evm-integration.md
 docs/build/cross-chain/awm/relayer.md
-docs/learn/acp.md
 
 # AvalancheGo API from GH repo via docusaurus-plugin-remote-content
 docs/reference/avalanchego/p-chain/api.md

--- a/configs/remoteContent.js
+++ b/configs/remoteContent.js
@@ -99,13 +99,13 @@ const remoteContent = [
           return {
             filename: "deep-dive.md",
             content: `---
-tags: [Avalanche Warp Messaging, AWM, Cross-Subnet Communication, Cross-Chain Communication]
-description: Avalanche Warp Messaging (AWM) provides a primitive for cross-subnet communication on the Avalanche Network.
-keywords: [ docs, documentation, avalanche, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-sidebar_label: Deep Dive
-sidebar_position: 1
+  tags: [Avalanche Warp Messaging, AWM, Cross-Subnet Communication, Cross-Chain Communication]
+  description: Avalanche Warp Messaging (AWM) provides a primitive for cross-subnet communication on the Avalanche Network.
+  keywords: [ docs, documentation, avalanche, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+  sidebar_label: Deep Dive
+  sidebar_position: 1
 ---
-              
+
 ${updatedContent}`,
           };
         }
@@ -138,14 +138,14 @@ ${updatedContent}`,
           return {
             filename: "relayer.md",
             content: `---
-  tags: [Avalanche Warp Messaging, Relayer]
-  description: Reference relayer implementation for cross-chain Avalanche Warp Message delivery.
-  keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-  sidebar_label: Run a Relayer
-  sidebar_position: 3
-  ---
+      tags: [Avalanche Warp Messaging, Relayer]
+      description: Reference relayer implementation for cross-chain Avalanche Warp Message delivery.
+      keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+      sidebar_label: Run a Relayer
+      sidebar_position: 3
+---
 
-  ${newContent}`,
+${newContent}`,
           };
         }
         return undefined;
@@ -158,7 +158,7 @@ ${updatedContent}`,
       // /docs/build/cross-chain/teleporter/overview.md
       name: "teleporter-overview",
       sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/",
+        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/teleporter/",
       documents: ["README.md"],
       outDir: "docs/build/cross-chain/teleporter/",
       // change file name and add metadata correct links
@@ -166,7 +166,7 @@ ${updatedContent}`,
         if (filename.includes("README")) {
           const updatedContent = replaceRelativeLinks(
             content,
-            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/"
+            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/teleporter/"
           );
 
           const newContent = insertLinesAfterFirstLine(
@@ -177,14 +177,14 @@ ${updatedContent}`,
           return {
             filename: "overview.md",
             content: `---
-    tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-    description: Teleporter is a messaging protocol built on top of Avalanche Warp Messaging that provides a developer-friendly interface for sending and receiving cross-chain messages from within the EVM.
-    keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-    sidebar_label: Overview
-    sidebar_position: 1
-    ---
+        tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+        description: Teleporter is a messaging protocol built on top of Avalanche Warp Messaging that provides a developer-friendly interface for sending and receiving cross-chain messages from within the EVM.
+        keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+        sidebar_label: Overview
+        sidebar_position: 1
+---
 
-    ${newContent}`,
+${newContent}`,
           };
         }
         return undefined;
@@ -211,15 +211,15 @@ ${updatedContent}`,
           return {
             filename: "deep-dive.md",
             content: `---
-    tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-    description: Teleporter is an EVM compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging (AWM), and implemented as a Solidity smart contract. It provides a mechanism to asynchronously invoke smart contract functions on other EVM blockchains within Avalanche. Teleporter provides a handful of useful features on top of AWM, such as specifying relayer incentives for message delivery, replay protection, message delivery and execution retries, and a standard interface for sending and receiving messages within a dApp deployed across multiple subnets.
-    keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-    sidebar_label: Deep Dive
-    sidebar_position: 2
-    title: Teleporter Deep Dive
-    ---
+        tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+        description: Teleporter is an EVM compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging (AWM), and implemented as a Solidity smart contract. It provides a mechanism to asynchronously invoke smart contract functions on other EVM blockchains within Avalanche. Teleporter provides a handful of useful features on top of AWM, such as specifying relayer incentives for message delivery, replay protection, message delivery and execution retries, and a standard interface for sending and receiving messages within a dApp deployed across multiple subnets.
+        keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+        sidebar_label: Deep Dive
+        sidebar_position: 2
+        title: Teleporter Deep Dive
+---
 
-    ${updatedContent}`,
+${updatedContent}`,
           };
         }
         return undefined;
@@ -251,14 +251,14 @@ ${updatedContent}`,
           return {
             filename: "cli.md",
             content: `---
-    tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-    description: This page the source code for the Avalanche Teleporter CLI. The CLI is a command line interface for interacting with the Teleporter contracts. It is written with [cobra](https://github.com/spf13/cobra) commands as a Go application.
-    keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication, teleporter cli ]
-    sidebar_label: CLI
-    sidebar_position: 6
-    ---
+        tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+        description: This page the source code for the Avalanche Teleporter CLI. The CLI is a command line interface for interacting with the Teleporter contracts. It is written with [cobra](https://github.com/spf13/cobra) commands as a Go application.
+        keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication, teleporter cli ]
+        sidebar_label: CLI
+        sidebar_position: 6
+---
 
-    ${newContent}`,
+${newContent}`,
           };
         }
         return undefined;
@@ -271,7 +271,7 @@ ${updatedContent}`,
       // /docs/build/cross-chain/teleporter/upgradeability.md
       name: "teleporter-upgradeability",
       sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/upgrades/",
+        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/teleporter/registry/",
       documents: ["README.md"],
       outDir: "docs/build/cross-chain/teleporter/",
       // change file name and add metadata correct links
@@ -279,7 +279,7 @@ ${updatedContent}`,
         if (filename.includes("README")) {
           const updatedContent = replaceRelativeLinks(
             content,
-            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/upgrades/"
+            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/teleporter/registry/"
           );
 
           const newContent = insertLinesAfterFirstLine(
@@ -290,14 +290,14 @@ ${updatedContent}`,
           return {
             filename: "upgradeability.md",
             content: `---
-    tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-    description: Teleporter is an EVM-compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging. The TeleporterMessenger contract is non-upgradable, once a version of the contract is deployed it cannot be changed. However, there could still be new versions of TeleporterMessenger contracts needed to be deployed in the future.
-    keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-    sidebar_label: Upgradeability
-    sidebar_position: 5
-    ---
+            tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+            description: Teleporter is an EVM-compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging. The TeleporterMessenger contract is non-upgradable, once a version of the contract is deployed it cannot be changed. However, there could still be new versions of TeleporterMessenger contracts needed to be deployed in the future.
+            keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+            sidebar_label: Upgradeability
+            sidebar_position: 5
+---
 
-    ${newContent}`,
+${newContent}`,
           };
         }
         return undefined;
@@ -310,7 +310,7 @@ ${updatedContent}`,
       // /docs/build/cross-chain/teleporter/evm-integration.md
       name: "awm-evm-integration",
       sourceBaseUrl:
-        "https://raw.githubusercontent.com/meaghanfitzgerald/coreth/docs-integration/precompile/contracts/warp/",
+        "https://raw.githubusercontent.com/ava-labs/coreth/master/precompile/contracts/warp/",
       documents: ["README.md"],
       outDir: "docs/build/cross-chain/awm/",
       // change file name and add metadata correct links
@@ -323,14 +323,14 @@ ${updatedContent}`,
           return {
             filename: "evm-integration.md",
             content: `---
-  tags: [Avalanche Warp Messaging, Coreth, Subnet-EVM, Cross-Subnet Communication, Cross-Chain Communication]
-  description: Avalanche Warp Messaging provides a basic primitive for signing and verifying messages between Subnets. The receiving network can verify whether an aggregation of signatures from a set of source Subnet validators represents a threshold of stake large enough for the receiving network to process the message. The Avalanche Warp Precompile enables this flow to send a message from blockchain A to blockchain B.
-  keywords: [ coreth, subnet-evm, docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-  sidebar_label: EVM Integration
-  sidebar_position: 2
-  ---
+    tags: [Avalanche Warp Messaging, Coreth, Subnet-EVM, Cross-Subnet Communication, Cross-Chain Communication]
+    description: Avalanche Warp Messaging provides a basic primitive for signing and verifying messages between Subnets. The receiving network can verify whether an aggregation of signatures from a set of source Subnet validators represents a threshold of stake large enough for the receiving network to process the message. The Avalanche Warp Precompile enables this flow to send a message from blockchain A to blockchain B.
+    keywords: [ coreth, subnet-evm, docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+    sidebar_label: EVM Integration
+    sidebar_position: 2
+---
 
-  ${updatedContent}`,
+${updatedContent}`,
           };
         }
         return undefined;

--- a/configs/remoteContent.js
+++ b/configs/remoteContent.js
@@ -113,538 +113,505 @@ ${updatedContent}`,
       },
     },
   ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/build/cross-chain/awm/relayer.md
-      name: "relayer-overview",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/awm-relayer/main/",
-      documents: ["README.md"],
-      outDir: "docs/build/cross-chain/awm/",
-      // change file name and add metadata correct links
-      modifyContent(filename, content) {
-        if (filename.includes("README")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/ava-labs/awm-relayer/blob/main/"
-          );
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/build/cross-chain/awm/relayer.md
+  //     name: "relayer-overview",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/awm-relayer/main/",
+  //     documents: ["README.md"],
+  //     outDir: "docs/build/cross-chain/awm/",
+  //     // change file name and add metadata correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("README")) {
+  //         const updatedContent = replaceRelativeLinks(
+  //           content,
+  //           "https://github.com/ava-labs/awm-relayer/blob/main/"
+  //         );
 
-          const newContent = insertLinesAfterFirstLine(
-            updatedContent,
-            teleporterCourse
-          );
+  //         const newContent = insertLinesAfterFirstLine(
+  //           updatedContent,
+  //           teleporterCourse
+  //         );
 
-          return {
-            filename: "relayer.md",
-            content: `---
-tags: [Avalanche Warp Messaging, Relayer]
-description: Reference relayer implementation for cross-chain Avalanche Warp Message delivery.
-keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-sidebar_label: Run a Relayer
-sidebar_position: 3
----
+  //         return {
+  //           filename: "relayer.md",
+  //           content: `---
+  // tags: [Avalanche Warp Messaging, Relayer]
+  // description: Reference relayer implementation for cross-chain Avalanche Warp Message delivery.
+  // keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+  // sidebar_label: Run a Relayer
+  // sidebar_position: 3
+  // ---
 
-${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/build/cross-chain/teleporter/overview.md
-      name: "teleporter-overview",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/",
-      documents: ["README.md"],
-      outDir: "docs/build/cross-chain/teleporter/",
-      // change file name and add metadata correct links
-      modifyContent(filename, content) {
-        if (filename.includes("README")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/"
-          );
+  // ${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/build/cross-chain/teleporter/overview.md
+  //     name: "teleporter-overview",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/",
+  //     documents: ["README.md"],
+  //     outDir: "docs/build/cross-chain/teleporter/",
+  //     // change file name and add metadata correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("README")) {
+  //         const updatedContent = replaceRelativeLinks(
+  //           content,
+  //           "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/"
+  //         );
 
-          const newContent = insertLinesAfterFirstLine(
-            updatedContent,
-            teleporterCourse
-          );
+  //         const newContent = insertLinesAfterFirstLine(
+  //           updatedContent,
+  //           teleporterCourse
+  //         );
 
-          return {
-            filename: "overview.md",
-            content: `---
-tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-description: Teleporter is a messaging protocol built on top of Avalanche Warp Messaging that provides a developer-friendly interface for sending and receiving cross-chain messages from within the EVM.
-keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-sidebar_label: Overview
-sidebar_position: 1
----
+  //         return {
+  //           filename: "overview.md",
+  //           content: `---
+  //   tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+  //   description: Teleporter is a messaging protocol built on top of Avalanche Warp Messaging that provides a developer-friendly interface for sending and receiving cross-chain messages from within the EVM.
+  //   keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+  //   sidebar_label: Overview
+  //   sidebar_position: 1
+  //   ---
 
-${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/build/cross-chain/teleporter/deep-dive.md
-      name: "teleporter-deep-dive",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/teleporter/main/",
-      documents: ["README.md"],
-      outDir: "docs/build/cross-chain/teleporter/",
-      // change file name and add metadata correct links
-      modifyContent(filename, content) {
-        if (filename.includes("README")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/ava-labs/teleporter/blob/main/"
-          );
+  //   ${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/build/cross-chain/teleporter/deep-dive.md
+  //     name: "teleporter-deep-dive",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/teleporter/main/",
+  //     documents: ["README.md"],
+  //     outDir: "docs/build/cross-chain/teleporter/",
+  //     // change file name and add metadata correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("README")) {
+  //         const updatedContent = replaceRelativeLinks(
+  //           content,
+  //           "https://github.com/ava-labs/teleporter/blob/main/"
+  //         );
 
-          return {
-            filename: "deep-dive.md",
-            content: `---
-tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-description: Teleporter is an EVM compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging (AWM), and implemented as a Solidity smart contract. It provides a mechanism to asynchronously invoke smart contract functions on other EVM blockchains within Avalanche. Teleporter provides a handful of useful features on top of AWM, such as specifying relayer incentives for message delivery, replay protection, message delivery and execution retries, and a standard interface for sending and receiving messages within a dApp deployed across multiple subnets.
-keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-sidebar_label: Deep Dive
-sidebar_position: 2
-title: Teleporter Deep Dive
----
+  //         return {
+  //           filename: "deep-dive.md",
+  //           content: `---
+  //   tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+  //   description: Teleporter is an EVM compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging (AWM), and implemented as a Solidity smart contract. It provides a mechanism to asynchronously invoke smart contract functions on other EVM blockchains within Avalanche. Teleporter provides a handful of useful features on top of AWM, such as specifying relayer incentives for message delivery, replay protection, message delivery and execution retries, and a standard interface for sending and receiving messages within a dApp deployed across multiple subnets.
+  //   keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+  //   sidebar_label: Deep Dive
+  //   sidebar_position: 2
+  //   title: Teleporter Deep Dive
+  //   ---
 
-${updatedContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/build/cross-chain/teleporter/cli.md
-      name: "teleporter-cli",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/teleporter/main/cmd/teleporter-cli/",
-      documents: ["README.md"],
-      outDir: "docs/build/cross-chain/teleporter/",
-      // change file name and add metadata correct links
-      modifyContent(filename, content) {
-        if (filename.includes("README")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/ava-labs/teleporter/blob/main/cmd/teleporter-cli/README.md"
-          );
+  //   ${updatedContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/build/cross-chain/teleporter/cli.md
+  //     name: "teleporter-cli",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/teleporter/main/cmd/teleporter-cli/",
+  //     documents: ["README.md"],
+  //     outDir: "docs/build/cross-chain/teleporter/",
+  //     // change file name and add metadata correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("README")) {
+  //         const updatedContent = replaceRelativeLinks(
+  //           content,
+  //           "https://github.com/ava-labs/teleporter/blob/main/cmd/teleporter-cli/README.md"
+  //         );
 
-          const newContent = insertLinesAfterFirstLine(
-            updatedContent,
-            teleporterCourse
-          );
+  //         const newContent = insertLinesAfterFirstLine(
+  //           updatedContent,
+  //           teleporterCourse
+  //         );
 
-          return {
-            filename: "cli.md",
-            content: `---
-tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-description: This page the source code for the Avalanche Teleporter CLI. The CLI is a command line interface for interacting with the Teleporter contracts. It is written with [cobra](https://github.com/spf13/cobra) commands as a Go application.
-keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication, teleporter cli ]
-sidebar_label: CLI
-sidebar_position: 6
----
+  //         return {
+  //           filename: "cli.md",
+  //           content: `---
+  //   tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+  //   description: This page the source code for the Avalanche Teleporter CLI. The CLI is a command line interface for interacting with the Teleporter contracts. It is written with [cobra](https://github.com/spf13/cobra) commands as a Go application.
+  //   keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication, teleporter cli ]
+  //   sidebar_label: CLI
+  //   sidebar_position: 6
+  //   ---
 
-${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/build/cross-chain/teleporter/upgradeability.md
-      name: "teleporter-upgradeability",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/upgrades/",
-      documents: ["README.md"],
-      outDir: "docs/build/cross-chain/teleporter/",
-      // change file name and add metadata correct links
-      modifyContent(filename, content) {
-        if (filename.includes("README")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/upgrades/"
-          );
+  //   ${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/build/cross-chain/teleporter/upgradeability.md
+  //     name: "teleporter-upgradeability",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/upgrades/",
+  //     documents: ["README.md"],
+  //     outDir: "docs/build/cross-chain/teleporter/",
+  //     // change file name and add metadata correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("README")) {
+  //         const updatedContent = replaceRelativeLinks(
+  //           content,
+  //           "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/upgrades/"
+  //         );
 
-          const newContent = insertLinesAfterFirstLine(
-            updatedContent,
-            teleporterCourse
-          );
+  //         const newContent = insertLinesAfterFirstLine(
+  //           updatedContent,
+  //           teleporterCourse
+  //         );
 
-          return {
-            filename: "upgradeability.md",
-            content: `---
-tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-description: Teleporter is an EVM-compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging. The TeleporterMessenger contract is non-upgradable, once a version of the contract is deployed it cannot be changed. However, there could still be new versions of TeleporterMessenger contracts needed to be deployed in the future.
-keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-sidebar_label: Upgradeability 
-sidebar_position: 5
----
+  //         return {
+  //           filename: "upgradeability.md",
+  //           content: `---
+  //   tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+  //   description: Teleporter is an EVM-compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging. The TeleporterMessenger contract is non-upgradable, once a version of the contract is deployed it cannot be changed. However, there could still be new versions of TeleporterMessenger contracts needed to be deployed in the future.
+  //   keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+  //   sidebar_label: Upgradeability
+  //   sidebar_position: 5
+  //   ---
 
-${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/build/cross-chain/teleporter/evm-integration.md
-      name: "awm-evm-integration",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/meaghanfitzgerald/coreth/docs-integration/precompile/contracts/warp/",
-      documents: ["README.md"],
-      outDir: "docs/build/cross-chain/awm/",
-      // change file name and add metadata correct links
-      modifyContent(filename, content) {
-        if (filename.includes("README")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/ava-labs/coreth/blob/master/precompile/contracts/warp/"
-          );
-          return {
-            filename: "evm-integration.md",
-            content: `---
-tags: [Avalanche Warp Messaging, Coreth, Subnet-EVM, Cross-Subnet Communication, Cross-Chain Communication]
-description: Avalanche Warp Messaging provides a basic primitive for signing and verifying messages between Subnets. The receiving network can verify whether an aggregation of signatures from a set of source Subnet validators represents a threshold of stake large enough for the receiving network to process the message. The Avalanche Warp Precompile enables this flow to send a message from blockchain A to blockchain B.
-keywords: [ coreth, subnet-evm, docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-sidebar_label: EVM Integration 
-sidebar_position: 2
----
+  //   ${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/build/cross-chain/teleporter/evm-integration.md
+  //     name: "awm-evm-integration",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/meaghanfitzgerald/coreth/docs-integration/precompile/contracts/warp/",
+  //     documents: ["README.md"],
+  //     outDir: "docs/build/cross-chain/awm/",
+  //     // change file name and add metadata correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("README")) {
+  //         const updatedContent = replaceRelativeLinks(
+  //           content,
+  //           "https://github.com/ava-labs/coreth/blob/master/precompile/contracts/warp/"
+  //         );
+  //         return {
+  //           filename: "evm-integration.md",
+  //           content: `---
+  // tags: [Avalanche Warp Messaging, Coreth, Subnet-EVM, Cross-Subnet Communication, Cross-Chain Communication]
+  // description: Avalanche Warp Messaging provides a basic primitive for signing and verifying messages between Subnets. The receiving network can verify whether an aggregation of signatures from a set of source Subnet validators represents a threshold of stake large enough for the receiving network to process the message. The Avalanche Warp Precompile enables this flow to send a message from blockchain A to blockchain B.
+  // keywords: [ coreth, subnet-evm, docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+  // sidebar_label: EVM Integration
+  // sidebar_position: 2
+  // ---
 
-${updatedContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/learn/acp.md
-      name: "acp-overview",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/meaghanfitzgerald/ACPs/main/",
-      documents: ["README.md"],
-      outDir: "docs/learn/",
-      // change file name and add metadata, correct links
-      modifyContent(filename, content) {
-        if (filename.includes("README")) {
-          const updatedContent = replaceRelativeLinks(
-            content,
-            "https://github.com/avalanche-foundation/ACPs/blob/main/"
-          );
-          return {
-            filename: "acp.md",
-            content: `---
-tags: [Avalanche Community Proposals, ACPs]
-description: An Avalanche Community Proposal is a concise document that introduces a change or best practice for adoption on the Avalanche Network. ACPs should provide clear technical specifications of any proposals and a compelling rationale for their adoption. ACPs are an open framework for proposing improvements and gathering consensus around changes to the Avalanche Network. ACPs can be proposed by anyone. 
-keywords: [ avalanche, nodes, preference, avalanche improvements, open source, acps, avalanche community proposals ]
-sidebar_label: Avalanche Community Proposals
-sidebar_position: 0
----
-
-${updatedContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/reference/p-chain/api.md
-      name: "p-api",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/platformvm/",
-      documents: ["service.md"],
-      outDir: "docs/reference/avalanchego/p-chain/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("service")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/service.md"
-          );
-          return {
-            filename: "api.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/reference/x-chain/api.md
-      name: "x-api",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/avm/",
-      documents: ["service.md"],
-      outDir: "docs/reference/avalanchego/x-chain/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("service")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/vms/avm/service.md"
-          );
-          return {
-            filename: "api.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/reference/admin-api.md
-      name: "admin-api",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/admin/",
-      documents: ["service.md"],
-      outDir: "docs/reference/avalanchego/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("service")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/api/admin/service.md"
-          );
-          return {
-            filename: "admin-api.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/reference/health-api.md
-      name: "health-api",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/health/",
-      documents: ["service.md"],
-      outDir: "docs/reference/avalanchego/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("service")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/api/health/service.md"
-          );
-          return {
-            filename: "health-api.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/reference/info-api.md
-      name: "info-api",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/info/",
-      documents: ["service.md"],
-      outDir: "docs/reference/avalanchego/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("service")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/api/info/service.md"
-          );
-          return {
-            filename: "info-api.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/reference/metrics-api.md
-      name: "metrics-api",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/metrics/",
-      documents: ["service.md"],
-      outDir: "docs/reference/avalanchego/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("service")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/api/metrics/service.md"
-          );
-          return {
-            filename: "metrics-api.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/reference/keystore-api.md
-      name: "keystore-api",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/keystore/",
-      documents: ["service.md"],
-      outDir: "docs/reference/avalanchego/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("service")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/api/keystore/service.md"
-          );
-          return {
-            filename: "keystore-api.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/reference/index-api.md
-      name: "index-api",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/indexer/",
-      documents: ["service.md"],
-      outDir: "docs/reference/avalanchego/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("service")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/indexer/service.md"
-          );
-          return {
-            filename: "index-api.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/nodes/configure/avalanchego-config-flags.md
-      name: "avalanchego-config-flags",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/config/",
-      documents: ["config.md"],
-      outDir: "docs/nodes/configure/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("config")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/config/config.md"
-          );
-          return {
-            filename: "avalanchego-config-flags.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/nodes/configure/subnet-configs.md
-      name: "subnet-configs",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/subnets/",
-      documents: ["config.md"],
-      outDir: "docs/nodes/configure/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("config")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/subnets/config.md"
-          );
-          return {
-            filename: "subnet-configs.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
-  [
-    "docusaurus-plugin-remote-content",
-    {
-      // /docs/nodes/configure/chain-configs/P.md
-      name: "P-configs",
-      sourceBaseUrl:
-        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/platformvm/config/",
-      documents: ["config.md"],
-      outDir: "docs/nodes/configure/chain-configs/",
-      // change filename and correct links
-      modifyContent(filename, content) {
-        if (filename.includes("config")) {
-          const newContent = insertSourceDocLink(
-            content,
-            "https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/config/config.md"
-          );
-          return {
-            filename: "P.md",
-            content: `${newContent}`,
-          };
-        }
-        return undefined;
-      },
-    },
-  ],
+  // ${updatedContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/reference/p-chain/api.md
+  //     name: "p-api",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/platformvm/",
+  //     documents: ["service.md"],
+  //     outDir: "docs/reference/avalanchego/p-chain/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("service")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/service.md"
+  //         );
+  //         return {
+  //           filename: "api.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/reference/x-chain/api.md
+  //     name: "x-api",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/avm/",
+  //     documents: ["service.md"],
+  //     outDir: "docs/reference/avalanchego/x-chain/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("service")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/vms/avm/service.md"
+  //         );
+  //         return {
+  //           filename: "api.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/reference/admin-api.md
+  //     name: "admin-api",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/admin/",
+  //     documents: ["service.md"],
+  //     outDir: "docs/reference/avalanchego/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("service")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/api/admin/service.md"
+  //         );
+  //         return {
+  //           filename: "admin-api.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/reference/health-api.md
+  //     name: "health-api",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/health/",
+  //     documents: ["service.md"],
+  //     outDir: "docs/reference/avalanchego/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("service")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/api/health/service.md"
+  //         );
+  //         return {
+  //           filename: "health-api.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/reference/info-api.md
+  //     name: "info-api",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/info/",
+  //     documents: ["service.md"],
+  //     outDir: "docs/reference/avalanchego/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("service")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/api/info/service.md"
+  //         );
+  //         return {
+  //           filename: "info-api.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/reference/metrics-api.md
+  //     name: "metrics-api",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/metrics/",
+  //     documents: ["service.md"],
+  //     outDir: "docs/reference/avalanchego/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("service")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/api/metrics/service.md"
+  //         );
+  //         return {
+  //           filename: "metrics-api.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/reference/keystore-api.md
+  //     name: "keystore-api",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/keystore/",
+  //     documents: ["service.md"],
+  //     outDir: "docs/reference/avalanchego/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("service")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/api/keystore/service.md"
+  //         );
+  //         return {
+  //           filename: "keystore-api.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/reference/index-api.md
+  //     name: "index-api",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/indexer/",
+  //     documents: ["service.md"],
+  //     outDir: "docs/reference/avalanchego/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("service")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/indexer/service.md"
+  //         );
+  //         return {
+  //           filename: "index-api.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/nodes/configure/avalanchego-config-flags.md
+  //     name: "avalanchego-config-flags",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/config/",
+  //     documents: ["config.md"],
+  //     outDir: "docs/nodes/configure/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("config")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/config/config.md"
+  //         );
+  //         return {
+  //           filename: "avalanchego-config-flags.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/nodes/configure/subnet-configs.md
+  //     name: "subnet-configs",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/subnets/",
+  //     documents: ["config.md"],
+  //     outDir: "docs/nodes/configure/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("config")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/subnets/config.md"
+  //         );
+  //         return {
+  //           filename: "subnet-configs.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
+  // [
+  //   "docusaurus-plugin-remote-content",
+  //   {
+  //     // /docs/nodes/configure/chain-configs/P.md
+  //     name: "P-configs",
+  //     sourceBaseUrl:
+  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/platformvm/config/",
+  //     documents: ["config.md"],
+  //     outDir: "docs/nodes/configure/chain-configs/",
+  //     // change filename and correct links
+  //     modifyContent(filename, content) {
+  //       if (filename.includes("config")) {
+  //         const newContent = insertSourceDocLink(
+  //           content,
+  //           "https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/config/config.md"
+  //         );
+  //         return {
+  //           filename: "P.md",
+  //           content: `${newContent}`,
+  //         };
+  //       }
+  //       return undefined;
+  //     },
+  //   },
+  // ],
   [
     "docusaurus-plugin-remote-content",
     {

--- a/configs/remoteContent.js
+++ b/configs/remoteContent.js
@@ -313,7 +313,7 @@ ${newContent}`,
         "https://raw.githubusercontent.com/ava-labs/coreth/master/precompile/contracts/warp/",
       documents: ["README.md"],
       outDir: "docs/build/cross-chain/awm/",
-      // change file name and add metadata correct links
+      // change the file name and add metadata correct links
       modifyContent(filename, content) {
         if (filename.includes("README")) {
           const updatedContent = replaceRelativeLinks(

--- a/configs/remoteContent.js
+++ b/configs/remoteContent.js
@@ -113,505 +113,505 @@ ${updatedContent}`,
       },
     },
   ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/build/cross-chain/awm/relayer.md
-  //     name: "relayer-overview",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/awm-relayer/main/",
-  //     documents: ["README.md"],
-  //     outDir: "docs/build/cross-chain/awm/",
-  //     // change file name and add metadata correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("README")) {
-  //         const updatedContent = replaceRelativeLinks(
-  //           content,
-  //           "https://github.com/ava-labs/awm-relayer/blob/main/"
-  //         );
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/build/cross-chain/awm/relayer.md
+      name: "relayer-overview",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/awm-relayer/main/",
+      documents: ["README.md"],
+      outDir: "docs/build/cross-chain/awm/",
+      // change file name and add metadata correct links
+      modifyContent(filename, content) {
+        if (filename.includes("README")) {
+          const updatedContent = replaceRelativeLinks(
+            content,
+            "https://github.com/ava-labs/awm-relayer/blob/main/"
+          );
 
-  //         const newContent = insertLinesAfterFirstLine(
-  //           updatedContent,
-  //           teleporterCourse
-  //         );
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            teleporterCourse
+          );
 
-  //         return {
-  //           filename: "relayer.md",
-  //           content: `---
-  // tags: [Avalanche Warp Messaging, Relayer]
-  // description: Reference relayer implementation for cross-chain Avalanche Warp Message delivery.
-  // keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-  // sidebar_label: Run a Relayer
-  // sidebar_position: 3
-  // ---
+          return {
+            filename: "relayer.md",
+            content: `---
+  tags: [Avalanche Warp Messaging, Relayer]
+  description: Reference relayer implementation for cross-chain Avalanche Warp Message delivery.
+  keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+  sidebar_label: Run a Relayer
+  sidebar_position: 3
+  ---
 
-  // ${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/build/cross-chain/teleporter/overview.md
-  //     name: "teleporter-overview",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/",
-  //     documents: ["README.md"],
-  //     outDir: "docs/build/cross-chain/teleporter/",
-  //     // change file name and add metadata correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("README")) {
-  //         const updatedContent = replaceRelativeLinks(
-  //           content,
-  //           "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/"
-  //         );
+  ${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/build/cross-chain/teleporter/overview.md
+      name: "teleporter-overview",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/",
+      documents: ["README.md"],
+      outDir: "docs/build/cross-chain/teleporter/",
+      // change file name and add metadata correct links
+      modifyContent(filename, content) {
+        if (filename.includes("README")) {
+          const updatedContent = replaceRelativeLinks(
+            content,
+            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/"
+          );
 
-  //         const newContent = insertLinesAfterFirstLine(
-  //           updatedContent,
-  //           teleporterCourse
-  //         );
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            teleporterCourse
+          );
 
-  //         return {
-  //           filename: "overview.md",
-  //           content: `---
-  //   tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-  //   description: Teleporter is a messaging protocol built on top of Avalanche Warp Messaging that provides a developer-friendly interface for sending and receiving cross-chain messages from within the EVM.
-  //   keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-  //   sidebar_label: Overview
-  //   sidebar_position: 1
-  //   ---
+          return {
+            filename: "overview.md",
+            content: `---
+    tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+    description: Teleporter is a messaging protocol built on top of Avalanche Warp Messaging that provides a developer-friendly interface for sending and receiving cross-chain messages from within the EVM.
+    keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+    sidebar_label: Overview
+    sidebar_position: 1
+    ---
 
-  //   ${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/build/cross-chain/teleporter/deep-dive.md
-  //     name: "teleporter-deep-dive",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/teleporter/main/",
-  //     documents: ["README.md"],
-  //     outDir: "docs/build/cross-chain/teleporter/",
-  //     // change file name and add metadata correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("README")) {
-  //         const updatedContent = replaceRelativeLinks(
-  //           content,
-  //           "https://github.com/ava-labs/teleporter/blob/main/"
-  //         );
+    ${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/build/cross-chain/teleporter/deep-dive.md
+      name: "teleporter-deep-dive",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/teleporter/main/",
+      documents: ["README.md"],
+      outDir: "docs/build/cross-chain/teleporter/",
+      // change file name and add metadata correct links
+      modifyContent(filename, content) {
+        if (filename.includes("README")) {
+          const updatedContent = replaceRelativeLinks(
+            content,
+            "https://github.com/ava-labs/teleporter/blob/main/"
+          );
 
-  //         return {
-  //           filename: "deep-dive.md",
-  //           content: `---
-  //   tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-  //   description: Teleporter is an EVM compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging (AWM), and implemented as a Solidity smart contract. It provides a mechanism to asynchronously invoke smart contract functions on other EVM blockchains within Avalanche. Teleporter provides a handful of useful features on top of AWM, such as specifying relayer incentives for message delivery, replay protection, message delivery and execution retries, and a standard interface for sending and receiving messages within a dApp deployed across multiple subnets.
-  //   keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-  //   sidebar_label: Deep Dive
-  //   sidebar_position: 2
-  //   title: Teleporter Deep Dive
-  //   ---
+          return {
+            filename: "deep-dive.md",
+            content: `---
+    tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+    description: Teleporter is an EVM compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging (AWM), and implemented as a Solidity smart contract. It provides a mechanism to asynchronously invoke smart contract functions on other EVM blockchains within Avalanche. Teleporter provides a handful of useful features on top of AWM, such as specifying relayer incentives for message delivery, replay protection, message delivery and execution retries, and a standard interface for sending and receiving messages within a dApp deployed across multiple subnets.
+    keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+    sidebar_label: Deep Dive
+    sidebar_position: 2
+    title: Teleporter Deep Dive
+    ---
 
-  //   ${updatedContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/build/cross-chain/teleporter/cli.md
-  //     name: "teleporter-cli",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/teleporter/main/cmd/teleporter-cli/",
-  //     documents: ["README.md"],
-  //     outDir: "docs/build/cross-chain/teleporter/",
-  //     // change file name and add metadata correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("README")) {
-  //         const updatedContent = replaceRelativeLinks(
-  //           content,
-  //           "https://github.com/ava-labs/teleporter/blob/main/cmd/teleporter-cli/README.md"
-  //         );
+    ${updatedContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/build/cross-chain/teleporter/cli.md
+      name: "teleporter-cli",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/teleporter/main/cmd/teleporter-cli/",
+      documents: ["README.md"],
+      outDir: "docs/build/cross-chain/teleporter/",
+      // change file name and add metadata correct links
+      modifyContent(filename, content) {
+        if (filename.includes("README")) {
+          const updatedContent = replaceRelativeLinks(
+            content,
+            "https://github.com/ava-labs/teleporter/blob/main/cmd/teleporter-cli/README.md"
+          );
 
-  //         const newContent = insertLinesAfterFirstLine(
-  //           updatedContent,
-  //           teleporterCourse
-  //         );
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            teleporterCourse
+          );
 
-  //         return {
-  //           filename: "cli.md",
-  //           content: `---
-  //   tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-  //   description: This page the source code for the Avalanche Teleporter CLI. The CLI is a command line interface for interacting with the Teleporter contracts. It is written with [cobra](https://github.com/spf13/cobra) commands as a Go application.
-  //   keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication, teleporter cli ]
-  //   sidebar_label: CLI
-  //   sidebar_position: 6
-  //   ---
+          return {
+            filename: "cli.md",
+            content: `---
+    tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+    description: This page the source code for the Avalanche Teleporter CLI. The CLI is a command line interface for interacting with the Teleporter contracts. It is written with [cobra](https://github.com/spf13/cobra) commands as a Go application.
+    keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication, teleporter cli ]
+    sidebar_label: CLI
+    sidebar_position: 6
+    ---
 
-  //   ${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/build/cross-chain/teleporter/upgradeability.md
-  //     name: "teleporter-upgradeability",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/upgrades/",
-  //     documents: ["README.md"],
-  //     outDir: "docs/build/cross-chain/teleporter/",
-  //     // change file name and add metadata correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("README")) {
-  //         const updatedContent = replaceRelativeLinks(
-  //           content,
-  //           "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/upgrades/"
-  //         );
+    ${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/build/cross-chain/teleporter/upgradeability.md
+      name: "teleporter-upgradeability",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/teleporter/main/contracts/src/Teleporter/upgrades/",
+      documents: ["README.md"],
+      outDir: "docs/build/cross-chain/teleporter/",
+      // change file name and add metadata correct links
+      modifyContent(filename, content) {
+        if (filename.includes("README")) {
+          const updatedContent = replaceRelativeLinks(
+            content,
+            "https://github.com/ava-labs/teleporter/blob/main/contracts/src/Teleporter/upgrades/"
+          );
 
-  //         const newContent = insertLinesAfterFirstLine(
-  //           updatedContent,
-  //           teleporterCourse
-  //         );
+          const newContent = insertLinesAfterFirstLine(
+            updatedContent,
+            teleporterCourse
+          );
 
-  //         return {
-  //           filename: "upgradeability.md",
-  //           content: `---
-  //   tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
-  //   description: Teleporter is an EVM-compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging. The TeleporterMessenger contract is non-upgradable, once a version of the contract is deployed it cannot be changed. However, there could still be new versions of TeleporterMessenger contracts needed to be deployed in the future.
-  //   keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-  //   sidebar_label: Upgradeability
-  //   sidebar_position: 5
-  //   ---
+          return {
+            filename: "upgradeability.md",
+            content: `---
+    tags: [Teleporter, Cross-Subnet Communication, Cross-Chain Communication]
+    description: Teleporter is an EVM-compatible cross-subnet communication protocol built on top of Avalanche Warp Messaging. The TeleporterMessenger contract is non-upgradable, once a version of the contract is deployed it cannot be changed. However, there could still be new versions of TeleporterMessenger contracts needed to be deployed in the future.
+    keywords: [ docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+    sidebar_label: Upgradeability
+    sidebar_position: 5
+    ---
 
-  //   ${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/build/cross-chain/teleporter/evm-integration.md
-  //     name: "awm-evm-integration",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/meaghanfitzgerald/coreth/docs-integration/precompile/contracts/warp/",
-  //     documents: ["README.md"],
-  //     outDir: "docs/build/cross-chain/awm/",
-  //     // change file name and add metadata correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("README")) {
-  //         const updatedContent = replaceRelativeLinks(
-  //           content,
-  //           "https://github.com/ava-labs/coreth/blob/master/precompile/contracts/warp/"
-  //         );
-  //         return {
-  //           filename: "evm-integration.md",
-  //           content: `---
-  // tags: [Avalanche Warp Messaging, Coreth, Subnet-EVM, Cross-Subnet Communication, Cross-Chain Communication]
-  // description: Avalanche Warp Messaging provides a basic primitive for signing and verifying messages between Subnets. The receiving network can verify whether an aggregation of signatures from a set of source Subnet validators represents a threshold of stake large enough for the receiving network to process the message. The Avalanche Warp Precompile enables this flow to send a message from blockchain A to blockchain B.
-  // keywords: [ coreth, subnet-evm, docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
-  // sidebar_label: EVM Integration
-  // sidebar_position: 2
-  // ---
+    ${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/build/cross-chain/teleporter/evm-integration.md
+      name: "awm-evm-integration",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/meaghanfitzgerald/coreth/docs-integration/precompile/contracts/warp/",
+      documents: ["README.md"],
+      outDir: "docs/build/cross-chain/awm/",
+      // change file name and add metadata correct links
+      modifyContent(filename, content) {
+        if (filename.includes("README")) {
+          const updatedContent = replaceRelativeLinks(
+            content,
+            "https://github.com/ava-labs/coreth/blob/master/precompile/contracts/warp/"
+          );
+          return {
+            filename: "evm-integration.md",
+            content: `---
+  tags: [Avalanche Warp Messaging, Coreth, Subnet-EVM, Cross-Subnet Communication, Cross-Chain Communication]
+  description: Avalanche Warp Messaging provides a basic primitive for signing and verifying messages between Subnets. The receiving network can verify whether an aggregation of signatures from a set of source Subnet validators represents a threshold of stake large enough for the receiving network to process the message. The Avalanche Warp Precompile enables this flow to send a message from blockchain A to blockchain B.
+  keywords: [ coreth, subnet-evm, docs, documentation, avalanche, teleporter, awm, cross-subnet communication, cross-chain, cross-chain communication ]
+  sidebar_label: EVM Integration
+  sidebar_position: 2
+  ---
 
-  // ${updatedContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/reference/p-chain/api.md
-  //     name: "p-api",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/platformvm/",
-  //     documents: ["service.md"],
-  //     outDir: "docs/reference/avalanchego/p-chain/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("service")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/service.md"
-  //         );
-  //         return {
-  //           filename: "api.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/reference/x-chain/api.md
-  //     name: "x-api",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/avm/",
-  //     documents: ["service.md"],
-  //     outDir: "docs/reference/avalanchego/x-chain/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("service")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/vms/avm/service.md"
-  //         );
-  //         return {
-  //           filename: "api.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/reference/admin-api.md
-  //     name: "admin-api",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/admin/",
-  //     documents: ["service.md"],
-  //     outDir: "docs/reference/avalanchego/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("service")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/api/admin/service.md"
-  //         );
-  //         return {
-  //           filename: "admin-api.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/reference/health-api.md
-  //     name: "health-api",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/health/",
-  //     documents: ["service.md"],
-  //     outDir: "docs/reference/avalanchego/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("service")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/api/health/service.md"
-  //         );
-  //         return {
-  //           filename: "health-api.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/reference/info-api.md
-  //     name: "info-api",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/info/",
-  //     documents: ["service.md"],
-  //     outDir: "docs/reference/avalanchego/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("service")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/api/info/service.md"
-  //         );
-  //         return {
-  //           filename: "info-api.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/reference/metrics-api.md
-  //     name: "metrics-api",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/metrics/",
-  //     documents: ["service.md"],
-  //     outDir: "docs/reference/avalanchego/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("service")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/api/metrics/service.md"
-  //         );
-  //         return {
-  //           filename: "metrics-api.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/reference/keystore-api.md
-  //     name: "keystore-api",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/keystore/",
-  //     documents: ["service.md"],
-  //     outDir: "docs/reference/avalanchego/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("service")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/api/keystore/service.md"
-  //         );
-  //         return {
-  //           filename: "keystore-api.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/reference/index-api.md
-  //     name: "index-api",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/indexer/",
-  //     documents: ["service.md"],
-  //     outDir: "docs/reference/avalanchego/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("service")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/indexer/service.md"
-  //         );
-  //         return {
-  //           filename: "index-api.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/nodes/configure/avalanchego-config-flags.md
-  //     name: "avalanchego-config-flags",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/config/",
-  //     documents: ["config.md"],
-  //     outDir: "docs/nodes/configure/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("config")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/config/config.md"
-  //         );
-  //         return {
-  //           filename: "avalanchego-config-flags.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/nodes/configure/subnet-configs.md
-  //     name: "subnet-configs",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/subnets/",
-  //     documents: ["config.md"],
-  //     outDir: "docs/nodes/configure/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("config")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/subnets/config.md"
-  //         );
-  //         return {
-  //           filename: "subnet-configs.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
-  // [
-  //   "docusaurus-plugin-remote-content",
-  //   {
-  //     // /docs/nodes/configure/chain-configs/P.md
-  //     name: "P-configs",
-  //     sourceBaseUrl:
-  //       "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/platformvm/config/",
-  //     documents: ["config.md"],
-  //     outDir: "docs/nodes/configure/chain-configs/",
-  //     // change filename and correct links
-  //     modifyContent(filename, content) {
-  //       if (filename.includes("config")) {
-  //         const newContent = insertSourceDocLink(
-  //           content,
-  //           "https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/config/config.md"
-  //         );
-  //         return {
-  //           filename: "P.md",
-  //           content: `${newContent}`,
-  //         };
-  //       }
-  //       return undefined;
-  //     },
-  //   },
-  // ],
+  ${updatedContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/reference/p-chain/api.md
+      name: "p-api",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/platformvm/",
+      documents: ["service.md"],
+      outDir: "docs/reference/avalanchego/p-chain/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("service")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/service.md"
+          );
+          return {
+            filename: "api.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/reference/x-chain/api.md
+      name: "x-api",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/avm/",
+      documents: ["service.md"],
+      outDir: "docs/reference/avalanchego/x-chain/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("service")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/vms/avm/service.md"
+          );
+          return {
+            filename: "api.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/reference/admin-api.md
+      name: "admin-api",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/admin/",
+      documents: ["service.md"],
+      outDir: "docs/reference/avalanchego/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("service")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/api/admin/service.md"
+          );
+          return {
+            filename: "admin-api.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/reference/health-api.md
+      name: "health-api",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/health/",
+      documents: ["service.md"],
+      outDir: "docs/reference/avalanchego/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("service")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/api/health/service.md"
+          );
+          return {
+            filename: "health-api.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/reference/info-api.md
+      name: "info-api",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/info/",
+      documents: ["service.md"],
+      outDir: "docs/reference/avalanchego/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("service")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/api/info/service.md"
+          );
+          return {
+            filename: "info-api.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/reference/metrics-api.md
+      name: "metrics-api",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/metrics/",
+      documents: ["service.md"],
+      outDir: "docs/reference/avalanchego/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("service")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/api/metrics/service.md"
+          );
+          return {
+            filename: "metrics-api.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/reference/keystore-api.md
+      name: "keystore-api",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/api/keystore/",
+      documents: ["service.md"],
+      outDir: "docs/reference/avalanchego/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("service")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/api/keystore/service.md"
+          );
+          return {
+            filename: "keystore-api.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/reference/index-api.md
+      name: "index-api",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/indexer/",
+      documents: ["service.md"],
+      outDir: "docs/reference/avalanchego/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("service")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/indexer/service.md"
+          );
+          return {
+            filename: "index-api.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/nodes/configure/avalanchego-config-flags.md
+      name: "avalanchego-config-flags",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/config/",
+      documents: ["config.md"],
+      outDir: "docs/nodes/configure/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("config")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/config/config.md"
+          );
+          return {
+            filename: "avalanchego-config-flags.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/nodes/configure/subnet-configs.md
+      name: "subnet-configs",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/subnets/",
+      documents: ["config.md"],
+      outDir: "docs/nodes/configure/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("config")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/subnets/config.md"
+          );
+          return {
+            filename: "subnet-configs.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
+  [
+    "docusaurus-plugin-remote-content",
+    {
+      // /docs/nodes/configure/chain-configs/P.md
+      name: "P-configs",
+      sourceBaseUrl:
+        "https://raw.githubusercontent.com/ava-labs/avalanchego/master/vms/platformvm/config/",
+      documents: ["config.md"],
+      outDir: "docs/nodes/configure/chain-configs/",
+      // change filename and correct links
+      modifyContent(filename, content) {
+        if (filename.includes("config")) {
+          const newContent = insertSourceDocLink(
+            content,
+            "https://github.com/ava-labs/avalanchego/tree/master/vms/platformvm/config/config.md"
+          );
+          return {
+            filename: "P.md",
+            content: `${newContent}`,
+          };
+        }
+        return undefined;
+      },
+    },
+  ],
   [
     "docusaurus-plugin-remote-content",
     {

--- a/docs/learn/acp.md
+++ b/docs/learn/acp.md
@@ -37,41 +37,41 @@ There are three kinds of ACP:
 There are four statuses of an ACP:
 
 - A `Proposed` ACP has been merged into the main branch of the ACP repository. It is actively being discussed by the Avalanche Community and may be modified based on feedback.
-- An `Implementable` ACP is considered "ready for implementation" by the author(s) and will no longer change meaningfully from its current form (which would require a new ACP).
+- An `Implementable` ACP is considered "ready for implementation" by the author and will no longer change meaningfully from its current form (which would require a new ACP).
 - An `Activated` ACP has been activated on the Avalanche Network via a coordinated upgrade by the Avalanche Community. Once an ACP is `Activated`, it is locked.
-- A `Stale` ACP has been abandoned by its author(s) because it is not supported by the Avalanche Community or has been replaced with another ACP.
+- A `Stale` ACP has been abandoned by its author because it is not supported by the Avalanche Community or has been replaced with another ACP.
 
 ## ACP Workflow
 
 ### Step 0: Think of a Novel Improvement to Avalanche
 
-The ACP process begins with a new idea for Avalanche. Each potential ACP must have an author(s): someone who writes the ACP using the style and format described below, shepherds the associated GitHub Discussion, and attempts to build consensus around the idea. Note that ideas and any resulting ACP is public. Authors should not post any ideas or anything in an ACP that the Author wants to keep confidential or to keep ownership rights in (such as intellectual property rights).
+The ACP process begins with a new idea for Avalanche. Each potential ACP must have an author: someone who writes the ACP using the style and format described below, shepherds the associated GitHub Discussion, and attempts to build consensus around the idea. Note that ideas and any resulting ACP is public. Authors should not post any ideas or anything in an ACP that the Author wants to keep confidential or to keep ownership rights in (such as intellectual property rights).
 
 ### Step 1: Post Your Idea to [GitHub Discussions](https://github.com/avalanche-foundation/ACPs/discussions/categories/ideas)
 
-The author(s) should first attempt to ascertain whether there is support for their idea by posting in the "Ideas" category of GitHub Discussions. Vetting an idea publicly before going as far as writing an ACP is meant to save both the potential author(s) and the wider Avalanche Community time. Asking the Avalanche Community first if an idea is original helps prevent too much time being spent on something that is guaranteed to be rejected based on prior discussions (searching the Internet does not always do the trick). It also helps to make sure the idea is applicable to the entire community and not just the author(s). Small enhancements or patches often don't need standardization between multiple projects; these don't need an ACP and should be injected into the relevant development workflow with a patch submission to the applicable ANC issue tracker.
+The author should first attempt to ascertain whether there is support for their idea by posting in the "Ideas" category of GitHub Discussions. Vetting an idea publicly before going as far as writing an ACP is meant to save both the potential author and the wider Avalanche Community time. Asking the Avalanche Community first if an idea is original helps prevent too much time being spent on something that is guaranteed to be rejected based on prior discussions (searching the Internet does not always do the trick). It also helps to make sure the idea is applicable to the entire community and not just the author. Small enhancements or patches often don't need standardization between multiple projects; these don't need an ACP and should be injected into the relevant development workflow with a patch submission to the applicable ANC issue tracker.
 
 ### Step 2: Propose an ACP via [Pull Request](https://github.com/avalanche-foundation/ACPs/pulls)
 
-Once the author(s) feels confident that an idea has a decent chance of acceptance, an ACP should be drafted and submitted as a pull request (PR). This draft must be written in ACP style as described below. It is highly recommended that a single ACP contain a single key proposal or new idea. The more focused the ACP, the more successful it tends to be. If in doubt, split your ACP into several well-focused ones. The PR number of the ACP will become its assigned number.
+Once the author feels confident that an idea has a decent chance of acceptance, an ACP should be drafted and submitted as a pull request (PR). This draft must be written in ACP style as described below. It is highly recommended that a single ACP contain a single key proposal or new idea. The more focused the ACP, the more successful it tends to be. If in doubt, split your ACP into several well-focused ones. The PR number of the ACP will become its assigned number.
 
 ### Step 3: Build Consensus on [GitHub Discussions](https://github.com/avalanche-foundation/ACPs/discussions/categories/discussion) and Provide an Implementation (if Applicable)
 
-ACPs will be merged by ACP maintainers if the proposal is generally well-formatted and coherent. ACP editors will attempt to merge anything worthy of discussion, regardless of feasibility or complexity, that is not a duplicate or incomplete. After an ACP is merged, an official GitHub Discussion will be opened for the ACP and linked to the proposal for community discussion. It is recommended for author(s) or supportive Avalanche Community members to post an accompanying non-technical overview of their ACP for general consumption in this GitHub Discussion. The ACP should be reviewed and broadly supported before a reference implementation is started, again to avoid wasting the author(s) and the Avalanche Community's time, unless a reference implementation will aid people in studying the ACP.
+ACPs will be merged by ACP maintainers if the proposal is generally well-formatted and coherent. ACP editors will attempt to merge anything worthy of discussion, regardless of feasibility or complexity, that is not a duplicate or incomplete. After an ACP is merged, an official GitHub Discussion will be opened for the ACP and linked to the proposal for community discussion. It is recommended for author or supportive Avalanche Community members to post an accompanying non-technical overview of their ACP for general consumption in this GitHub Discussion. The ACP should be reviewed and broadly supported before a reference implementation is started, again to avoid wasting the author and the Avalanche Community's time, unless a reference implementation will aid people in studying the ACP.
 
 ### Step 4: Mark ACP as `Implementable` via [Pull Request](https://github.com/avalanche-foundation/ACPs/pulls)
 
-Once an ACP is considered complete by the author(s), it should be marked as `Implementable`. At this point, all open questions should be addressed and an associated reference implementation should be provided (if applicable). As mentioned earlier, the Avalanche Foundation meets periodically to recommend the ratification of specific ACPs but it is ultimately up to members of the Avalanche Network/Community to adopt ACPs they support by running a compatible Avalanche Network Client (ANC), such as [AvalancheGo](https://github.com/ava-labs/avalanchego).
+Once an ACP is considered complete by the author, it should be marked as `Implementable`. At this point, all open questions should be addressed and an associated reference implementation should be provided (if applicable). As mentioned earlier, the Avalanche Foundation meets periodically to recommend the ratification of specific ACPs but it is ultimately up to members of the Avalanche Network/Community to adopt ACPs they support by running a compatible Avalanche Network Client (ANC), such as [AvalancheGo](https://github.com/ava-labs/avalanchego).
 
 ### [Optional] Step 5: Mark ACP as `Stale` via [Pull Request](https://github.com/avalanche-foundation/ACPs/pulls)
 
-An ACP can be superseded by a different ACP, rendering the original obsolete. If this occurs, the original ACP will be marked as `Stale`. ACPs may also be marked as `Stale` if the author(s) abandon work on it for a prolonged period of time (12+ months). ACPs may be reopened and moved back to `Proposed` if the author(s) restart work.
+An ACP can be superseded by a different ACP, rendering the original obsolete. If this occurs, the original ACP will be marked as `Stale`. ACPs may also be marked as `Stale` if the author abandon work on it for a prolonged period of time (12+ months). ACPs may be reopened and moved back to `Proposed` if the author restart work.
 
-## What belongs in a successful ACP?
+## What Belongs in a Successful ACP?
 
 Each ACP must have the following parts:
 
-- `Preamble`: Markdown table containing metadata about the ACP, including the ACP number, a short descriptive title, the author(s), and optionally the contact info for each author, etc.
+- `Preamble`: Markdown table containing metadata about the ACP, including the ACP number, a short descriptive title, the author, and optionally the contact info for each author, etc.
 - `Abstract`: Concise (~200 word) description of the ACP
 - `Motivation`: Rationale for adopting the ACP and the specific issue/challenge/opportunity it addresses
 - `Specification`: Complete description of the semantics of any change should allow any ANC/Avalanche Community member to implement the ACP

--- a/docs/learn/acp.md
+++ b/docs/learn/acp.md
@@ -1,0 +1,114 @@
+---
+tags: [Avalanche Community Proposals, ACPs]
+description: An Avalanche Community Proposal is a concise document that introduces a change or best practice for adoption on the Avalanche Network. ACPs should provide clear technical specifications of any proposals and a compelling rationale for their adoption. ACPs are an open framework for proposing improvements and gathering consensus around changes to the Avalanche Network. ACPs can be proposed by anyone.
+keywords:
+  [
+    avalanche,
+    nodes,
+    preference,
+    avalanche improvements,
+    open source,
+    acps,
+    avalanche community proposals,
+  ]
+sidebar_label: Avalanche Community Proposals
+sidebar_position: 0
+---
+
+# What is an Avalanche Community Proposal (ACP)?
+
+[<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512" width="30" height="30"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>](https://github.com/avalanche-foundation/ACPs)
+
+An Avalanche Community Proposal is a concise document that introduces a change or best practice for adoption on the [Avalanche Network](https://www.avax.com). ACPs should provide clear technical specifications of any proposals and a compelling rationale for their adoption.
+
+ACPs are an open framework for proposing improvements and gathering consensus around changes to the Avalanche Network. ACPs can be proposed by anyone and will be merged into this repository as long as they are well-formatted and coherent. Once an overwhelming majority of the Avalanche Network/Community have [signaled their support for an ACP](https://docs.avax.network/nodes/configure/avalanchego-config-flags#avalanche-community-proposals), it may be scheduled for activation on the Avalanche Network by Avalanche Network Clients (ANCs). It is ultimately up to members of the Avalanche Network/Community to adopt ACPs they support by running a compatible ANC, such as [AvalancheGo](https://github.com/ava-labs/avalanchego).
+
+## ACP Tracks
+
+There are three kinds of ACP:
+
+- A `Standards Track` ACP describes a change to the design or function of the Avalanche Network, such as a change to the P2P networking protocol, P-Chain design, Subnet architecture, or any change/addition that affects the interoperability of Avalanche Network Clients (ANCs).
+- A `Best Practices Track` ACP describes a design pattern or common interface that should be used across the Avalanche Network to make it easier to integrate with Avalanche or for Subnets to interoperate with each other. This would include things like proposing a smart contract interface, not proposing a change to how smart contracts are executed.
+- A `Meta Track` ACP describes a change to the ACP process or suggests a new way for the Avalanche Community to collaborate.
+- A `Subnet Track` ACP describes a change to a particular Subnet. This would include things like configuration changes or coordinated Subnet upgrades.
+
+## ACP Statuses
+
+There are four statuses of an ACP:
+
+- A `Proposed` ACP has been merged into the main branch of the ACP repository. It is actively being discussed by the Avalanche Community and may be modified based on feedback.
+- An `Implementable` ACP is considered "ready for implementation" by the author(s) and will no longer change meaningfully from its current form (which would require a new ACP).
+- An `Activated` ACP has been activated on the Avalanche Network via a coordinated upgrade by the Avalanche Community. Once an ACP is `Activated`, it is locked.
+- A `Stale` ACP has been abandoned by its author(s) because it is not supported by the Avalanche Community or has been replaced with another ACP.
+
+## ACP Workflow
+
+### Step 0: Think of a Novel Improvement to Avalanche
+
+The ACP process begins with a new idea for Avalanche. Each potential ACP must have an author(s): someone who writes the ACP using the style and format described below, shepherds the associated GitHub Discussion, and attempts to build consensus around the idea. Note that ideas and any resulting ACP is public. Authors should not post any ideas or anything in an ACP that the Author wants to keep confidential or to keep ownership rights in (such as intellectual property rights).
+
+### Step 1: Post Your Idea to [GitHub Discussions](https://github.com/avalanche-foundation/ACPs/discussions/categories/ideas)
+
+The author(s) should first attempt to ascertain whether there is support for their idea by posting in the "Ideas" category of GitHub Discussions. Vetting an idea publicly before going as far as writing an ACP is meant to save both the potential author(s) and the wider Avalanche Community time. Asking the Avalanche Community first if an idea is original helps prevent too much time being spent on something that is guaranteed to be rejected based on prior discussions (searching the Internet does not always do the trick). It also helps to make sure the idea is applicable to the entire community and not just the author(s). Small enhancements or patches often don't need standardization between multiple projects; these don't need an ACP and should be injected into the relevant development workflow with a patch submission to the applicable ANC issue tracker.
+
+### Step 2: Propose an ACP via [Pull Request](https://github.com/avalanche-foundation/ACPs/pulls)
+
+Once the author(s) feels confident that an idea has a decent chance of acceptance, an ACP should be drafted and submitted as a pull request (PR). This draft must be written in ACP style as described below. It is highly recommended that a single ACP contain a single key proposal or new idea. The more focused the ACP, the more successful it tends to be. If in doubt, split your ACP into several well-focused ones. The PR number of the ACP will become its assigned number.
+
+### Step 3: Build Consensus on [GitHub Discussions](https://github.com/avalanche-foundation/ACPs/discussions/categories/discussion) and Provide an Implementation (if Applicable)
+
+ACPs will be merged by ACP maintainers if the proposal is generally well-formatted and coherent. ACP editors will attempt to merge anything worthy of discussion, regardless of feasibility or complexity, that is not a duplicate or incomplete. After an ACP is merged, an official GitHub Discussion will be opened for the ACP and linked to the proposal for community discussion. It is recommended for author(s) or supportive Avalanche Community members to post an accompanying non-technical overview of their ACP for general consumption in this GitHub Discussion. The ACP should be reviewed and broadly supported before a reference implementation is started, again to avoid wasting the author(s) and the Avalanche Community's time, unless a reference implementation will aid people in studying the ACP.
+
+### Step 4: Mark ACP as `Implementable` via [Pull Request](https://github.com/avalanche-foundation/ACPs/pulls)
+
+Once an ACP is considered complete by the author(s), it should be marked as `Implementable`. At this point, all open questions should be addressed and an associated reference implementation should be provided (if applicable). As mentioned earlier, the Avalanche Foundation meets periodically to recommend the ratification of specific ACPs but it is ultimately up to members of the Avalanche Network/Community to adopt ACPs they support by running a compatible Avalanche Network Client (ANC), such as [AvalancheGo](https://github.com/ava-labs/avalanchego).
+
+### [Optional] Step 5: Mark ACP as `Stale` via [Pull Request](https://github.com/avalanche-foundation/ACPs/pulls)
+
+An ACP can be superseded by a different ACP, rendering the original obsolete. If this occurs, the original ACP will be marked as `Stale`. ACPs may also be marked as `Stale` if the author(s) abandon work on it for a prolonged period of time (12+ months). ACPs may be reopened and moved back to `Proposed` if the author(s) restart work.
+
+## What belongs in a successful ACP?
+
+Each ACP must have the following parts:
+
+- `Preamble`: Markdown table containing metadata about the ACP, including the ACP number, a short descriptive title, the author(s), and optionally the contact info for each author, etc.
+- `Abstract`: Concise (~200 word) description of the ACP
+- `Motivation`: Rationale for adopting the ACP and the specific issue/challenge/opportunity it addresses
+- `Specification`: Complete description of the semantics of any change should allow any ANC/Avalanche Community member to implement the ACP
+- `Security Considerations`: Security implications of the proposed ACP
+
+Each ACP can have the following parts:
+
+- `Open Questions`: Questions that should be resolved before implementation
+
+Each `Standards Track` ACP must have the following parts:
+
+- `Backwards Compatibility`: List of backwards incompatible changes required to implement the ACP and their impact on the Avalanche Community
+- `Reference Implementation`: Code, documentation, and telemetry (from a local network) of the ACP change
+
+Each `Best Practices Track` ACP can have the following parts:
+
+- `Backwards Compatibility`: List of backwards incompatible changes required to implement the ACP and their impact on the Avalanche Community
+- `Reference Implementation`: Code, documentation, and telemetry (from a local network) of the ACP change
+
+### ACP Formats and Templates
+
+Each ACP is allocated a unique subdirectory in the `ACPs` directory. The name of this subdirectory must be of the form `N-T` where `N` is the ACP number and `T` is the ACP title with any spaces replaced by hyphens. ACPs must be written in [markdown](https://daringfireball.net/projects/markdown/syntax) format and stored at `ACPs/N-T/README.md`. Please see the [ACP template](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/TEMPLATE.md) for an example of the correct layout.
+
+### Auxiliary Files
+
+ACPs may include auxiliary files such as diagrams or code snippets. Such files should be stored in the ACP's subdirectory (`ACPs/N-T/*`). There is no required naming convention for auxiliary files.
+
+### Waived Copyright
+
+ACP authors must waive any copyright claims before an ACP will be merged into the repository. This can be done by including the following text in an ACP:
+
+```text
+## Copyright
+
+Copyright and related rights waived via [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+```
+
+## Contributing
+
+Before contributing to ACPs, please read the [ACP Terms of Contribution](https://github.com/avalanche-foundation/ACPs/blob/main/CONTRIBUTING.md).

--- a/i18n/es/docusaurus-plugin-content-docs/current/learn/acp.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/learn/acp.md
@@ -1,7 +1,7 @@
 ---
-etiquetas: [Propuestas de la Comunidad Avalanche, ACPs]
-descripción: Una Propuesta de la Comunidad Avalanche es un documento conciso que introduce un cambio o una mejor práctica para su adopción en la Red Avalanche. Las ACPs deben proporcionar especificaciones técnicas claras de cualquier propuesta y una justificación convincente para su adopción. Las ACPs son un marco abierto para proponer mejoras y reunir consenso en torno a los cambios en la Red Avalanche. Cualquier persona puede proponer ACPs.
-palabras clave:
+tags: [Propuestas de la Comunidad Avalanche, ACPs]
+description: Una Propuesta de la Comunidad Avalanche es un documento conciso que introduce un cambio o una mejor práctica para su adopción en la Red Avalanche. Las ACPs deben proporcionar especificaciones técnicas claras de cualquier propuesta y una justificación convincente para su adopción. Las ACPs son un marco abierto para proponer mejoras y reunir consenso en torno a los cambios en la Red Avalanche. Cualquier persona puede proponer ACPs.
+keywords:
   [
     avalanche,
     nodos,
@@ -19,7 +19,7 @@ sidebar_position: 0
 
 [<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512" width="30" height="30"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>](https://github.com/avalanche-foundation/ACPs)
 
-Una Propuesta de la Comunidad Avalanche es un documento conciso que introduce un cambio o una mejor práctica para su adopción en la [Red Avalanche](https://www.avax.com). Las ACPs deben proporcionar especificaciones técnicas claras de cualquier propuesta y una justificación convincente para su adopción.
+Una Propuesta de la Comunidad Avalanche es un documento conciso que introduce un cambio o una mejor práctica para su adopción en la [Avalanche Network](https://www.avax.com). Las ACPs deben proporcionar especificaciones técnicas claras de cualquier propuesta y una justificación convincente para su adopción.
 
 Las ACPs son un marco abierto para proponer mejoras y reunir consenso en torno a los cambios en la Red Avalanche. Cualquier persona puede proponer ACPs y se fusionarán en este repositorio siempre que estén bien formateadas y sean coherentes. Una vez que una abrumadora mayoría de la Red/Comunidad Avalanche ha [señalado su apoyo a una ACP](https://docs.avax.network/nodes/configure/avalanchego-config-flags#avalanche-community-proposals), puede programarse su activación en la Red Avalanche por parte de los Clientes de la Red Avalanche (ANCs). En última instancia, depende de los miembros de la Red/Comunidad Avalanche adoptar las ACPs que apoyan ejecutando un ANC compatible, como [AvalancheGo](https://github.com/ava-labs/avalanchego).
 

--- a/i18n/es/docusaurus-plugin-content-docs/current/learn/acp.md
+++ b/i18n/es/docusaurus-plugin-content-docs/current/learn/acp.md
@@ -1,0 +1,104 @@
+---
+etiquetas: [Propuestas de la Comunidad Avalanche, ACPs]
+descripción: Una Propuesta de la Comunidad Avalanche es un documento conciso que introduce un cambio o una mejor práctica para su adopción en la Red Avalanche. Las ACPs deben proporcionar especificaciones técnicas claras de cualquier propuesta y una justificación convincente para su adopción. Las ACPs son un marco abierto para proponer mejoras y reunir consenso en torno a los cambios en la Red Avalanche. Cualquier persona puede proponer ACPs.
+palabras clave:
+  [
+    avalanche,
+    nodos,
+    preferencia,
+    mejoras avalanche,
+    código abierto,
+    acps,
+    propuestas de la comunidad avalanche,
+  ]
+sidebar_label: Propuestas de la Comunidad Avalanche
+sidebar_position: 0
+---
+
+# ¿Qué es una Propuesta de la Comunidad Avalanche (ACP)?
+
+[<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 496 512" width="30" height="30"><path d="M165.9 397.4c0 2-2.3 3.6-5.2 3.6-3.3 .3-5.6-1.3-5.6-3.6 0-2 2.3-3.6 5.2-3.6 3-.3 5.6 1.3 5.6 3.6zm-31.1-4.5c-.7 2 1.3 4.3 4.3 4.9 2.6 1 5.6 0 6.2-2s-1.3-4.3-4.3-5.2c-2.6-.7-5.5 .3-6.2 2.3zm44.2-1.7c-2.9 .7-4.9 2.6-4.6 4.9 .3 2 2.9 3.3 5.9 2.6 2.9-.7 4.9-2.6 4.6-4.6-.3-1.9-3-3.2-5.9-2.9zM244.8 8C106.1 8 0 113.3 0 252c0 110.9 69.8 205.8 169.5 239.2 12.8 2.3 17.3-5.6 17.3-12.1 0-6.2-.3-40.4-.3-61.4 0 0-70 15-84.7-29.8 0 0-11.4-29.1-27.8-36.6 0 0-22.9-15.7 1.6-15.4 0 0 24.9 2 38.6 25.8 21.9 38.6 58.6 27.5 72.9 20.9 2.3-16 8.8-27.1 16-33.7-55.9-6.2-112.3-14.3-112.3-110.5 0-27.5 7.6-41.3 23.6-58.9-2.6-6.5-11.1-33.3 2.6-67.9 20.9-6.5 69 27 69 27 20-5.6 41.5-8.5 62.8-8.5s42.8 2.9 62.8 8.5c0 0 48.1-33.6 69-27 13.7 34.7 5.2 61.4 2.6 67.9 16 17.7 25.8 31.5 25.8 58.9 0 96.5-58.9 104.2-114.8 110.5 9.2 7.9 17 22.9 17 46.4 0 33.7-.3 75.4-.3 83.6 0 6.5 4.6 14.4 17.3 12.1C428.2 457.8 496 362.9 496 252 496 113.3 383.5 8 244.8 8zM97.2 352.9c-1.3 1-1 3.3 .7 5.2 1.6 1.6 3.9 2.3 5.2 1 1.3-1 1-3.3-.7-5.2-1.6-1.6-3.9-2.3-5.2-1zm-10.8-8.1c-.7 1.3 .3 2.9 2.3 3.9 1.6 1 3.6 .7 4.3-.7 .7-1.3-.3-2.9-2.3-3.9-2-.6-3.6-.3-4.3 .7zm32.4 35.6c-1.6 1.3-1 4.3 1.3 6.2 2.3 2.3 5.2 2.6 6.5 1 1.3-1.3 .7-4.3-1.3-6.2-2.2-2.3-5.2-2.6-6.5-1zm-11.4-14.7c-1.6 1-1.6 3.6 0 5.9 1.6 2.3 4.3 3.3 5.6 2.3 1.6-1.3 1.6-3.9 0-6.2-1.4-2.3-4-3.3-5.6-2z"/></svg>](https://github.com/avalanche-foundation/ACPs)
+
+Una Propuesta de la Comunidad Avalanche es un documento conciso que introduce un cambio o una mejor práctica para su adopción en la [Red Avalanche](https://www.avax.com). Las ACPs deben proporcionar especificaciones técnicas claras de cualquier propuesta y una justificación convincente para su adopción.
+
+Las ACPs son un marco abierto para proponer mejoras y reunir consenso en torno a los cambios en la Red Avalanche. Cualquier persona puede proponer ACPs y se fusionarán en este repositorio siempre que estén bien formateadas y sean coherentes. Una vez que una abrumadora mayoría de la Red/Comunidad Avalanche ha [señalado su apoyo a una ACP](https://docs.avax.network/nodes/configure/avalanchego-config-flags#avalanche-community-proposals), puede programarse su activación en la Red Avalanche por parte de los Clientes de la Red Avalanche (ANCs). En última instancia, depende de los miembros de la Red/Comunidad Avalanche adoptar las ACPs que apoyan ejecutando un ANC compatible, como [AvalancheGo](https://github.com/ava-labs/avalanchego).
+
+## Pistas de ACP
+
+Hay tres tipos de ACP:
+
+- Una ACP de `Pista de Estándares` describe un cambio en el diseño o la función de la Red Avalanche, como un cambio en el protocolo de red P2P, el diseño de la Cadena-P, la arquitectura de las Subredes, o cualquier cambio/adición que afecte a la interoperabilidad de los Clientes de la Red Avalanche (ANCs).
+- Una ACP de `Pista de Mejores Prácticas` describe un patrón de diseño o una interfaz común que se debe utilizar en toda la Red Avalanche para facilitar la integración con Avalanche o para que las Subredes interoperen entre sí. Esto incluiría cosas como proponer una interfaz de contrato inteligente, no proponer un cambio en cómo se ejecutan los contratos inteligentes.
+- Una ACP de `Pista Meta` describe un cambio en el proceso de las ACPs o sugiere una nueva forma para que la Comunidad Avalanche colabore.
+- Una ACP de `Pista de Subred` describe un cambio en una Subred en particular. Esto incluiría cosas como cambios de configuración o actualizaciones coordinadas de la Subred.
+
+## Estados de las ACPs
+
+Hay cuatro estados de una ACP:
+
+- Una ACP `Propuesta` se ha fusionado en la rama principal del repositorio de ACPs. Se está discutiendo activamente por la Comunidad Avalanche y puede modificarse en función de los comentarios.
+- Una ACP `Implementable` se considera "lista para su implementación" por parte del autor y ya no cambiará significativamente en
+
+El autor debe primero intentar determinar si hay apoyo para su idea publicando en la categoría "Ideas" de las Discusiones de GitHub. Vetar una idea públicamente antes de llegar tan lejos como escribir un ACP tiene como objetivo ahorrar tiempo tanto al autor potencial como a la comunidad Avalanche en general. Preguntar primero a la comunidad Avalanche si una idea es original ayuda a evitar que se gaste demasiado tiempo en algo que está garantizado a ser rechazado basado en discusiones previas (buscar en Internet no siempre funciona). También ayuda a asegurar que la idea sea aplicable a toda la comunidad y no solo al autor. Pequeñas mejoras o parches a menudo no necesitan estandarización entre múltiples proyectos; estos no necesitan un ACP y deben ser inyectados en el flujo de trabajo de desarrollo relevante con una presentación de parche al rastreador de problemas ANC aplicable.
+
+### Paso 2: Proponer un ACP a través de una solicitud de extracción (PR)
+
+Una vez que el autor se siente seguro de que una idea tiene una buena oportunidad de ser aceptada, se debe redactar un ACP y enviarlo como una solicitud de extracción (PR). Este borrador debe estar escrito en estilo ACP como se describe a continuación. Se recomienda encarecidamente que un solo ACP contenga una sola propuesta clave o una nueva idea. Cuanto más enfocado esté el ACP, más éxito tiende a tener. Si tienes dudas, divide tu ACP en varios enfoques bien definidos. El número de PR del ACP se convertirá en su número asignado.
+
+### Paso 3: Construir consenso en las Discusiones de GitHub y proporcionar una implementación (si corresponde)
+
+Los ACPs serán fusionados por los mantenedores de ACPs si la propuesta está generalmente bien formateada y coherente. Los editores de ACPs intentarán fusionar cualquier cosa que valga la pena discutir, independientemente de la viabilidad o complejidad, que no sea un duplicado o esté incompleto. Después de que un ACP se fusiona, se abrirá una Discusión oficial de GitHub para el ACP y se vinculará a la propuesta para su discusión comunitaria. Se recomienda que el autor o miembros de la Comunidad Avalanche de apoyo publiquen un resumen no técnico acompañante de su ACP para consumo general en esta Discusión de GitHub. El ACP debe ser revisado y ampliamente apoyado antes de que se inicie una implementación de referencia, nuevamente para evitar desperdiciar el tiempo del autor y de la comunidad Avalanche, a menos que una implementación de referencia ayude a las personas a estudiar el ACP.
+
+### Paso 4: Marcar el ACP como `Implementable` a través de una solicitud de extracción (PR)
+
+Una vez que un ACP es considerado completo por el autor, debe ser marcado como `Implementable`. En este punto, todas las preguntas abiertas deben ser abordadas y se debe proporcionar una implementación de referencia asociada (si corresponde). Como se mencionó anteriormente, la Fundación Avalanche se reúne periódicamente para recomendar la ratificación de ACPs específicos, pero en última instancia, depende de los miembros de la Red/Comunidad Avalanche adoptar los ACPs que apoyan ejecutando un Cliente de Red Avalanche compatible (ANC), como [AvalancheGo](https://github.com/ava-labs/avalanchego).
+
+### [Opcional] Paso 5: Marcar el ACP como `Stale` a través de una solicitud de extracción (PR)
+
+Un ACP puede ser reemplazado por un ACP diferente, volviendo el original obsoleto. Si esto ocurre, el ACP original se marcará como `Stale`. Los ACPs también pueden ser marcados como `Stale` si el autor abandona el trabajo en él durante un período prolongado de tiempo (12+ meses). Los ACPs pueden ser reabiertos y movidos de vuelta a `Proposed` si el autor reinicia el trabajo.
+
+## ¿Qué debe incluir un ACP exitoso?
+
+Cada ACP debe tener las siguientes partes:
+
+- `Preambulo`: Tabla en formato Markdown que contiene metadatos sobre el ACP, incluyendo el número del ACP, un título descriptivo corto, el autor y opcionalmente la información de contacto de cada autor, etc.
+- `Resumen`: Descripción concisa (~200 palabras) del ACP
+- `Motivación`: Justificación para adoptar el ACP y el problema/especificidad/oportunidad específica que aborda
+- `Especificación`: Descripción completa de la semántica de cualquier cambio que permita a cualquier miembro de la ANC/Comunidad Avalanche implementar el ACP
+- `Consideraciones de seguridad`: Implicaciones de seguridad del ACP propuesto
+
+Cada ACP puede tener las siguientes partes:
+
+- `Preguntas abiertas`: Preguntas que deben resolverse antes de la implementación
+
+Cada ACP de `Ruta de estándares` debe tener las siguientes partes:
+
+- `Compatibilidad hacia atrás`: Lista de cambios incompatibles hacia atrás requeridos para implementar el ACP y su impacto en la Comunidad Avalanche
+- `Implementación de referencia`: Código, documentación y telemetría (de una red local) del cambio de ACP
+
+Cada ACP de `Ruta de mejores prácticas` puede tener las siguientes partes:
+
+- `Compatibilidad hacia atrás`: Lista de cambios incompatibles hacia atrás requeridos para implementar el ACP y su impacto en la Comunidad Avalanche
+- `Implementación de referencia`: Código, documentación y telemetría (de una red local) del cambio de ACP
+
+### Formatos y plantillas de ACP
+
+Cada ACP tiene asignado un subdirectorio único en el directorio `ACPs`. El nombre de este subdirectorio debe tener la forma `N-T` donde `N` es el número del ACP y `T` es el título del ACP con cualquier espacio reemplazado por guiones. Los ACPs deben estar escritos en formato [markdown](https://daringfireball.net/projects/markdown/syntax) y almacenados en `ACPs/N-T/README.md`. Por favor, consulta la [plantilla de ACP](https://github.com/avalanche-foundation/ACPs/blob/main/ACPs/TEMPLATE.md) para ver un ejemplo del diseño correcto.
+
+### Archivos auxiliares
+
+Los ACPs pueden incluir archivos auxiliares como diagramas o fragmentos de código. Dichos archivos deben almacenarse en el subdirectorio del ACP (`ACPs/N-T/*`). No hay una convención de nomenclatura requerida para los archivos auxiliares.
+
+### Derechos de autor renunciados
+
+Los autores de los ACPs deben renunciar a cualquier reclamo de derechos de autor antes de que un ACP se fusione en el repositorio. Esto se puede hacer incluyendo el siguiente texto en un ACP:
+
+```text
+## Derechos de autor
+
+Derechos de autor y derechos relacionados renunciados a través de [CC0](https://creativecommons.org/publicdomain/zero/1.0/).
+```
+
+## Contribuciones
+
+Antes de contribuir a los ACPs, por favor lee los [Términos de Contribución de los ACPs](https://github.com/avalanche-foundation/ACPs/blob/main/CONTRIBUTING.md).


### PR DESCRIPTION
## Why this should be merged

the build has been broken due to invalid `sourceBaseUrl`s in `remoteContent.js`. These Urls point to `.md` files in remote repositories (ie. https://github.com/ava-labs/avalanchego/) that are pulled into docs via `docusaurus-plugin-remote-content` community plugin. 

I wrote a [detailed guide](https://github.com/ava-labs/avalanche-docs/blob/7a40b5bd83af114e3dfadfd5b9cc85329417646a/editing-guides/remote-github-content-guide.md) on how I implemented `docusaurus-plugin-remote-content` to pull remote docs. Many FAQs are answered there. 

## How this works

- changes the invalid URLs to valid URLs 
- removed the ACP remote URLs and replaced with a hardcoded file in `docs/learn/acp.md`

## How these changes were tested 

`yarn build`
`yarn start`