### PR TITLE
replace: subnet -> blockchain

### DIFF
--- a/content/docs/cross-chain/teleporter/teleporter-on-devnet.mdx
+++ b/content/docs/cross-chain/teleporter/teleporter-on-devnet.mdx
@@ -202,7 +202,7 @@ By executing `subnet describe` on a Teleporter enabled Subnet, the following rel
 Let's get the information for `<subnet1>`:
 
 ```
-avalanche subnet describe <subnet1>
+avalanche blockchain describe <subnet1>
 
  _____       _        _ _
 |  __ \     | |      (_) |

--- a/content/docs/cross-chain/teleporter/teleporter-on-local-network.mdx
+++ b/content/docs/cross-chain/teleporter/teleporter-on-local-network.mdx
@@ -18,7 +18,7 @@ Create Subnet Configurations[​](#create-subnet-configurations "Direct link to 
 Let's create a Subnet called `<subnet1>` with the latest Subnet-EVM version, a chain ID of 1, TOKEN1 as the token name, and with default Subnet-EVM parameters (more information regarding Subnet creation can be found [here](/subnets/build-first-subnet#create-your-subnet-configuration)):
 
 ```
-avalanche subnet create <subnet1> --evm --latest\
+avalanche blockchain create <subnet1> --evm --latest\
     --evm-chain-id 1 --evm-token TOKEN1 --evm-defaults
 
 creating genesis for <subnet subnet1>
@@ -38,7 +38,7 @@ To disable Relayer in your Subnet, use the flag `--relayer=false` when creating 
 Now let's create a second Subnet called `<subnet2>`, with similar settings:
 
 ```
-avalanche subnet create <subnet2> --evm --latest\
+avalanche blockchain create <subnet2> --evm --latest\
     --evm-chain-id 2 --evm-token TOKEN2 --evm-defaults
 
 creating genesis for <subnet subnet2>
@@ -55,7 +55,7 @@ Deploy the Subnets to Local Network[​](#deploy-the-subnets-to-local-network "D
 Let's deploy `<subnet1>`:
 
 ```
-avalanche subnet deploy <subnet1> --local
+avalanche blockchain deploy <subnet1> --local
 
 Deploying [<subnet1>] to Local Network
 Backend controller started, pid: 149427, output at: ~/.avalanche-cli/runs/server_20240229_165923/avalanche-cli-backend.log
@@ -109,7 +109,7 @@ CLI configures the Relayer to enable every Subnet to send messages to all other 
 When deploying Subnet `<subnet2>`, the two Teleporter contracts will not be deployed to C-Chain in Local Network as they have already been deployed when we deployed the first Subnet.
 
 ```
-avalanche subnet deploy <subnet2> --local
+avalanche blockchain deploy <subnet2> --local
 
 Deploying [<subnet2>] to Local Network
 
@@ -197,7 +197,7 @@ By executing `subnet describe` on a Teleporter enabled Subnet, the following rel
 Let's get the information for `<subnet1>`:
 
 ```
-avalanche subnet describe <subnet1>
+avalanche blockchain describe <subnet1>
 
  _____       _        _ _
 |  __ \     | |      (_) |

--- a/content/docs/subnets/avalanche-cli-subnets.mdx
+++ b/content/docs/subnets/avalanche-cli-subnets.mdx
@@ -5,7 +5,7 @@ description: Learn about Avalanche CLI and its different commands for Subnets.
 
 Avalanche-CLI is a command-line tool that gives developers access to everything Avalanche. This release specializes in helping developers build and test Subnets.
 
-To get started, look at the documentation for the subcommands or jump right in with `avalanche subnet create myNewSubnet`.
+To get started, look at the documentation for the subcommands or jump right in with `avalanche blockchain create myNewSubnet`.
 
 [Install Avalanche CLI](/tooling/guides/get-avalanche-cli)
 
@@ -176,7 +176,7 @@ By default, running the command with a `subnetName` that already exists causes t
 **Usage**:
 
 ```bash
-avalanche subnet create [subnetName] [flags]
+avalanche blockchain create [subnetName] [flags]
 ```
 
 **Flags**:
@@ -229,7 +229,7 @@ Avalanche-CLI only supports deploying an individual Subnet once per network. Sub
 **Usage**:
 
 ```bash
-avalanche subnet deploy [subnetName] [flags]
+avalanche blockchain deploy [subnetName] [flags]
 ```
 
 **Flags**:
@@ -264,7 +264,7 @@ The `subnet describe` command prints the details of a Subnet configuration to th
 **Usage**:
 
 ```bash
-avalanche subnet describe [subnetName] [flags]
+avalanche blockchain describe [subnetName] [flags]
 ```
 
 **Flags**:

--- a/content/docs/subnets/build-first-subnet.mdx
+++ b/content/docs/subnets/build-first-subnet.mdx
@@ -38,7 +38,7 @@ The Subnet command suite provides a collection of tools for developing and deplo
 The Subnet Creation Wizard walks you through the process of creating your Subnet. To get started, first pick a name for your Subnet. This tutorial uses `mySubnet`, but feel free to substitute that with any name you like. Once you've picked your name, run:
 
 ```bash
-avalanche subnet create mySubnet
+avalanche blockchain create mySubnet
 ```
 
 The following sections walk through each question in the wizard.
@@ -91,7 +91,7 @@ Deploying Subnets Locally[​](#deploying-subnets-locally "Direct link to headin
 To deploy your Subnet, run:
 
 ```bash
-avalanche subnet deploy mySubnet
+avalanche blockchain deploy mySubnet
 ```
 
 Make sure to substitute the name of your Subnet if you used a different one than `mySubnet`.
@@ -105,7 +105,7 @@ Note: If you run `bash` on your shell and are running Avalanche-CLI on ARM64 on 
 If all works as expected, the command output should look something like this:
 
 ```bash
-avalanche subnet deploy mySubnet
+avalanche blockchain deploy mySubnet
 
 # output
 ✔ Local Network
@@ -195,7 +195,7 @@ In the Core Extension click, `See All Networks` and then select the `+` icon in 
 
 ![Add network](/images/deploy-subnet5.png)
 
-Enter your Subnet's details, found in the output of your `avalanche subnet deploy` [command](#deploying-subnets-locally), into the form and click `Save`.
+Enter your Subnet's details, found in the output of your `avalanche blockchain deploy` [command](#deploying-subnets-locally), into the form and click `Save`.
 
 ![Add network 2](/images/deploy-subnet6.png)
 

--- a/content/docs/subnets/deploy-a-subnet/avalanche-mainnet.mdx
+++ b/content/docs/subnets/deploy-a-subnet/avalanche-mainnet.mdx
@@ -104,7 +104,7 @@ Deploy the Subnet[​](#deploy-the-subnet "Direct link to heading")
 With your Ledger unlocked and running the Avalanche app, run
 
 ```bash
-avalanche subnet deploy testsubnet
+avalanche blockchain deploy testsubnet
 ```
 
 This is going to start a new prompt series.

--- a/content/docs/subnets/deploy-a-subnet/custom-virtual-machine.mdx
+++ b/content/docs/subnets/deploy-a-subnet/custom-virtual-machine.mdx
@@ -107,7 +107,7 @@ Create the Subnet Configuration[​](#create-the-subnet-configuration "Direct li
 Now that you have your binary, it's time to create the Subnet configuration. This tutorial uses `myCustomSubnet` as it Subnet name. Invoke the Subnet Creation Wizard with this command:
 
 ```bash
-avalanche subnet create myCustomSubnet
+avalanche blockchain create myCustomSubnet
 ```
 
 ### Choose Your VM[​](#choose-your-vm "Direct link to heading")
@@ -146,7 +146,7 @@ Now it's time to deploy it.
 Deploy the Subnet Locally[​](#deploy-the-subnet-locally "Direct link to heading")
 ---------------------------------------------------------------------------------
 
-To deploy your Subnet, run: `avalanche subnet deploy myCustomSubnet`
+To deploy your Subnet, run: `avalanche blockchain deploy myCustomSubnet`
 
 Make sure to substitute the name of your Subnet if you used a different one than `myCustomSubnet`.
 
@@ -165,7 +165,7 @@ This command boots a five node Avalanche network on your machine. It needs to do
 If all works as expected, the command output should look something like this:
 
 ```bash
-> avalanche subnet deploy myCustomSubnet
+> avalanche blockchain deploy myCustomSubnet
 ✔ Local Network
 Deploying [myCustomSubnet] to Local Network
 Backend controller started, pid: 26110, output at: /home/fm/.avalanche-cli/runs/server_20230816_131014/avalanche-cli-backend.log

--- a/content/docs/subnets/deploy-a-subnet/fuji-testnet.mdx
+++ b/content/docs/subnets/deploy-a-subnet/fuji-testnet.mdx
@@ -181,7 +181,7 @@ Creating a Subnet with `Avalanche-CLI` for `Fuji` works the same way as with a l
 To create an EVM Subnet, run the `subnet create` command with a name of your choice:
 
 ```bash
-avalanche subnet create testsubnet
+avalanche blockchain create testsubnet
 ```
 
 This is going to start a series of prompts to customize your EVM Subnet to your needs. Most prompts have some validation to reduce issues due to invalid input. The first prompt asks for the type of the virtual machine (see [Virtual Machine](#virtual-machine)).
@@ -261,7 +261,7 @@ At this point, CLI creates the specification of the new Subnet on disk, but isn'
 Print the specification to disk by running the `describe` command:
 
 ```bash
-avalanche subnet describe testsubnet
+avalanche blockchain describe testsubnet
  _____       _        _ _
 |  __ \     | |      (_) |
 | |  | | ___| |_ __ _ _| |___
@@ -379,7 +379,7 @@ To deploy the Subnet, you will need some testnet AVAX on the P-chain.
 To deploy the new Subnet, run:
 
 ```bash
-avalanche subnet deploy testsubnet
+avalanche blockchain deploy testsubnet
 ```
 
 This is going to start a new prompt series.

--- a/content/docs/subnets/deploy-a-subnet/local-network.mdx
+++ b/content/docs/subnets/deploy-a-subnet/local-network.mdx
@@ -15,13 +15,13 @@ In the following commands, make sure to substitute the name of your Subnet confi
 To deploy your Subnet, run
 
 ```bash
-avalanche subnet deploy <subnetName>
+avalanche blockchain deploy <subnetName>
 ```
 
 and, select `Local Network` to deploy on. Alternatively, you can bypass this prompt by providing the `--local` flag. For example:
 
 ```bash
-avalanche subnet deploy <subnetName> --local
+avalanche blockchain deploy <subnetName> --local
 ```
 
 The command may take a couple minutes to run.
@@ -35,7 +35,7 @@ If you run `bash` on your shell and are running Avalanche-CLI on ARM64 on Mac, y
 If all works as expected, the command output should look something like this:
 
 ```bash
-> avalanche subnet deploy mySubnet
+> avalanche blockchain deploy mySubnet
 ✔ Local Network
 Deploying [mySubnet] to Local Network
 Installing subnet-evm-v0.4.3...
@@ -86,5 +86,5 @@ To redeploy the Subnet, you first need to wipe the Subnet state. This permanentl
 You are now free to redeploy your Subnet with:
 
 ```bash
-avalanche subnet deploy <subnetName> --local
+avalanche blockchain deploy <subnetName> --local
 ```

--- a/content/docs/subnets/deploy-a-subnet/multisig-auth.mdx
+++ b/content/docs/subnets/deploy-a-subnet/multisig-auth.mdx
@@ -28,7 +28,7 @@ When issuing the transactions to create the Subnet, you need to sign the TXs wit
 Start the Subnet deployment with
 
 ```bash
-avalanche subnet deploy testsubnet
+avalanche blockchain deploy testsubnet
 ```
 
 First step is to specify `Fuji` or `Mainnet` as the network:

--- a/content/docs/subnets/maintain/view-subnets.mdx
+++ b/content/docs/subnets/maintain/view-subnets.mdx
@@ -30,7 +30,7 @@ avalanche subnet list --deployed
 ```
 
 ```bash
-avalanche subnet describe firstsubnet
+avalanche blockchain describe firstsubnet
 
 #output
  _____       _        _ _
@@ -117,7 +117,7 @@ No precompiles set
 If you'd like to see the raw genesis file, supply the `--genesis` flag to the describe command:
 
 ```bash
-avalanche subnet describe firstsubnet --genesis
+avalanche blockchain describe firstsubnet --genesis
 
 # output
 {

--- a/content/docs/subnets/troubleshooting.mdx
+++ b/content/docs/subnets/troubleshooting.mdx
@@ -9,7 +9,7 @@ Deployment Times Out[​](#deployment-times-out "Direct link to heading")
 During a local deployment, your network may fail to start. Your error may look something like this:
 
 ```bash
-[~]$ avalanche subnet deploy mySubnet
+[~]$ avalanche blockchain deploy mySubnet
 ✔ Local Network
 Deploying [mySubnet] to Local Network
 Backend controller started, pid: 26388, output at: /Users/user/.avalanche-cli/runs/server_20221231_111605/avalanche-cli-backend
@@ -47,7 +47,7 @@ Incompatible RPC Version for Custom VM[​](#incompatible-rpc-version-for-custom
 If you're locally deploying a custom VM, you may run into this error message.
 
 ```bash
-[~]$ avalanche subnet deploy mySubnet
+[~]$ avalanche blockchain deploy mySubnet
 ✔ Local Network
 Deploying [mySubnet] to Local Network
 Backend controller started, pid: 26388, output at: /Users/user/.avalanche-cli/runs/server_20221231_111605/avalanche-cli-backend
@@ -123,7 +123,7 @@ Updates to AvalancheGo's RPC version are **not** tied to its semantic version sc
 Fix for MacBook Air M1/M2: ‘Bad CPU type in executable' Error[​](#fix-for-macbook-air-m1m2-bad-cpu-type-in-executable-error "Direct link to heading")
 -----------------------------------------------------------------------------------------------------------------------------------------------------
 
-When running `avalanche subnet deploy` via the Avalanche-CLI, the terminal may throw an error that contains the following:
+When running `avalanche blockchain deploy` via the Avalanche-CLI, the terminal may throw an error that contains the following:
 
 ```bash
 zsh: bad CPU type in executable:

--- a/content/docs/subnets/upgrade/subnet-virtual-machine.mdx
+++ b/content/docs/subnets/upgrade/subnet-virtual-machine.mdx
@@ -32,7 +32,7 @@ After starting the Subnet Upgrade Wizard, you should see something like this:
     Existing local deployment
 ```
 
-If you select the first option, Avalanche-CLI updates your Subnet's config and any future calls to `avalanche subnet deploy` use the new version you select. However, any existing local deployments continue to use the old version.
+If you select the first option, Avalanche-CLI updates your Subnet's config and any future calls to `avalanche blockchain deploy` use the new version you select. However, any existing local deployments continue to use the old version.
 
 If you select the second option, the opposite occurs. The existing local deployment switches to the new VM but subsequent deploys use the original.
 

--- a/content/docs/tooling/avalanche-cli.mdx
+++ b/content/docs/tooling/avalanche-cli.mdx
@@ -3,7 +3,7 @@ title: Introduction
 description: Avalanche-CLI is a command-line tool that gives developers access to everything Avalanche.
 ---
 
-To get started, look at the documentation for the subcommands or jump right in with `avalanche subnet create myNewSubnet`.
+To get started, look at the documentation for the subcommands or jump right in with `avalanche blockchain create myNewSubnet`.
 
 [Install Avalanche CLI](/tooling/guides/get-avalanche-cli)
 
@@ -176,7 +176,7 @@ By default, running the command with a `subnetName` that already exists causes t
 **Usage**:
 
 ```bash
-avalanche subnet create [subnetName] [flags]
+avalanche blockchain create [subnetName] [flags]
 ```
 
 **Flags**:
@@ -231,7 +231,7 @@ Avalanche-CLI only supports deploying an individual Subnet once per network. Sub
 **Usage**:
 
 ```bash
-avalanche subnet deploy [subnetName] [flags]
+avalanche blockchain deploy [subnetName] [flags]
 ```
 
 **Flags**:
@@ -266,7 +266,7 @@ The `subnet describe` command prints the details of a Subnet configuration to th
 **Usage**:
 
 ```bash
-avalanche subnet describe [subnetName] [flags]
+avalanche blockchain describe [subnetName] [flags]
 ```
 
 **Flags**:

--- a/content/docs/tooling/create-avalanche-nodes/deploy-custom-vm.mdx
+++ b/content/docs/tooling/create-avalanche-nodes/deploy-custom-vm.mdx
@@ -88,7 +88,7 @@ Create the Subnet[​](#create-the-subnet "Direct link to heading")
 Let's create a Subnet called `<subnetName>`, with custom VM binary and genesis.
 
 ```bash
-avalanche subnet create <subnetName>
+avalanche blockchain create <subnetName>
 ```
 
 Choose custom
@@ -131,7 +131,7 @@ Successfully created subnet configuration
 For this example, we will deploy the Subnet and blockchain on Fuji. Run:
 
 ```bash
-avalanche subnet deploy <subnetName>
+avalanche blockchain deploy <subnetName>
 ```
 
 Choose Fuji:

--- a/content/docs/tooling/create-deploy-subnets/create-subnet.mdx
+++ b/content/docs/tooling/create-deploy-subnets/create-subnet.mdx
@@ -36,7 +36,7 @@ The Subnet command suite provides a collection of tools for developing and deplo
 The Subnet Creation Wizard walks you through the process of creating your Subnet. To get started, first pick a name for your Subnet. This tutorial uses `mySubnet`, but feel free to substitute that with any name you like. Once you've picked your name, run:
 
 ```bash
-avalanche subnet create mySubnet
+avalanche blockchain create mySubnet
 ```
 
 The following sections walk through each question in the wizard.
@@ -89,7 +89,7 @@ Deploying Subnets Locally[​](#deploying-subnets-locally "Direct link to headin
 To deploy your Subnet, run:
 
 ```bash
-avalanche subnet deploy mySubnet
+avalanche blockchain deploy mySubnet
 ```
 
 Make sure to substitute the name of your Subnet if you used a different one than `mySubnet`.
@@ -103,7 +103,7 @@ Note: If you run `bash` on your shell and are running Avalanche-CLI on ARM64 on 
 If all works as expected, the command output should look something like this:
 
 ```bash
-> avalanche subnet deploy mySubnet
+> avalanche blockchain deploy mySubnet
 ✔ Local Network
 Deploying [mySubnet] to Local Network
 Installing subnet-evm-v0.4.3...
@@ -191,7 +191,7 @@ In the Core Extension click, `See All Networks` and then select the `+` icon in 
 
 ![](/images/create-subnet5.png)
 
-Enter your Subnet's details, found in the output of your `avalanche subnet deploy` [command](#deploying-subnets-locally), into the form and click `Save`.
+Enter your Subnet's details, found in the output of your `avalanche blockchain deploy` [command](#deploying-subnets-locally), into the form and click `Save`.
 
 ![](/images/create-subnet5.png)
 

--- a/content/docs/tooling/create-deploy-subnets/deploy-locally.mdx
+++ b/content/docs/tooling/create-deploy-subnets/deploy-locally.mdx
@@ -18,13 +18,13 @@ In the following commands, make sure to substitute the name of your Subnet confi
 To deploy your Subnet, run:
 
 ```bash
-avalanche subnet deploy <subnetName>
+avalanche blockchain deploy <subnetName>
 ```
 
 and select `Local Network` to deploy on. Alternatively, you can bypass this prompt by providing the `--local` flag. For example:
 
 ```bash
-avalanche subnet deploy <subnetName> --local
+avalanche blockchain deploy <subnetName> --local
 ```
 
 The command may take a couple minutes to run.
@@ -36,7 +36,7 @@ Note: If you run `bash` on your shell and are running Avalanche-CLI on ARM64 on 
 If all works as expected, the command output should look something like this:
 
 ```bash
-> avalanche subnet deploy mySubnet
+> avalanche blockchain deploy mySubnet
 ✔ Local Network
 Deploying [mySubnet] to Local Network
 Installing subnet-evm-v0.4.3...
@@ -88,5 +88,5 @@ To redeploy the Subnet, you first need to wipe the Subnet state. This permanentl
 You are now free to redeploy your Subnet with
 
 ```bash
-avalanche subnet deploy <subnetName> --local
+avalanche blockchain deploy <subnetName> --local
 ```

--- a/content/docs/tooling/create-deploy-subnets/deploy-on-fuji-testnet.mdx
+++ b/content/docs/tooling/create-deploy-subnets/deploy-on-fuji-testnet.mdx
@@ -181,7 +181,7 @@ Creating a Subnet with `Avalanche-CLI` for `Fuji` works the same way as with a l
 To create an EVM Subnet, run the `subnet create` command with a name of your choice:
 
 ```bash
-avalanche subnet create testsubnet
+avalanche blockchain create testsubnet
 ```
 
 This is going to start a series of prompts to customize your EVM Subnet to your needs. Most prompts have some validation to reduce issues due to invalid input. The first prompt asks for the type of the virtual machine (see [Virtual Machine](#virtual-machine)).
@@ -261,7 +261,7 @@ At this point, CLI creates the specification of the new Subnet on disk, but isn'
 Print the specification to disk by running the `describe` command:
 
 ```bash
-avalanche subnet describe testsubnet
+avalanche blockchain describe testsubnet
  _____       _        _ _
 |  __ \     | |      (_) |
 | |  | | ___| |_ __ _ _| |___
@@ -375,7 +375,7 @@ Deploy the Subnet[​](#deploy-the-subnet "Direct link to heading")
 To deploy the new Subnet, run
 
 ```bash
-avalanche subnet deploy testsubnet
+avalanche blockchain deploy testsubnet
 ```
 
 This is going to start a new prompt series.

--- a/content/docs/tooling/create-deploy-subnets/deploy-on-mainnet.mdx
+++ b/content/docs/tooling/create-deploy-subnets/deploy-on-mainnet.mdx
@@ -105,7 +105,7 @@ Deploy the Subnet[​](#deploy-the-subnet "Direct link to heading")
 With your Ledger unlocked and running the Avalanche app, run
 
 ```bash
-avalanche subnet deploy testsubnet
+avalanche blockchain deploy testsubnet
 ```
 
 This is going to start a new prompt series.

--- a/content/docs/tooling/create-deploy-subnets/view-subnets.mdx
+++ b/content/docs/tooling/create-deploy-subnets/view-subnets.mdx
@@ -34,12 +34,12 @@ To see detailed information about your deployed Subnets, add the `--deployed` fl
 
 ## Describe Subnet Configurations
 
-To see the details of a specific configuration, run: `avalanche subnet describe <subnetName>`
+To see the details of a specific configuration, run: `avalanche blockchain describe <subnetName>`
 
 Example:
 
 ```bash
-> avalanche subnet describe firstsubnet
+> avalanche blockchain describe firstsubnet
 
  _____       _        _ _
 |  __ \     | |      (_) |
@@ -123,12 +123,12 @@ No precompiles set
 
 ## Viewing a Genesis File
 
-If you'd like to see the raw genesis file, supply the `--genesis` flag to the describe command: `avalanche subnet describe <subnetName> --genesis`
+If you'd like to see the raw genesis file, supply the `--genesis` flag to the describe command: `avalanche blockchain describe <subnetName> --genesis`
 
 Example:
 
 ```bash
-> avalanche subnet describe firstsubnet --genesis
+> avalanche blockchain describe firstsubnet --genesis
 {
     "config": {
         "chainId": 12345,

--- a/content/docs/tooling/cross-chain/teleporter-devnet.mdx
+++ b/content/docs/tooling/cross-chain/teleporter-devnet.mdx
@@ -202,7 +202,7 @@ By executing `subnet describe` on a Teleporter enabled Subnet, the following rel
 Let's get the information for `<subnet1>`:
 
 ```bash
-avalanche subnet describe <subnet1>
+avalanche blockchain describe <subnet1>
 
  _____       _        _ _
 |  __ \     | |      (_) |

--- a/content/docs/tooling/cross-chain/teleporter-local-network.mdx
+++ b/content/docs/tooling/cross-chain/teleporter-local-network.mdx
@@ -21,7 +21,7 @@ Create Subnet Configurations[​](#create-subnet-configurations "Direct link to 
 Let's create a Subnet called `<subnet1>` with the latest Subnet-EVM version, a chain ID of 1, TOKEN1 as the token name, and with default Subnet-EVM parameters (more information regarding Subnet creation can be found [here](/subnets/build-first-subnet#create-your-subnet-configuration)):
 
 ```bash
-avalanche subnet create <subnet1> --evm --latest\
+avalanche blockchain create <subnet1> --evm --latest\
     --evm-chain-id 1 --evm-token TOKEN1 --evm-defaults
 
 creating genesis for <subnet subnet1>
@@ -41,7 +41,7 @@ To disable Relayer in your Subnet, use the flag `--relayer=false` when creating 
 Now let's create a second Subnet called `<subnet2>`, with similar settings:
 
 ```bash
-avalanche subnet create <subnet2> --evm --latest\
+avalanche blockchain create <subnet2> --evm --latest\
     --evm-chain-id 2 --evm-token TOKEN2 --evm-defaults
 
 creating genesis for <subnet subnet2>
@@ -58,7 +58,7 @@ Deploy the Subnets to Local Network[​](#deploy-the-subnets-to-local-network "D
 Let's deploy `<subnet1>`:
 
 ```bash
-avalanche subnet deploy <subnet1> --local
+avalanche blockchain deploy <subnet1> --local
 
 Deploying [<subnet1>] to Local Network
 Backend controller started, pid: 149427, output at: ~/.avalanche-cli/runs/server_20240229_165923/avalanche-cli-backend.log
@@ -112,7 +112,7 @@ CLI configures the Relayer to enable every Subnet to send messages to all other 
 When deploying Subnet `<subnet2>`, the two Teleporter contracts will not be deployed to C-Chain in Local Network as they have already been deployed when we deployed the first Subnet.
 
 ```bash
-avalanche subnet deploy <subnet2> --local
+avalanche blockchain deploy <subnet2> --local
 
 Deploying [<subnet2>] to Local Network
 
@@ -200,7 +200,7 @@ By executing `subnet describe` on a Teleporter enabled Subnet, the following rel
 Let's get the information for `<subnet1>`:
 
 ```bash
-avalanche subnet describe <subnet1>
+avalanche blockchain describe <subnet1>
 
  _____       _        _ _
 |  __ \     | |      (_) |


### PR DESCRIPTION
We are deprecating the term Subnet and therefore have changed Avalanche CLI commands. Even though the old command still work, we should replace them everywhere in our content in the Avalanche Academy and Avalanche Docs.


avalanche subnet create => avalanche blockchain create

avalanche subnet deploy => avalanche blockchain deploy

avalanche subnet describe => avalanche blockchain describe