### PR TITLE
add: search index for integration pages

### DIFF
--- a/app/(docs)/[...slug]/page.tsx
+++ b/app/(docs)/[...slug]/page.tsx
@@ -3,7 +3,7 @@ import { Card, Cards } from 'fumadocs-ui/components/card';
 import { DocsPage, DocsBody } from 'fumadocs-ui/page';
 import { notFound } from 'next/navigation';
 import { createMetadata } from '@/utils/metadata';
-import { getPage, getPages, type Page } from '@/utils/docs-loader';
+import { getDocsPage, getDocsPages, type Page } from '@/utils/docs-loader';
 import { ArrowUpRightIcon } from '@heroicons/react/20/solid';
 
 interface Param {
@@ -17,7 +17,7 @@ export default function Page({
 }: {
   params: Param;
 }): React.ReactElement {
-  const page = getPage(params.slug);
+  const page = getDocsPage(params.slug);
 
   if (!page) notFound();
 
@@ -59,7 +59,7 @@ export default function Page({
 }
 
 function Category({ page }: { page: Page }): React.ReactElement {
-  const filtered = getPages()
+  const filtered = getDocsPages()
     .filter(
       (item) =>
         item.file.dirname === page.file.dirname && item.file.name !== 'index',
@@ -80,13 +80,13 @@ function Category({ page }: { page: Page }): React.ReactElement {
 }
 
 export async function generateStaticParams() {
-  return getPages().map((page) => ({
+  return getDocsPages().map((page) => ({
     slug: page.slugs,
   }));
 }
 
 export function generateMetadata({ params }: { params: Param }): Metadata {
-  const page = getPage(params.slug);
+  const page = getDocsPage(params.slug);
 
   if (!page) notFound();
 

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,11 +1,20 @@
 import { getPages } from '@/utils/docs-loader';
+import { getIntegrationPages } from '@/utils/integrations-loader';
 import { createSearchAPI } from 'fumadocs-core/search/server';
 
 export const { GET } = createSearchAPI('advanced', {
-  indexes: getPages().map((page) => ({
-    title: page.data.title,
-    structuredData: page.data.exports.structuredData,
-    id: page.url,
-    url: page.url,
-  })),
+  indexes: [
+    ...getPages().map((page) => ({
+      title: page.data.title,
+      structuredData: page.data.exports.structuredData,
+      id: page.url,
+      url: page.url,
+    })),
+    ...getIntegrationPages().map((page) => ({
+      title: page.data.title,
+      structuredData: page.data.exports.structuredData,
+      id: page.url,
+      url: page.url,
+    })),
+  ],
 });

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -1,10 +1,10 @@
-import { getPages } from '@/utils/docs-loader';
+import { getDocsPages } from '@/utils/docs-loader';
 import { getIntegrationPages } from '@/utils/integrations-loader';
 import { createSearchAPI } from 'fumadocs-core/search/server';
 
 export const { GET } = createSearchAPI('advanced', {
   indexes: [
-    ...getPages().map((page) => ({
+    ...getDocsPages().map((page) => ({
       title: page.data.title,
       structuredData: page.data.exports.structuredData,
       id: page.url,

--- a/app/integrations/[slug]/page.tsx
+++ b/app/integrations/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import type { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import Link from 'next/link';
-import { getPage, getPages } from '@/utils/integrations-loader';
+import { getIntegrationPage, getIntegrationPages } from '@/utils/integrations-loader';
 import { createMetadata } from '@/utils/metadata';
 import { buttonVariants } from '@/components/ui/button';
 import { ArrowUpRightIcon } from 'lucide-react';
@@ -19,7 +19,7 @@ export default function Page({
 }: {
     params: Param;
 }): React.ReactElement {
-    const page = getPage([params.slug]);
+    const page = getIntegrationPage([params.slug]);
 
     if (!page) notFound();
 
@@ -109,7 +109,7 @@ export default function Page({
 }
 
 export function generateMetadata({ params }: { params: Param }): Metadata {
-    const page = getPage([params.slug]);
+    const page = getIntegrationPage([params.slug]);
 
     if (!page) notFound();
 
@@ -142,7 +142,7 @@ export function generateMetadata({ params }: { params: Param }): Metadata {
 
 
 export function generateStaticParams(): Param[] {
-    return getPages().map<Param>((page) => ({
+    return getIntegrationPages().map<Param>((page) => ({
         slug: page.slugs[0],
     }));
 }

--- a/app/integrations/page.tsx
+++ b/app/integrations/page.tsx
@@ -1,12 +1,12 @@
 import Link from 'next/link';
-import { getPages } from '@/utils/integrations-loader';
+import { getIntegrationPages } from '@/utils/integrations-loader';
 import { cn } from '@/utils/cn';
 import { buttonVariants } from '@/components/ui/button';
 import { Pills } from '@/components/ui/pills';
 
 
 export default function Page(): React.ReactElement {
-    const integrationsList = [...getPages()]
+    const integrationsList = [...getIntegrationPages()]
 
     const groupedIntegrations: { [key: string]: any[] } = integrationsList.reduce((acc: { [key: string]: any[] }, integration) => {
         const category = integration.data.category;
@@ -30,7 +30,7 @@ export default function Page(): React.ReactElement {
                 <div className="mx-auto w-full flex flex-col items-center lg:mx-0">
                     <h1 className="mb-6 text-center text-4xl font-semibold md:text-5xl">Find an Integration</h1>
                     <p className="mb-6 h-fit text-center p-2 text-fd-muted-foreground md:max-w-[80%] md:text-xl">
-                        Discover best-in-class intergrations for your Avalanche L1 and learn how to use them.
+                        Discover best-in-class integrations for your Avalanche L1 and learn how to use them.
                     </p>
                     <div className='inline-flex items-center gap-3'>
                         <Link className={cn(buttonVariants())} href={`#${firstCategory}`}>Discover Integrations</Link>

--- a/app/layout.config.tsx
+++ b/app/layout.config.tsx
@@ -1,6 +1,6 @@
 import { type BaseLayoutProps, type DocsLayoutProps } from 'fumadocs-ui/layout';
 import { Title } from '@/app/layout.client';
-import { pageTree } from '@/utils/docs-loader';
+import { docsPageTree } from '@/utils/docs-loader';
 import { RootToggle } from 'fumadocs-ui/components/layout/root-toggle';
 import { MailIcon, SproutIcon, SquareGanttChart, IndentDecrease, Layers, MonitorCheck, Settings, Webhook } from 'lucide-react';
 
@@ -30,7 +30,7 @@ export const baseOptions: BaseLayoutProps = {
 // docs layout configuration
 export const docsOptions: DocsLayoutProps = {
   ...baseOptions,
-  tree: pageTree,
+  tree: docsPageTree,
   sidebar: {
     defaultOpenLevel: 0,
     banner: (

--- a/utils/docs-loader.ts
+++ b/utils/docs-loader.ts
@@ -26,4 +26,4 @@ const loaderOutput = loader({
 
 export type Page = InferPageType<typeof loaderOutput>;
 export type Meta = InferMetaType<typeof loaderOutput>;
-export const { getPage, getPages, pageTree } = loaderOutput;
+export const { getPage: getDocsPage, getPages: getDocsPages, pageTree: docsPageTree } = loaderOutput;

--- a/utils/integrations-loader.ts
+++ b/utils/integrations-loader.ts
@@ -30,4 +30,4 @@ const loaderOutput = loader({
 
 export type Page = InferPageType<typeof loaderOutput>;
 export type Meta = InferMetaType<typeof loaderOutput>;
-export const { getPage, getPages, pageTree } = loaderOutput;
+export const { getPage: getIntegrationPage, getPages: getIntegrationPages, pageTree: integrationPageTree } = loaderOutput;

--- a/utils/integrations-loader.ts
+++ b/utils/integrations-loader.ts
@@ -5,7 +5,6 @@ import { loader } from 'fumadocs-core/source';
 import { icons } from 'lucide-react';
 import { map } from '.map';
 import { create } from '@/components/ui/icon';
-import { availableMemory } from 'process';
 
 const loaderOutput = loader({
     baseUrl: '/integrations',


### PR DESCRIPTION
till now, the search route only creates index for the Docs pages. this PR configure the search route file and integration-loader to also create index for integration pages.

TODO: replicate this on Academy (to include guides in search)