### PR TITLE
`avalanche key transfer`

### DIFF
--- a/content/docs/tooling/meta.json
+++ b/content/docs/tooling/meta.json
@@ -10,6 +10,7 @@
     "create-avalanche-nodes",
     "cross-chain",
     "transfer-p-chain-funds",
+    "transactions",
     "---Scripts & APIs---",
     "avalanche-js",
     "glacier-api",

--- a/content/docs/tooling/transactions/ledger-p-chain-transfer.mdx
+++ b/content/docs/tooling/transactions/ledger-p-chain-transfer.mdx
@@ -1,5 +1,5 @@
 ---
-title: Transfer P-Chain Funds
+title: Ledger P-Chain Transfer
 description: Transferring funds between P-Chain using Avalanche CLI.
 ---
 

--- a/content/docs/tooling/transactions/native-send.mdx
+++ b/content/docs/tooling/transactions/native-send.mdx
@@ -33,7 +33,7 @@ You will be prompted to answer the following questions:
     Devnet
     Local Network
 ```
-
+<Accordions>
 <Accordion title="Note: Devnet">
 If you select "Devnet", you must input the RPC URL. If your devnet's C-Chain RPC is `https://demo.avax-dev.network/ext/bc/C/rpc`, you should input the URL as: 
 
@@ -42,6 +42,7 @@ If you select "Devnet", you must input the RPC URL. If your devnet's C-Chain RPC
 ```
 
 </Accordion>
+</Accordions>
 
 Select the chain you want to transfer funds from:
 

--- a/content/docs/tooling/transactions/native-send.mdx
+++ b/content/docs/tooling/transactions/native-send.mdx
@@ -10,7 +10,7 @@ description: Learn how to execute a native transfer on the C or P-Chain using th
 - Fund the key with AVAX. You can use the [faucet](https://test.core.app/tools/testnet-faucet/?subnet=c&token=c) with coupon code `devrel-avax-0112` to get testnet AVAX. 
 - *Optionally*, you can [export](https://docs.avax.network/tooling/avalanche-cli#key-export) your private key for use in scripting or other tools. 
 
-# Initiate the `transfer` Command and Walk Through the Prompts
+## Initiate the `transfer` Command and Walk Through the Prompts
 
 In your terminal, run the following command:
 

--- a/content/docs/tooling/transactions/native-send.mdx
+++ b/content/docs/tooling/transactions/native-send.mdx
@@ -1,0 +1,105 @@
+---
+title: Send AVAX on C/P-Chain
+description: Learn how to execute a native transfer on the C or P-Chain using the Avalanche CLI.
+---
+
+# Prerequisites
+
+- Install the [Avalanche CLI](https://docs.avax.network/tooling/guides/get-avalanche-cli).
+- Use the CLI to [create a key](https://docs.avax.network/tooling/avalanche-cli#key-create).
+- Fund the key with AVAX. You can use the [faucet](https://test.core.app/tools/testnet-faucet/?subnet=c&token=c) with coupon code `devrel-avax-0112` to get testnet AVAX. 
+- *Optionally*, you can [export](https://docs.avax.network/tooling/avalanche-cli#key-export) your private key for use in scripting or other tools. 
+
+# Initiate the `transfer` Command and Walk Through the Prompts
+
+In your terminal, run the following command:
+
+```zsh
+avalanche key transfer
+```
+
+You will be prompted to answer the following questions:
+
+```zsh
+? On what Network do you want to execute the transfer?:
+  ▸ Mainnet
+    Fuji Testnet
+    Devnet
+    Local Network
+```
+
+<Accordion title="Note: Devnet">
+If you select "Devnet", you must input the RPC URL. If your devnet's C-Chain RPC is `https://demo.avax-dev.network/ext/bc/C/rpc`, you should input the URL as: 
+
+```zsh
+✔ Devnet Endpoint: https://demo.avax-dev.network
+```
+
+</Accordion>
+
+Select the chain you want to transfer funds from:
+
+```zsh
+? Where are the funds to transfer?:
+  ▸ P-Chain
+    C-Chain
+    My blockchain isn't listed
+```
+
+Select the chain you want to transfer funds to:
+
+```zsh
+? Destination Chain:
+  ▸ P-Chain
+    X-Chain
+```
+
+Select the step of the transfer process you want to execute:
+
+```zsh
+? Step of the transfer:
+  ▸ Send
+    Receive
+```
+
+<Callout title="Note">
+
+If you are performing a native transfer where the sender and receiver address are on the same chain, you only need to complete a "send" transaction. 
+
+If you wish to perform a cross-chain transfer (i.e. from C to P-Chain), you should abort this flow and reinitiate the command as `avalanche key transfer --fund-p-chain` or `avalanche key transfer --fund-x-chain`, completing both the "send" and "receive" flows with keys stored in the CLI.
+You can fund your CLI-stored key with AVAX on the C-Chain using the [faucet](https://test.core.app/tools/testnet-faucet/?subnet=c&token=c) with coupon code `devrel-avax-0112`.
+
+</Callout>
+
+Select the sender address:
+
+```zsh
+? Which key should be used as the sender?:
+  ▸ Use stored key
+    Use ledger
+? Which stored key should be used as the sender address?:
+  ▸ DemoKey
+    MyKey
+    ewoq
+```
+
+Specify the amount to send, input the destination address: 
+  
+```zsh
+✗ Amount to send (AVAX units): 100
+✗ Destination address: P-avax1zgjx8zj7z7zj7z7zj7z7zj7z7zj7zj7zj7zj7e
+```
+
+Review the transaction details and confirm/abort:
+
+```zsh
+this operation is going to:
+- send 100.000000000 AVAX from P-avax1gmuqt8xg9j4h88kj3hyprt23nf50azlfg8txn2 to destination address P-avax1f630gvct4ht35ragcheapnn2n5cv2tkmq73ec0
+- take a fee of 0.001000000 AVAX from source address P-avax1gmuqt8xg9j4h88kj3hyprt23nf50azlfg8txn2
+? Confirm transfer:
+    No
+  ▸ Yes
+```
+
+
+

--- a/content/docs/tooling/transactions/native-send.mdx
+++ b/content/docs/tooling/transactions/native-send.mdx
@@ -18,6 +18,12 @@ In your terminal, run the following command:
 avalanche key transfer
 ```
 
+<Callout title="Note">
+
+This command and all of its flags are documented [here](https://docs.avax.network/tooling/avalanche-cli#key-transfer).
+
+</Callout>
+
 You will be prompted to answer the following questions:
 
 ```zsh
@@ -100,6 +106,3 @@ this operation is going to:
     No
   ▸ Yes
 ```
-
-
-

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -596,6 +596,11 @@ const config = {
         permanent: true,
       },
       {
+        source: '/tooling/transfer-p-chain-funds',
+        destination: '/tooling/transactions/ledger-p-chain-transfer',
+        permanent: true,
+      },
+      {
         source: '/tooling/avalanchego-postman-collection/data-visualization',
         destination: '/tooling/avalanche-postman/data-visualization',
         permanent: true,


### PR DESCRIPTION
Documents the CLI for a native P-chain address to P-chain address. Include notes about using this funcitonality for cross-primary-network-chain transfers (i.e. sending AVAX from C to P-chain). 