### PR TITLE
fix 404s

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -875,6 +875,125 @@ const config = {
         destination: '/tooling/create-deploy-avalanche-l1s/deploy-locally',
         permanent: true,
       },
+      {
+        source: '/tooling/guides/import-subnet',
+        destination: '/tooling/guides/import-avalanche-l1',
+        permanent: true,
+      },
+      {
+        source: '/tooling/create-avalanche-nodes/validate-subnet',
+        destination: '/tooling/create-avalanche-nodes/validate-avalanche-l1',
+        permanent: true,
+      },
+      {
+        source: '/tooling/create-avalanche-nodes/execute-ssh-commander',
+        destination: '/tooling/create-avalanche-nodes/execute-ssh-commands',
+        permanent: true,
+      },
+      {
+        source: '/tooling/create-deploy-subnets',
+        destination: '/tooling/create-deploy-avalanche-l1s',
+        permanent: true,
+      },
+      {
+        source: '/nodes/configure/subnet-configs',
+        destination: '/nodes/configure/avalanche-l1-configs',
+      },
+      {
+        source: '/api-reference/p-chain/transaction-format',
+        destination: '/api-reference/p-chain/txn-format/',
+        permanent: true,
+      }, 
+      {
+        source: '/api-reference/c-chain/transaction-format',
+        destination: '/api-reference/c-chain/txn-format',
+        permanent: true,
+      },
+      {
+        source: '/api-reference/x-chain/transaction-format',
+        destination: '/api-reference/x-chain/txn-format',
+        permanent: true,
+      },
+      {
+        source: '/api-reference/standards/serialization',
+        destination: '/api-reference/standards/serialization-primitives',
+        permanent: true,
+      },
+      {
+        source: '/api-reference/standards/cryptography',
+        destination: '/api-reference/standards/cryptographic-primitives',
+        permanent: true,
+      },
+      {
+        source: '/api-reference/standards/guides/flow-single-blockchain',
+        destination: '/api-reference/standards/guides/blockchain-flow',
+        permanent: true,
+      },
+      {
+        source: '/api-reference/standards/guides/api-calls',
+        destination: '/api-reference/standards/guides/issuing-api-calls',
+        permanent: true,
+      },
+      {
+        source: '/api-reference/standards/network-protocol',
+        destination: '/api-reference/standards/avalanche-network-protocol',
+        permanent: true,
+      },
+      {
+        source: '/dapps/smart-contract-dev/interact-golang-map',
+        destination: '/dapps/smart-contract-dev/interact-golang-app',
+        permanent: true,
+      },
+      {
+        source: '/subnets/upgrade/considerations',
+        destination: '/avalanche-l1s/upgrade/considerations',
+        permanent: true,
+      },
+      {
+        source: '/subnets/upgrade/durango-upgrade',
+        destination: '/avalanche-l1s/upgrade/durango-upgrade',
+        permanent: true,
+      },
+      {
+        source: '/subnets/upgrade/subnet-precompfile-config',
+        destination: '/avalanche-l1s/upgrade/avalanche-l1-precompile-config',
+        permanent: true,
+      },
+      {
+        source: '/subnets/avalanche-cli-subnets',
+        destination: '/avalanche-l1s/deploy-a-avalanche-l1/local-network',
+        permanent: true,
+      },
+      {
+        source: '/subnets/deploy-a-subnet/production-infrastructure',
+        destination: '/avalanche-l1s/deploy-a-avalanche-l1/production-infrastructure',
+        permanent: true,
+      },
+      {
+        source: '/subnets/deploy-a-subnet/multisig-auth',
+        destination: '/avalanche-l1s/deploy-a-avalanche-l1/multisig-auth',
+        permanent: true,
+      },
+      {
+        source: '/subnets/maintain/transfer-pchain-funds',
+        destination: '/avalanche-l1s/maintain/transfer-pchain-funds',
+        permanent: true,
+      },
+      {
+        source: '/subnets/add-utility/cross-chain-bridge',
+        destination: '/avalanche-l1s/add-utility/cross-chain-bridge',
+        permanent: true,
+      },
+      {
+        source: '/subnets/add-utility/deploy-smart-contract',
+        destination: '/avalanche-l1s/add-utility/deploy-smart-contract',
+        permanent: true,
+      },
+      {
+        source: '/subnets/wagmi-subnet',
+        destination: '/avalanche-l1s/wagmi-avalanche-l1',
+        permanent: true,
+      },
     ]
   },
 };

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -898,6 +898,7 @@ const config = {
       {
         source: '/nodes/configure/subnet-configs',
         destination: '/nodes/configure/avalanche-l1-configs',
+        permanent: true,
       },
       {
         source: '/api-reference/p-chain/transaction-format',
@@ -993,7 +994,7 @@ const config = {
         source: '/subnets/wagmi-subnet',
         destination: '/avalanche-l1s/wagmi-avalanche-l1',
         permanent: true,
-      },
+      }
     ]
   },
 };


### PR DESCRIPTION
Pulled all mdx paths from commit hash abf978b9172914136a020f48148d0d4e210433ad (fumadocs migration)
Checked them against https://docs.avax.network

```
192 links founds

https://docs.avax.network/tooling/guides/import-subnet 404
https://docs.avax.network/tooling/create-avalanche-nodes/validate-subnet 404
https://docs.avax.network/tooling/create-avalanche-nodes/execute-ssh-commander 404
https://docs.avax.network/tooling/create-deploy-subnets 404
https://docs.avax.network/nodes/configure/subnet-configs 404
https://docs.avax.network/api-reference/p-chain/transaction-format 404
https://docs.avax.network/api-reference/c-chain/transaction-format 404
https://docs.avax.network/api-reference/x-chain/transaction-format 404
https://docs.avax.network/api-reference/standards/serialization 404
https://docs.avax.network/api-reference/standards/cryptography 404
https://docs.avax.network/api-reference/standards/guides/flow-single-blockchain 404
https://docs.avax.network/api-reference/standards/guides/api-calls 404
https://docs.avax.network/api-reference/standards/network-protocol 404
https://docs.avax.network/dapps/smart-contract-dev/interact-golang-map 404
https://docs.avax.network/subnets/upgrade/considerations 404
https://docs.avax.network/subnets/upgrade/durango-upgrade 404
https://docs.avax.network/subnets/upgrade/subnet-precompfile-config 404
https://docs.avax.network/subnets/avalanche-cli-subnets 404
https://docs.avax.network/subnets/deploy-a-subnet/production-infrastructure 404
https://docs.avax.network/subnets/deploy-a-subnet/multisig-auth 404
https://docs.avax.network/subnets/maintain/transfer-pchain-funds 404
https://docs.avax.network/subnets/add-utility/cross-chain-bridge 404
https://docs.avax.network/subnets/add-utility/deploy-smart-contract 404
https://docs.avax.network/subnets/wagmi-subnet 404

24 broken links
```

Added redirects to `next.config.mjs`