### PR TITLE
Fix typo in 'Custom Virtual Machine' documentation

### DIFF
--- a/content/docs/avalanche-l1s/deploy-a-avalanche-l1/custom-virtual-machine.mdx
+++ b/content/docs/avalanche-l1s/deploy-a-avalanche-l1/custom-virtual-machine.mdx
@@ -104,7 +104,7 @@ timestamp when you create your genesis file.
 Create the Avalanche L1 Configuration[​](#create-the-avalanche-l1-configuration "Direct link to heading")
 ---------------------------------------------------------------------------------------------
 
-Now that you have your binary, it's time to create the Avalanche L1 configuration. This tutorial uses `myblockchain` as it Avalanche L1 name. Invoke the Avalanche L1 Creation Wizard with this command:
+Now that you have your binary, it's time to create the Avalanche L1 configuration. This tutorial uses `myblockchain` as it's Avalanche L1 name. Invoke the Avalanche L1 Creation Wizard with this command:
 
 ```bash
 avalanche blockchain create myblockchain


### PR DESCRIPTION
Fixes #1967 

This pull request includes a minor correction to the `content/docs/avalanche-l1s/deploy-a-avalanche-l1/custom-virtual-machine.mdx` file. The change corrects a grammatical error in the documentation.

* Corrected "it Avalanche L1 name" to "it's Avalanche L1 name" in the `content/docs/avalanche-l1s/deploy-a-avalanche-l1/custom-virtual-machine.mdx` file.