### PR TITLE
remove eth_getAssetBalance

### DIFF
--- a/content/docs/api-reference/c-chain/api.mdx
+++ b/content/docs/api-reference/c-chain/api.mdx
@@ -83,71 +83,13 @@ number of items is 40. We are working on to support a larger batch size.
 
 ### Avalanche - Ethereum APIs
 
-In addition to the standard Ethereum APIs, Avalanche offers `eth_getAssetBalance`, `eth_baseFee`,
+In addition to the standard Ethereum APIs, Avalanche offers `eth_baseFee`,
 `eth_maxPriorityFeePerGas`, and `eth_getChainConfig`.
 
 They use the same endpoint as standard Ethereum APIs:
 
 ```sh
 /ext/bc/C/rpc
-```
-
-#### `eth_getAssetBalance`
-
-Retrieves the balance of first class Avalanche Native Tokens on the C-Chain (excluding AVAX,
-which must be fetched with `eth_getBalance`).
-
-<Callout title="Note">
-
-The AssetID for AVAX differs depending on the network you are on.
-
-Mainnet: FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z
-
-Testnet: U8iRqJoiJm8xZHAacmvYyZVwqQx6uDNtQeP3CQ6fcgQk3JqnK
-
-For finding the `assetID` of other assets, please note that
-`avax.getUTXOs` and `avax.getAtomicTx` return the `assetID` in
-their output.
-
-</Callout>
-
-**Signature:**
-
-```sh
-eth_getAssetBalance({
-    address: string,
-    blk: BlkNrOrHash,
-    assetID: string,
-}) -> {balance: int}
-```
-
-- `address` owner of the asset
-- `blk` is the block number or hash at which to retrieve the balance
-- `assetID` id of the asset for which the balance is requested
-
-**Example Call:**
-
-```sh
-curl -X POST --data '{
-    "jsonrpc": "2.0",
-    "method": "eth_getAssetBalance",
-    "params": [
-        "0x8723e5773847A4Eb5FeEDabD9320802c5c812F46",
-        "latest",
-        "3RvKBAmQnfYionFXMfW5P8TDZgZiogKbHjM8cjpu16LKAgF5T"
-    ],
-    "id": 1
-}' -H 'content-type:application/json;' 127.0.0.1:9650/ext/bc/C/rpc
-```
-
-**Example Response:**
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "result": "0x1388"
-}
 ```
 
 #### `eth_baseFee`

--- a/content/docs/api-reference/c-chain/configs.mdx
+++ b/content/docs/api-reference/c-chain/configs.mdx
@@ -274,7 +274,6 @@ Adds the following RPC calls to the `eth_*` namespace. Defaults to `true`.
 - `eth_chainId`
 - `eth_blockNumber`
 - `eth_getBalance`
-- `eth_getAssetBalance`
 - `eth_getProof`
 - `eth_getHeaderByNumber`
 - `eth_getHeaderByHash`

--- a/content/docs/nodes/chain-configs/c-chain.mdx
+++ b/content/docs/nodes/chain-configs/c-chain.mdx
@@ -225,7 +225,6 @@ Adds the following RPC calls to the `eth_*` namespace. Defaults to `true`.
 - `eth_chainId`
 - `eth_blockNumber`
 - `eth_getBalance`
-- `eth_getAssetBalance`
 - `eth_getProof`
 - `eth_getHeaderByNumber`
 - `eth_getHeaderByHash`

--- a/content/docs/tooling/avalanche-postman/data-visualization.mdx
+++ b/content/docs/tooling/avalanche-postman/data-visualization.mdx
@@ -13,7 +13,6 @@ Data visualizations are available for following API calls:
 - [`eth_baseFee`](/api-reference/c-chain/api#eth_basefee)
 - [`eth_blockNumber`](https://www.quicknode.com/docs/ethereum/eth_blockNumber)
 - [`eth_chainId`](https://www.quicknode.com/docs/ethereum/eth_chainId)
-- [`eth_getAssetBalance`](/api-reference/c-chain/api#eth_getassetbalance)
 - [`eth_getBalance`](https://www.quicknode.com/docs/ethereum/eth_getBalance)
 - [`eth_getBlockByHash`](https://www.quicknode.com/docs/ethereum/eth_getBlockByHash)
 - [`eth_getBlockByNumber`](https://www.quicknode.com/docs/ethereum/eth_getBlockByNumber)


### PR DESCRIPTION
ANT (avalanche native tokens) precompiles have been disabled completely since ApricotPhase 6, and there is no intention to re-enable them in the future.
We plan to remove these from coreth: https://github.com/ava-labs/coreth/pull/715.