### PR TITLE
Remove deprecated x-chain wss endpoint examples

### DIFF
--- a/content/docs/api-reference/rpc-providers.mdx
+++ b/content/docs/api-reference/rpc-providers.mdx
@@ -140,10 +140,9 @@ Features:
 
 ##### Websockets[​](#websockets-2 "Direct link to heading")
 
-Websockets are available for the C-chain and the X-chain.
+Websockets are available for the C-chain
 
-- For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is `wss://avalanche-mainnet.core.chainstack.com/ws/ext/bc/C/ws/API_KEY`
-- For X-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/X/events`, and the global elastic node URL is `wss://avalanche-mainnet.core.chainstack.com/ws/ext/bc/X/events/API_KEY`
+For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-mainnet.core.chainstack.com/ext/bc/C/ws/API_KEY`
 
 #### Testnet (Fuji)[​](#testnet-fuji-2 "Direct link to heading")
 
@@ -155,10 +154,9 @@ Websockets are available for the C-chain and the X-chain.
 
 ##### Websockets[​](#websockets-3 "Direct link to heading")
 
-Websockets are available for the C-chain and the X-chain.
+Websockets are available for the C-chain
 
-- For C-Chain API, the URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`
-- For X-Chain API, the URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/X/events`
+For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-fuji.core.chainstack.com/ext/bc/C/ws/API_KEY`
 
 ### DRPC[​](#drpc "Direct link to heading")
 

--- a/content/docs/api-reference/rpc-providers.mdx
+++ b/content/docs/api-reference/rpc-providers.mdx
@@ -156,7 +156,7 @@ For the C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p
 
 Websockets are available for the C-chain.
 
-For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-fuji.core.chainstack.com/ext/bc/C/ws/API_KEY`
+For the C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is `wss://avalanche-fuji.core.chainstack.com/ext/bc/C/ws/API_KEY`
 
 ### DRPC[​](#drpc "Direct link to heading")
 

--- a/content/docs/api-reference/rpc-providers.mdx
+++ b/content/docs/api-reference/rpc-providers.mdx
@@ -142,7 +142,7 @@ Features:
 
 Websockets are available for the C-chain.
 
-For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-mainnet.core.chainstack.com/ext/bc/C/ws/API_KEY`
+For the C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is `wss://avalanche-mainnet.core.chainstack.com/ext/bc/C/ws/API_KEY`
 
 #### Testnet (Fuji)[​](#testnet-fuji-2 "Direct link to heading")
 

--- a/content/docs/api-reference/rpc-providers.mdx
+++ b/content/docs/api-reference/rpc-providers.mdx
@@ -154,7 +154,7 @@ For the C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p
 
 ##### Websockets[​](#websockets-3 "Direct link to heading")
 
-Websockets are available for the C-chain
+Websockets are available for the C-chain.
 
 For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-fuji.core.chainstack.com/ext/bc/C/ws/API_KEY`
 

--- a/content/docs/api-reference/rpc-providers.mdx
+++ b/content/docs/api-reference/rpc-providers.mdx
@@ -140,7 +140,7 @@ Features:
 
 ##### Websockets[​](#websockets-2 "Direct link to heading")
 
-Websockets are available for the C-chain
+Websockets are available for the C-chain.
 
 For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-mainnet.core.chainstack.com/ext/bc/C/ws/API_KEY`
 

--- a/content/docs/tooling/rpc-providers.mdx
+++ b/content/docs/tooling/rpc-providers.mdx
@@ -208,10 +208,9 @@ Features:
 
 ##### Websockets
 
-Websockets are available for the C-chain and the X-chain.
+Websockets are available for the C-chain
 
-- For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is `wss://avalanche-mainnet.core.chainstack.com/ws/ext/bc/C/ws/API_KEY`
-- For X-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/X/events`, and the global elastic node URL is `wss://avalanche-mainnet.core.chainstack.com/ws/ext/bc/X/events/API_KEY`
+For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-mainnet.core.chainstack.com/ext/bc/C/ws/API_KEY`
 
 #### Testnet (Fuji)
 
@@ -223,10 +222,9 @@ Websockets are available for the C-chain and the X-chain.
 
 ##### Websockets
 
-Websockets are available for the C-chain and the X-chain.
+Websockets are available for the C-chain
 
-- For C-Chain API, the URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`
-- For X-Chain API, the URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/X/events`
+For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-fuji.core.chainstack.com/ext/bc/C/ws/API_KEY`
 
 ### DRPC
 

--- a/content/docs/tooling/rpc-providers.mdx
+++ b/content/docs/tooling/rpc-providers.mdx
@@ -210,7 +210,7 @@ Features:
 
 Websockets are available for the C-chain.
 
-For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-mainnet.core.chainstack.com/ext/bc/C/ws/API_KEY`
+For the C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is `wss://avalanche-mainnet.core.chainstack.com/ext/bc/C/ws/API_KEY`
 
 #### Testnet (Fuji)
 

--- a/content/docs/tooling/rpc-providers.mdx
+++ b/content/docs/tooling/rpc-providers.mdx
@@ -222,7 +222,7 @@ For the C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p
 
 ##### Websockets
 
-Websockets are available for the C-chain
+Websockets are available for the C-chain.
 
 For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-fuji.core.chainstack.com/ext/bc/C/ws/API_KEY`
 

--- a/content/docs/tooling/rpc-providers.mdx
+++ b/content/docs/tooling/rpc-providers.mdx
@@ -224,7 +224,7 @@ For the C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p
 
 Websockets are available for the C-chain.
 
-For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-fuji.core.chainstack.com/ext/bc/C/ws/API_KEY`
+For the C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is `wss://avalanche-fuji.core.chainstack.com/ext/bc/C/ws/API_KEY`
 
 ### DRPC
 

--- a/content/docs/tooling/rpc-providers.mdx
+++ b/content/docs/tooling/rpc-providers.mdx
@@ -208,7 +208,7 @@ Features:
 
 ##### Websockets
 
-Websockets are available for the C-chain
+Websockets are available for the C-chain.
 
 For C-Chain API, the regional elastic node URL is `wss://ws-nd-123-145-789.p2pify.com/API_KEY/ext/bc/C/ws`, and the global elastic node URL is wss://avalanche-mainnet.core.chainstack.com/ext/bc/C/ws/API_KEY`
 


### PR DESCRIPTION
Since the X-Chain events websocket endpoint is deprecated in the node client as per https://docs.avax.network/api-reference/x-chain/api#events , removing it from the docs pertaining to Chainstack as well.