### PR TITLE
Fixes minor English errors (in 07-message-delivery.mdx) and tests "Edit on GitHub" button

### DIFF
--- a/content/academy/interchain-messaging/09-avalanche-warp-messaging/07-message-delivery.mdx
+++ b/content/academy/interchain-messaging/09-avalanche-warp-messaging/07-message-delivery.mdx
@@ -8,7 +8,7 @@ icon: BookOpen
 
 import { Step, Steps } from 'fumadocs-ui/components/steps';
 
-Next, the AWM Relayer delivers the message with the aggregated signature by simply submitting a transaction to the destination Avalanche L1. The transaction is propagated through the validator set of the destination blockchain just as any other regular transaction would.
+Next, the AWM Relayer delivers the message with the aggregated signature by simply submitting a transaction to the destination Avalanche L1. The transaction is propagated through the validator set of the destination blockchain just as any other regular transaction would be.
 
 In order to submit the transaction, the AWM Relayer needs access to the private key of a wallet holding the gas token of the destination blockchain to sign the transaction.
 
@@ -27,7 +27,7 @@ The verifying validators of the destination L1 each query the validator set of t
 <Step>
  
 ### Verify Sufficient Stake Weight:
-First, the verifying validators are checking if the combined stake weight of the validators that have signed the Warp message is large enough to accept the message (e.g. validators representing 50% of the total stake have signed the message). The required stake weight required to accept a message from a source chain can be set arbitrarily by the destination chain. An Avalanche L1 may require 50% for chain A and 90% for chain B. If the stake weight of the validators of the aggregate signature is insufficient the message is rejected.
+First, the verifying validators are checking if the combined stake weight of the validators that have signed the Warp message is large enough to accept the message (e.g. validators representing 50% of the total stake have signed the message). The required stake weight to accept a message from a source chain can be set arbitrarily by the destination chain. An Avalanche L1 may require 50% for chain A and 90% for chain B. If the stake weight of the validators of the aggregate signature is insufficient the message is rejected.
 
 </Step>
 


### PR DESCRIPTION
I noticed a couple of minor language inconsistencies and tested the "Edit on GitHub" button in the UI. It seems the button links to a defunct branch: [here](https://github.com/ava-labs/avalanche-docs/blob/main/content/academy/interchain-messaging/09-avalanche-warp-messaging/07-message-delivery.mdx) (this leads to a 404 page). This PR fixes these small English issues for clarity and readability. I don't want to update the link in case there is a rationale behind the current implementation. 

I’m exploring ways to contribute further and familiarizing myself with the workflow for creating PRs in the docs repo. Feel free to let me know if there's anything else you'd like me to refine, I'm happy to make similar changes to previous sections if it would be helpful.