### PR TITLE
chore: fixed missing semicolon in networkID declaration

### DIFF
--- a/scripts/fund-cchain-addresses.js
+++ b/scripts/fund-cchain-addresses.js
@@ -8,7 +8,7 @@ const sleep = (ms) => {
 const ip = "localhost";
 const port = 9650;
 const protocol = "http";
-const networkID = 1337
+const networkID = 1337;
 const avalanche = new avalanche_1.Avalanche(ip, port, protocol, networkID);
 const mstimeout = 3000;
 const xchain = avalanche.XChain();


### PR DESCRIPTION
I added a semicolon at the end of the `const networkID = 1337` declaration.
While this doesn't cause an issue in JavaScript, it improves readability and ensures better compatibility with various build tools and linters.