### PR TITLE
docs: fix typo error "rountripMessage" to "roundtripMessage" on academy 05-02 

### DIFF
--- a/content/academy/interchain-messaging/05-two-way-communication/02-sender-contract.mdx
+++ b/content/academy/interchain-messaging/05-two-way-communication/02-sender-contract.mdx
@@ -27,7 +27,7 @@ import "@teleporter/ITeleporterReceiver.sol"; // [!code highlight]
 contract SenderOnCChain is ITeleporterReceiver { // [!code highlight]
     ITeleporterMessenger public immutable messenger = ITeleporterMessenger(0x253b2784c75e510dD0fF1da844684a1aC0aa5fcf);
 
-    string public rountripMessage;
+    string public roundtripMessage;
 
     /**
      * @dev Sends a message to another chain.
@@ -51,7 +51,7 @@ contract SenderOnCChain is ITeleporterReceiver { // [!code highlight]
         require(msg.sender == address(messenger), "SenderOnCChain: unauthorized TeleporterMessenger");
 
         // Store the message.
-        rountripMessage = abi.decode(message, (string));
+        roundtripMessage = abi.decode(message, (string));
     }
 }
 ```


### PR DESCRIPTION

### Fix typo in Interchain Messaging section 02 :

- The variable "roundtripMessage" was "rountripMessage" leading to confusion and an error when in the section 06 we call the getter of the variable.
- This update improves clarity and correct this problem.