### PR TITLE
fix: update dead link to Privy website

### DIFF
--- a/content/integrations/privy.mdx
+++ b/content/integrations/privy.mdx
@@ -5,7 +5,7 @@ available: ["C-Chain", "All EVM L1s"]
 description: "Spin up embedded wallets and beautiful authentication flows for all users."
 logo: /images/privy.png
 developer: Privy
-website: https://privy.dev/
+website: https://privy.io/
 documentation: https://docs.privy.io/
 ---
 


### PR DESCRIPTION
Hi! I fixes a dead link in the `privy.mdx` file. The old link pointed to a non-existent page for the Privy website. It has been updated to the correct and current URL.