### PR TITLE
chore: fix JSON syntax issue in create_config_file

### DIFF
--- a/scripts/avalanchego-installer.sh
+++ b/scripts/avalanchego-installer.sh
@@ -68,7 +68,7 @@ create_config_file () {
     echo "  \"state-sync-enabled\": true$commaAdd">>config.json
   fi
   if [ "$stateOpt" = "off" ]; then
-    echo "  \"state-sync-enabled\": false$commaAdd">>config.json
+    echo "  \"state-sync-enabled\": false">>config.json
   fi
   if [ "$archivalOpt" = "true" ]; then
     echo "  \"pruning-enabled\": false">>config.json


### PR DESCRIPTION
Found and fixed a bug in `create_config_file` that could produce invalid JSON.  

Previously, the `commaAdd` variable was appended even to the last element, causing a syntax error. Now, if `state-sync-enabled` is the last item, the comma is no longer added.  

The generated file is now valid.