### PR TITLE
docs: fix typos in Core Wallet setup and deployment instructions

### DIFF
--- a/content/academy/avalanche-fundamentals/04-creating-a-blockchain/03-create-on-avacloud.mdx
+++ b/content/academy/avalanche-fundamentals/04-creating-a-blockchain/03-create-on-avacloud.mdx
@@ -15,7 +15,7 @@ In this section, we will get our first taste of deploying an Avalanche L1.
 
 ### Connect Core Wallet
 
-To start, please make sure your have the Core wallet set up. Connect the wallet at the top right.
+To start, please make sure you have the Core wallet set up. Connect the wallet at the top right.
 
 </Step>
 <Step>
@@ -50,7 +50,7 @@ At the bottom, you will see a button named Advanced Avalanche L1 Setup. You can 
 
 ### Deploy the L1
 
-Click the next button, hit the Submit Devnet button on the next page, and you will have successful deployed your Avalanche L1. You should see a screen similar to the following:
+Click the next button, hit the Submit Devnet button on the next page, and you will have successfully deployed your Avalanche L1. You should see a screen similar to the following:
 
 ![](/course-images/avalanche-fundamentals/23.png)
 


### PR DESCRIPTION
I spotted a couple of small typos in the guide:  

1. **"please make sure your have the Core wallet set up."** → Fixed **"your"** to **"you"**  
2. **"you will have successful deployed your Avalanche L1."** → Changed **"successful"** to **"successfully"**  

Thanks!