### PR TITLE
Documentation Refinements: Grammar & Clarity Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ For small typos or corrections, it is easy to contribute without the need to clo
 repository. Simply:
 
 - Find the page you want to edit.
-- Click on the "Edit on GitHub" button in the right sidebar
+- Click the "Edit on GitHub" button in the right sidebar
 - Make the changes and Hit "Commit changes ..."
 - Edit the `commit message` to describe the change in 4 or less words, and include any extra details in the description
 - Hit "Sign off and commit changes" to raise a PR with your proposed changes

--- a/content/academy/avacloudapis/02-overview/03-dataapi-endpoints.mdx
+++ b/content/academy/avacloudapis/02-overview/03-dataapi-endpoints.mdx
@@ -10,7 +10,7 @@ icon: Book
 The AvaCloud Data API provides a comprehensive set of endpoints to interact with Avalanche networks. These endpoints allow you to query information about blocks, transactions, assets, and more.
 
 Below are some of the key endpoints available in the Data API.
-A more comphrensive list of Data API endpoints can be found [here](https://developers.avacloud.io/data-api/overview).
+A more comprehensive list of Data API endpoints can be found [here](https://developers.avacloud.io/data-api/overview).
 
 ## Data API Reference
 ### EVM Endpoints

--- a/upcoming_content/hypersdk/03-creating-actions/01-create-custom-action.mdx
+++ b/upcoming_content/hypersdk/03-creating-actions/01-create-custom-action.mdx
@@ -8,7 +8,7 @@ icon: Book
 
 ## Add Your Own Custom Action
 
-Think of actions in HyperSDK like functions in EVMs. They have inputs, outputs, and execution logic.
+Think of actions in HyperSDK as functions in EVMs. They have inputs, outputs, and execution logic.
 
 Let's add the Greeting action. This action doesn’t change anything; it simply prints your balance and the current date. However, if it's executed in a transaction, the output will be recorded in a block on the chain.
 


### PR DESCRIPTION
 Improved phrasing for clarity
File: contributing.md
Change:
- Click on the "Edit on GitHub" button in the right sidebar
+ Click the "Edit on GitHub" button in the right sidebar
Reason:
The phrase "Click on" is redundant in this context. The correct form is "Click the", which is more concise and natural.
Fixed a typo in "comphrensive" → "comprehensive"
File: data-api.md
Change:
- A more comphrensive list of Data API endpoints can be found [here](https://developers.avacloud.io/data-api/overview).
+ A more comprehensive list of Data API endpoints can be found [here](https://developers.avacloud.io/data-api/overview).
Reason:
"Comphrensive" is a misspelling. The correct spelling is "comprehensive".
Corrected preposition use in comparison statement
File: hyper-sdk-actions.md
Change:
- Think of actions in HyperSDK like functions in EVMs. They have inputs, outputs, and execution logic.
+ Think of actions in HyperSDK as functions in EVMs. They have inputs, outputs, and execution logic.
Reason:
The phrase "Think of X like Y" is commonly used to describe similarity in behavior, but "Think of X as Y" is grammatically correct when making a direct comparison of roles or functions.
