### PR TITLE
chore: escape $ char to cancel LaTeX formatting

### DIFF
--- a/content/common/multi-chain-architecture/etna-upgrade-motivation.mdx
+++ b/content/common/multi-chain-architecture/etna-upgrade-motivation.mdx
@@ -24,7 +24,7 @@ This change maintains the short time of finality and high throughput Avalanche S
 
 ### Economic Barriers
 
-The Primary Network currently has a staking requirement of **2,000 AVAX per validator**. If we assume a price of $20 per AVAX, a Subnet would have to have each of its validators stake AVAX worth $40,000 in addition to its own staking requirements. This is a significant economic barrier for the creation of new Subnets.
+The Primary Network currently has a staking requirement of **2,000 AVAX per validator**. If we assume a price of \$20 per AVAX, a Subnet would have to have each of its validators stake AVAX worth \$40,000 in addition to its own staking requirements. This is a significant economic barrier for the creation of new Subnets.
 
 ![Staking Requirements](/common-images/multi-chain-architecture/etna-upgrade/subnets-staking-requirements.png)
 


### PR DESCRIPTION
<img width="803" alt="Screenshot 2025-03-10 at 1 04 40 PM" src="https://github.com/user-attachments/assets/5fa91b97-5787-49ed-8f59-a28864af4911" />

Currently, the two `$` characters are causing this string of text to be treated as LaTeX. This should correct that issue.