### PR TITLE
Update Fuji Testnet Documentation – Use Absolute URLs

### DIFF
--- a/content/docs/quick-start/networks/fuji-testnet.mdx
+++ b/content/docs/quick-start/networks/fuji-testnet.mdx
@@ -3,15 +3,15 @@ title: Fuji Testnet
 description: Learn about the official Testnet for the Avalanche ecosystem.
 ---
 
-Fuji's infrastructure imitates Avalanche Mainnet. It's comprised of a [Primary Network](/docs/quick-start/primary-network) formed by instances of X, P, and C-Chain, as well as many test Avalanche L1s.
+Fuji's infrastructure imitates Avalanche Mainnet. It's comprised of a [Primary Network](https://github.com/ava-labs/avalanche-docs/blob/master/content/docs/quick-start/primary-network.mdx) formed by instances of X, P, and C-Chain, as well as many test Avalanche L1s.
 
 ## When to Use Fuji
 
-Fuji provides users with a platform to simulate the conditions found in the Mainnet environment. It enables developers to deploy demo Smart Contracts, allowing them to test and refine their applications before deploying them on the [Primary Network](/docs/quick-start/primary-network).
+Fuji provides users with a platform to simulate the conditions found in the Mainnet environment. It enables developers to deploy demo Smart Contracts, allowing them to test and refine their applications before deploying them on the [Primary Network](https://github.com/ava-labs/avalanche-docs/blob/master/content/docs/quick-start/primary-network.mdx).
 
 Users interested in experimenting with Avalanche can receive free testnet AVAX, allowing them to explore the platform without any risk. These testnet tokens have no value in the real world and are only meant for experimentation purposes within the Fuji test network.
 
-To receive testnet tokens, users can request funds from the [Avalanche Faucet](/docs/dapps/smart-contract-dev/get-test-funds). If there's already an AVAX balance greater than zero on Mainnet, paste the C-Chain address there, and request test tokens. Otherwise, please request a faucet coupon on [Guild](https://guild.xyz/avalanche). Admins and mods on the official [Discord](https://discord.com/invite/RwXY7P6) can provide testnet AVAX if developers are unable to obtain it from the other two options.
+To receive testnet tokens, users can request funds from the [Avalanche Faucet](https://github.com/ava-labs/avalanche-docs/blob/master/content/docs/dapps/smart-contract-dev/get-test-funds.mdx). If there's already an AVAX balance greater than zero on Mainnet, paste the C-Chain address there, and request test tokens. Otherwise, please request a faucet coupon on [Guild](https://guild.xyz/avalanche). Admins and mods on the official [Discord](https://discord.com/invite/RwXY7P6) can provide testnet AVAX if developers are unable to obtain it from the other two options.
 
 ## Add Avalanche C-Chain Testnet to Wallet
 
@@ -27,5 +27,5 @@ Head over to explorer linked above and select "Add Avalanche C-Chain to Wallet" 
 ## Additional Details
 
 - Fuji Testnet has its own dedicated [block explorer](https://subnets-test.avax.network/).
-- The Public API endpoint for Fuji is not the same as Mainnet. More info is available in the [Public API Server](/docs/tooling/rpc-providers) documentation.
+- The Public API endpoint for Fuji is not the same as Mainnet. More info is available in the [Public API Server](https://github.com/ava-labs/avalanche-docs/blob/master/content/docs/tooling/rpc-providers.mdx) documentation.
 - You can run a Fuji validator node by staking only **1 Fuji AVAX**.


### PR DESCRIPTION
**Description:**  
This pull request updates documentation by replacing relative links with absolute URLs. These changes improve link reliability and ensure users are directed to the correct GitHub-hosted resources. The previous version used relative URLs that return a 404 error when accessed externally.The modifications include:

- **Primary Network Link:** Updated from a relative path (`/docs/quick-start/primary-network`) to the absolute GitHub URL.
- **Avalanche Faucet Link:** Changed from a relative path (`/docs/dapps/smart-contract-dev/get-test-funds`) to the full GitHub URL.
- **Public API Server Link:** Updated from a relative path (`/docs/tooling/rpc-providers`) to the absolute GitHub URL.